### PR TITLE
add TypeScript checking to main process code (electron.js)

### DIFF
--- a/electron.vite.config.mjs
+++ b/electron.vite.config.mjs
@@ -24,6 +24,7 @@ export default defineConfig(async ({ mode }) => {
         extensions: ['.ts', '.js']
       },
       plugins: [
+        typescript({ tsconfig: './tsconfig.main.json' }),
         externalizeDepsPlugin({
           include: ['@ledgerhq/hw-transport-node-hid', '@ledgerhq/hw-transport', 'node-hid', 'usb']
         })

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es2019",
-    "lib": ["ESNext", "dom"],
+    "target": "es2022",
+    "lib": ["es2024", "ESNext.Array", "ESNext.Collection", "ESNext.Iterator", "dom"],
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "module": "CommonJS",
-    "moduleResolution": "node",
-    "outDir": "./public/",
+    "module": "nodenext",
+    "moduleResolution": "node16",
+    "noEmit": true,
     "pretty": true
   },
   "include": ["./src/main", "./src/shared", "src/vite-env.d.ts"],

--- a/tsconfig.main.json
+++ b/tsconfig.main.json
@@ -6,9 +6,10 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "module": "nodenext",
-    "moduleResolution": "node16",
+    "module": "es2022",
+    "moduleResolution": "bundler",
     "noEmit": true,
+    "noEmitOnError": true,
     "pretty": true
   },
   "include": ["./src/main", "./src/shared", "src/vite-env.d.ts"],


### PR DESCRIPTION
Because of an upstream bug https://github.com/microsoft/TypeScript/issues/61441 tsconfig is currently set to target `"module": "es2022"` even though, once that bug is resolved, it should really be set to:

```
    "module": "nodenext",
    "moduleResolution": "node16",
```

It also probably shouldn't have the `"dom"` lib either, but TypeScript recursively checks all imported files with the same rules, and a few files (`renderer/services/app/service.ts`, `renderer/services/wallet/keystore.ts`) currently access the `window` global object.

(both files are imported by `bsc/common.ts` .. `bsc/balances.ts` .. `clients/balances.ts` .. `clients/index.ts` .. `wallet/types.ts` .. `src/renderer/helpers/addressHelper.ts` .. `src/renderer/helpers/assetHelper.ts`, and assetHelper is imported by several files in the main code like `src/main/api/ledger/ethereum/transaction.ts`)