### PR TITLE
update UI to show correct outbound fee

### DIFF
--- a/src/renderer/helpers/poolHelperMaya.ts
+++ b/src/renderer/helpers/poolHelperMaya.ts
@@ -1,7 +1,7 @@
 import { Balance, Network } from '@xchainjs/xchain-client'
 import { AssetCacao, MAYAChain } from '@xchainjs/xchain-mayachain'
 import { PoolDetail } from '@xchainjs/xchain-mayamidgard'
-import { bnOrZero, assetFromString, BaseAmount, Chain, baseAmount } from '@xchainjs/xchain-util'
+import { bnOrZero, assetFromString, BaseAmount, Chain, baseAmount, AnyAsset } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import * as A from 'fp-ts/lib/Array'
 import * as FP from 'fp-ts/lib/function'
@@ -14,7 +14,12 @@ import { PoolAddress, PoolDetails } from '../services/mayaMigard/types'
 import { getPoolDetail, toPoolData } from '../services/mayaMigard/utils'
 import { MimirHalt } from '../services/thorchain/types'
 import { PoolData, PoolTableRowData, PoolTableRowsData, PricePool } from '../views/pools/Pools.types'
-import { getPoolTableRowDataMaya, getValueOfAsset1InAsset2, getValueOfRuneInAsset } from '../views/pools/Pools.utils'
+import {
+  getPoolTableRowDataMaya,
+  getValueOfAsset1InAsset2,
+  getValueOfAssetInRune,
+  getValueOfRuneInAsset
+} from '../views/pools/Pools.utils'
 import { convertBaseAmountDecimal, isCacaoAsset, to1e10BaseAmount, to1e8BaseAmount } from './assetHelper'
 import { eqAsset, eqChain, eqString } from './fp/eq'
 import { ordBaseAmount } from './fp/ord'
@@ -201,6 +206,46 @@ export const getUSDValue = ({
           const amountDecimal = amount.amount().toNumber() // Convert amount to a decimal number
           const usdValue = Number(assetPriceUSD) * amountDecimal // Multiply by the price in USD
           return baseAmount(usdValue, amount.decimal) // Convert back to `BaseAmount` with 1e8 decimals
+        })
+      )
+    )
+  )
+}
+
+/**
+ * Helper to get an asset amount from its USD value in THOR pools
+ */
+export const getAssetAmountFromUSDValue = ({
+  usdValue,
+  poolDetails,
+  asset,
+  amount,
+  pricePool: { asset: priceAsset, poolData: pricePoolData }
+}: {
+  usdValue: BaseAmount
+  poolDetails: PoolDetails
+  asset: AnyAsset
+  amount: BaseAmount
+  pricePool: PricePool
+}): O.Option<BaseAmount> => {
+  // no pricing logic needed if asset === price pool asset
+  if (eqAsset.equals(asset, priceAsset)) return O.some(usdValue)
+
+  // Handle Rune as a special case
+  if (isCacaoAsset(asset)) {
+    return O.some(getValueOfAssetInRune(usdValue, pricePoolData))
+  }
+
+  // For other assets
+  return FP.pipe(
+    getPoolDetail(poolDetails, asset), // Get the pool detail for the asset
+    O.chain((poolDetail) =>
+      FP.pipe(
+        O.fromNullable(poolDetail.assetPriceUSD), // Extract `assetPriceUSD` safely
+        O.map((assetPriceUSD) => {
+          const usdDecimal = usdValue.amount().toNumber() // Convert USD value to a decimal number
+          const assetAmount = usdDecimal / Number(assetPriceUSD) // Divide USD value by the asset price in USD
+          return baseAmount(assetAmount, amount.decimal) // Convert back to `BaseAmount`
         })
       )
     )


### PR DESCRIPTION
Previous outbound fee was showing the outbound fee from asgasrdex fee logic and not from TC quote.
This is fixed with some helpers. Now the chain asset fee in this case Sats reflects the $dollar value properly
<img width="507" alt="Screenshot 2024-12-19 at 3 08 55 PM" src="https://github.com/user-attachments/assets/f6356f17-8806-46e5-8c9d-f95327514b0f" />


Also Affiliate will display `free` if applyBps is false