### PR TITLE
quiet some new(?) lints in typescript-eslint 8.x

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,6 +105,7 @@ export default [
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
+          caughtErrorsIgnorePattern: '^_',
           varsIgnorePattern: '^_',
           argsIgnorePattern: '^_'
         }
@@ -149,6 +150,7 @@ export default [
       'unused-imports/no-unused-vars': [
         'warn',
         {
+          caughtErrorsIgnorePattern: '^_',
           vars: 'all',
           varsIgnorePattern: '^_',
           args: 'after-used',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -102,6 +102,12 @@ export default [
       '@typescript-eslint/ban-types': 'off',
       '@typescript-eslint/ban-ts-ignore': 'off',
 
+      '@typescript-eslint/no-unused-expressions': [
+        'error',
+        {
+          allowTernary: true
+        }
+      ],
       '@typescript-eslint/no-unused-vars': [
         'error',
         {

--- a/src/main/api/url.ts
+++ b/src/main/api/url.ts
@@ -65,7 +65,7 @@ export const openExternal = (target: string) => {
       return shell.openExternal(target)
     }
     return Promise.reject(`URL ${target} has been blocked by ASGARDEX`)
-  } catch (e) {
+  } catch (_e) {
     return Promise.reject(`URL ${target} could not be parsed`)
   }
 }

--- a/src/renderer/components/header/netstatus/HeaderNetStatus.tsx
+++ b/src/renderer/components/header/netstatus/HeaderNetStatus.tsx
@@ -307,7 +307,7 @@ export const HeaderNetStatus: React.FC<Props> = (props): JSX.Element => {
       {isDesktopView && (
         <Col span={24}>
           <Dropdown overlay={desktopMenu} trigger={['click']} placement="bottom">
-            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+            {}
             <a className="ant-dropdown-link" onClick={(e) => e.preventDefault()}>
               <Row justify="space-between" align="middle">
                 <ConnectionStatus color={appOnlineStatusColor} />

--- a/src/renderer/components/swap/ProviderIcon.tsx
+++ b/src/renderer/components/swap/ProviderIcon.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
 
-/* eslint-disable import/no-webpack-loader-syntax */
 import ChainflipIcon from '../../assets/png/asset-flip.png'
 import MayaIcon from '../../assets/png/asset-maya.png'
 import ThorchainIcon from '../../assets/svg/asset-rune.svg?url'

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -216,7 +216,7 @@ export const Swap = ({
 
   const [oTargetWalletType, setTargetWalletType] = useState<O.Option<WalletType>>(oInitialTargetWalletType)
 
-  const [isStreaming, setIsStreaming] = useState<Boolean>(true)
+  const [isStreaming, setIsStreaming] = useState<boolean>(true)
   const openExplorer = useOpenExplorerTxUrl(
     FP.pipe(
       oQuoteProtocol,

--- a/src/renderer/components/swap/TradeSwap.tsx
+++ b/src/renderer/components/swap/TradeSwap.tsx
@@ -239,7 +239,7 @@ export const TradeSwap = ({
 
   const [oTargetWalletType, setTargetWalletType] = useState<O.Option<WalletType>>(oInitialTargetWalletType)
 
-  const [isStreaming, setIsStreaming] = useState<Boolean>(true)
+  const [isStreaming, setIsStreaming] = useState<boolean>(true)
 
   // Update state needed - initial target walletAddress is loaded async and can be different at first run
   useEffect(() => {

--- a/src/renderer/components/uielements/charts/pieChart.tsx
+++ b/src/renderer/components/uielements/charts/pieChart.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-template-curly-in-string */
 import { useMemo } from 'react'
 
 import ReactECharts from 'echarts-for-react'

--- a/src/renderer/components/uielements/stepBar/StepBar.styles.tsx
+++ b/src/renderer/components/uielements/stepBar/StepBar.styles.tsx
@@ -15,7 +15,7 @@ export const Dot = styled.div`
   background: ${palette('gray', 1)};
 `
 
-export const Line = styled.div<{ size: Number }>`
+export const Line = styled.div<{ size: number }>`
   width: 5px;
   ${({ size }) => `height: ${size}px;`};
   border-right: 1px solid ${palette('gray', 1)};

--- a/src/renderer/components/wallet/phrase/NewPhraseConfirm.helper.ts
+++ b/src/renderer/components/wallet/phrase/NewPhraseConfirm.helper.ts
@@ -12,7 +12,6 @@ export const checkPhraseConfirmWordsFactory =
         const selectedWord = selectedWords[i]
 
         if (word._id !== selectedWord._id) {
-          // eslint-disable-next-line no-loop-func
           newWords = words.map((e: WordType) => {
             if (e._id === selectedWord._id) {
               e.error = true

--- a/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
+++ b/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
@@ -66,7 +66,7 @@ export const NewPhraseGenerate: React.FC<Props> = ({ onSubmit, walletId, walletN
         try {
           setLoading(true)
           onSubmit({ phrase, password, name: name || initialWalletName })
-        } catch (err) {
+        } catch (_err) {
           setLoading(false)
         }
       }

--- a/src/renderer/components/wallet/txs/interact/InteractFormThor.tsx
+++ b/src/renderer/components/wallet/txs/interact/InteractFormThor.tsx
@@ -453,7 +453,7 @@ export const InteractFormThor: React.FC<Props> = (props) => {
           setThornameRegister(thornameDetails.name === '')
           setIsOwner(balance.walletAddress === thornameDetails.owner)
         }
-      } catch (error) {
+      } catch (_error) {
         setThornameAvailable(true)
       }
       // setThorname(O.none)

--- a/src/renderer/helpers/stringHelper.ts
+++ b/src/renderer/helpers/stringHelper.ts
@@ -12,7 +12,7 @@ export const getPair = (info?: string): Pair => ({
 export const compareShallowStr = (str1: string, str2: string): boolean => {
   try {
     return str1.toLowerCase() === str2.toLowerCase()
-  } catch (error) {
+  } catch (_error) {
     return false
   }
 }

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -11,6 +11,6 @@ import { App } from './App'
 // React 18 introduces a new root API
 // @see https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis
 const container = document.getElementById('root')
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
 const root = createRoot(container!) // createRoot(container!) if you use TypeScript
 root.render(<App />)

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -24,7 +24,7 @@ type RunObservable = <T>(callback: RunObservableCallback<T>) => T
 
 declare global {
   const runObservable: RunObservable
-  // eslint-disable-next-line no-redeclare, @typescript-eslint/no-namespace
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace NodeJS {
     interface Global {
       runObservable: RunObservable
@@ -38,7 +38,7 @@ declare global {
     apiUrl: ApiUrl
   }
 
-  // eslint-disable-next-line no-redeclare, @typescript-eslint/no-namespace
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
     interface Matchers<R> {
       toBeNone(): R


### PR DESCRIPTION
https://typescript-eslint.io/rules/no-unused-vars
https://typescript-eslint.io/rules/no-wrapper-object-types

Not sure when, but several `eslint-disable` directives stopped doing anything at some point.

And using a ternary operator to just call code with side effects gets linted unless the lint is disabled:

https://github.com/asgardex/asgardex-desktop/blob/780947479fbc564ae4830b5f0a20b8b6df26d02a/src/renderer/views/deposit/DepositView.tsx#L132-L134

https://eslint.org/docs/latest/rules/no-unused-expressions#allowternary