### PR TITLE
update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ _(in alphabetical order)_
 
 ## Installation
 
-It's recommended to use a Node version as same as Electron is running with (currently: [`Electron v26.0.x` / Node `18.16.1`](https://github.com/electron/releases#releases)). It's recommended to install [nvm](https://github.com/nvm-sh/nvm) to run as the same Node version locally as used for building ASGARDEX on CI.
+It's recommended to use a Node version as same as Electron is running with (currently: [`Electron 27` / Node `18.17`](https://www.electronjs.org/docs/latest/tutorial/electron-timelines)). It's recommended to install [nvm](https://github.com/nvm-sh/nvm) to run as the same Node version locally as used for building ASGARDEX on CI.
 
 ```bash
 git clone https://github.com/asgardex/asgardex-desktop.git asgardex


### PR DESCRIPTION
Asgardex updated to Electron 27 (which uses Node 18.17) in #360.