### PR TITLE
fix logic around chainAsset Amounts for cosmos send

### DIFF
--- a/src/renderer/components/wallet/txs/send/SendFormCOSMOS.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormCOSMOS.tsx
@@ -25,7 +25,7 @@ import { getChainAsset } from '../../../../helpers/chainHelper'
 import { sequenceTOption } from '../../../../helpers/fpHelpers'
 import { getPoolPriceValue } from '../../../../helpers/poolHelperMaya'
 import { loadingString } from '../../../../helpers/stringHelper'
-import { getCacaoAmountFromBalances } from '../../../../helpers/walletHelper'
+import { getAmountFromBalances } from '../../../../helpers/walletHelper'
 import { calculateMayaValueInUSD, MayaScanPriceRD } from '../../../../hooks/useMayascanPrice'
 import { usePricePool } from '../../../../hooks/usePricePool'
 import { usePricePoolMaya } from '../../../../hooks/usePricePoolMaya'
@@ -149,8 +149,8 @@ export const SendFormCOSMOS: React.FC<Props> = (props): JSX.Element => {
       return O.some(balance.amount)
     }
     // or check list of other assets to get balance
-    return FP.pipe(getCacaoAmountFromBalances(balances, getChainAsset(asset.chain)), O.map(assetToBase))
-  }, [asset.chain, balance.amount, balances, isChainAsset])
+    return FP.pipe(getAmountFromBalances(balances, balance.walletType, getChainAsset(asset.chain)), O.map(assetToBase))
+  }, [asset.chain, balance.amount, balance.walletType, balances, isChainAsset])
 
   const oChainAssetAmount: O.Option<BaseAmount> = useMemo(() => {
     // return balance of current asset
@@ -158,8 +158,8 @@ export const SendFormCOSMOS: React.FC<Props> = (props): JSX.Element => {
       return O.some(balance.amount)
     }
     // or check list of other assets to get balance
-    return FP.pipe(getCacaoAmountFromBalances(balances, chainAsset), O.map(assetToBase))
-  }, [balance.amount, balances, chainAsset, isChainAsset])
+    return FP.pipe(getAmountFromBalances(balances, balance.walletType, chainAsset), O.map(assetToBase))
+  }, [balance.amount, balance.walletType, balances, chainAsset, isChainAsset])
 
   const isFeeError = useMemo(() => {
     return FP.pipe(

--- a/src/renderer/helpers/walletHelper.ts
+++ b/src/renderer/helpers/walletHelper.ts
@@ -153,8 +153,15 @@ export const getLtcAmountFromBalances = (balances: WalletBalances): O.Option<Ass
 export const getRuneNativeAmountFromBalances = (balances: WalletBalances): O.Option<AssetAmount> =>
   getAssetAmountFromBalances(balances, isRuneNativeAsset)
 
-export const getCacaoAmountFromBalances = (balances: WalletBalances, assetToFind: AnyAsset): O.Option<AssetAmount> =>
-  getAssetAmountFromBalances(balances, (asset) => asset === assetToFind)
+export const getAmountFromBalances = (
+  balances: WalletBalances,
+  walletType: WalletType,
+  assetToFind: AnyAsset
+): O.Option<AssetAmount> =>
+  getAssetAmountFromBalances(
+    balances.filter((balance) => balance.walletType === walletType),
+    (asset) => asset === assetToFind
+  )
 export const getMayaAmountFromBalances = (balances: WalletBalances): O.Option<AssetAmount> =>
   getAssetAmountFromBalances(balances, isMayaAsset)
 


### PR DESCRIPTION
original logic did not differentiate between wallet types when sending assets on ledger (Thorchain). 
Passed in a new param 'walletType' which points the find first to the correct chain balance 