### PR TITLE
fix imports of CJS modules

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,4 +1,6 @@
-import { default as t } from '@asgardex/asgardex-theme'
+import theme from '@asgardex/asgardex-theme'
+
+const { default: t } = theme
 
 /** @type {import('tailwindcss').Config} */
 export default {


### PR DESCRIPTION
Oops. `import` of a CommonJS module gives its whole [`module.exports` object](https://nodejs.org/api/esm.html#interoperability-with-commonjs) as a default export, not its `.default` export.

Fixes for #722 & #723