### PR TITLE
fix notarize

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest --config vite.test.config.ts",
     "package": "yarn build && yarn package:electron",
     "package:electron": "yarn force-rebuild-native-deps && electron-builder build -c.extraMetadata.main=build/main/electron.js --config .electronbuildrc",
+    "package:electron:dry": "electron-builder --dir -c.extraMetadata.main=build/main/electron.js --config .electronbuildrc",
     "package:ci": "yarn postinstall && yarn build && yarn package:electron --publish always",
     "postinstall": "git config blame.ignoreRevsFile .git-blame-ignore-revs && yarn force-rebuild-native-deps && electron-builder install-app-deps",
     "lint": "trunk check --filter=eslint --filter=prettier",

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -1,5 +1,5 @@
-import 'dotenv/config'
-import { notarize } from '@electron/notarize'
+require('dotenv').config()
+const { notarize } = require('@electron/notarize')
 
 /*
  Pre-requisites: https://github.com/electron/electron-notarize#prerequisites


### PR DESCRIPTION
- Reverts a part of https://github.com/asgardex/asgardex-desktop/pull/723/ that breaks `yarn package`
- Adds `package:electron:dry` for package testing and possible CI integration later