### PR TITLE
turn require() statements into import statements

### DIFF
--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,5 +1,5 @@
-require('dotenv').config()
-const { notarize } = require('@electron/notarize')
+import 'dotenv/config'
+import { notarize } from '@electron/notarize'
 
 /*
  Pre-requisites: https://github.com/electron/electron-notarize#prerequisites

--- a/src/main/electron.ts
+++ b/src/main/electron.ts
@@ -86,7 +86,7 @@ const closeHandler = () => {
 }
 
 const setupDevEnv = async () => {
-  const { default: installExtension, REACT_DEVELOPER_TOOLS } = require('electron-devtools-installer')
+  const { default: installExtension, REACT_DEVELOPER_TOOLS } = await import('electron-devtools-installer')
   try {
     await installExtension(REACT_DEVELOPER_TOOLS)
   } catch (e) {


### PR DESCRIPTION
https://www.npmjs.com/package/dotenv#how-do-i-use-dotenv-with-import

This syntax is useable since `dotenv` [8.5.0](https://github.com/motdotla/dotenv/blob/master/CHANGELOG.md#850-2021-05-05) (The version of `electron-builder` in asgardex currently uses version 9.0)