### PR TITLE
replace windows-2019 runner image with windows-2022

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019]
+        os: [windows-latest]
 
     steps:
       - name: Checkout git repo


### PR DESCRIPTION
`windows-2019` is being deprecated in June.

https://github.com/actions/runner-images/issues/12045