### PR TITLE
fix TypeScript errors

### DIFF
--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -22,6 +22,7 @@ import * as walletRoutes from '../../routes/wallet'
 import {
   MidgardStatusRD,
   MidgardUrlRD,
+  PricePool,
   PricePools,
   PriceRD,
   SelectedPricePoolAsset
@@ -130,7 +131,7 @@ export const HeaderComponent: React.FC<Props> = (props): JSX.Element => {
   const pricePoolAssets = useMemo(() => {
     return FP.pipe(
       oPricePools,
-      O.map(A.map((pool) => pool.asset)),
+      O.map(A.map((pool: PricePool) => pool.asset)),
       O.map((assets) => {
         prevPricePoolAssets.current = assets
         return assets

--- a/src/renderer/components/wallet/txs/interact/InteractFormMaya.tsx
+++ b/src/renderer/components/wallet/txs/interact/InteractFormMaya.tsx
@@ -505,10 +505,21 @@ export const InteractFormMaya = (props: Props) => {
         walletIndex,
         hdMode,
         amount: amountToSend,
-        memo: getMemo()
+        memo: getMemo(),
+        asset
       })
     )
-  }, [subscribeInteractState, interactMaya$, walletType, walletAccount, walletIndex, hdMode, amountToSend, getMemo])
+  }, [
+    subscribeInteractState,
+    interactMaya$,
+    walletType,
+    walletAccount,
+    walletIndex,
+    hdMode,
+    amountToSend,
+    getMemo,
+    asset
+  ])
 
   const [showConfirmationModal, setShowConfirmationModal] = useState(false)
 

--- a/src/renderer/contexts/WalletContext.tsx
+++ b/src/renderer/contexts/WalletContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext } from 'react'
 
 import { option as O } from 'fp-ts'
 
-type Option = O.Option
+type Option<T> = O.Option<T>
 const { none, some } = O
 
 import {
@@ -73,7 +73,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   <WalletContext.Provider value={some(initialContext)}>{children}</WalletContext.Provider>
 )
 
-export const useWalletContext = () => {
+export const useWalletContext = (): WalletContextValue => {
   const context = O.toNullable(useContext(WalletContext))
   if (!context) {
     throw new Error('Context must be used within a WalletProvider.')

--- a/src/renderer/helpers/fpHelpers.ts
+++ b/src/renderer/helpers/fpHelpers.ts
@@ -17,7 +17,7 @@ export const sequenceSOption = sequenceS(O.Applicative)
 export const sequenceTRD = sequenceT(RD.remoteData)
 export const sequenceTRDFromArray = A.sequence(RD.remoteData)
 
-type Lazy = F.Lazy
+type Lazy<T> = F.Lazy<T>
 
 /**
  * Creation

--- a/src/renderer/helpers/rx/liveData.ts
+++ b/src/renderer/helpers/rx/liveData.ts
@@ -7,12 +7,8 @@ import {
   coproductMapLeft
 } from '@devexperts/utils/dist/typeclasses/product-left-coproduct-left/product-left-coproduct-left.utils'
 
-import type { filterable } from 'fp-ts'
-import type { monadThrow } from 'fp-ts'
-
-type Filterable2 = filterable.Filterable2
-type MonadThrow2 = monadThrow.MonadThrow2
-
+import type { filterable as Fi } from 'fp-ts'
+import type { monadThrow as MT } from 'fp-ts'
 import { apply } from 'fp-ts'
 import { array as A } from 'fp-ts'
 import { option as O } from 'fp-ts'
@@ -33,13 +29,13 @@ declare module 'fp-ts/lib/HKT' {
   }
 }
 
-const foldableValueRemoteData: FoldableValue2<typeof RD.remoteData.URI> & MonadThrow2<typeof RD.remoteData.URI> = {
+const foldableValueRemoteData: FoldableValue2<typeof RD.remoteData.URI> & MT.MonadThrow2<typeof RD.remoteData.URI> = {
   ...RD.remoteData,
   foldValue: (fa, onNever, onValue) => (RD.isSuccess(fa) ? onValue(fa.value) : onNever(fa)),
   throwError: RD.failure
 }
 
-export const instanceLiveData: MonadThrow2<URIType> & CoproductLeft<URIType> & Filterable2<URIType> = {
+export const instanceLiveData: MT.MonadThrow2<URIType> & CoproductLeft<URIType> & Fi.Filterable2<URIType> = {
   URI,
   ...getLiveDataM(instanceObservable, foldableValueRemoteData)
 }

--- a/src/renderer/services/midgard/midgardTypes.ts
+++ b/src/renderer/services/midgard/midgardTypes.ts
@@ -21,7 +21,7 @@ import { option as O } from 'fp-ts'
 import { IntlShape } from 'react-intl'
 import * as Rx from 'rxjs'
 
-type NonEmptyArray = nonEmptyArray.NonEmptyArray
+type NonEmptyArray<T> = nonEmptyArray.NonEmptyArray<T>
 
 import { LiveData } from '../../helpers/rx/liveData'
 import { AssetWithAmount, DepositType } from '../../types/asgardex'

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -8,7 +8,7 @@ import { function as FP } from 'fp-ts'
 import { option as O } from 'fp-ts'
 import * as Rx from 'rxjs'
 
-type NonEmptyArray = nonEmptyArray.NonEmptyArray
+type NonEmptyArray<T> = nonEmptyArray.NonEmptyArray<T>
 const { getMonoid } = array
 
 import { KeystoreWallet, KeystoreWallets } from '../../../shared/api/io'

--- a/src/renderer/types/asgardex.ts
+++ b/src/renderer/types/asgardex.ts
@@ -1,7 +1,7 @@
 import { BaseAmount, Address, AnyAsset } from '@xchainjs/xchain-util'
 import type { option } from 'fp-ts'
 
-type Option = option.Option
+type Option<T> = option.Option<T>
 
 import { WalletType } from '../../shared/wallet/types'
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -8,8 +8,8 @@ import { RunHelpers } from 'rxjs/internal/testing/TestScheduler'
 import { TestScheduler } from 'rxjs/testing'
 import { vi } from 'vitest'
 
-type Either = either.Either
-type Option = option.Option
+type Either<T, U> = either.Either<T, U>
+type Option<T> = option.Option<T>
 const { isLeft } = either
 const { isNone } = option
 


### PR DESCRIPTION
Fix up #718 & #694; also add two missing type annotations that were always required by fp-ts (but the import statements were missing type information till #718).