### PR TITLE
modernize whitelist generate scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "@types/lodash": "^4",
     "@types/lodash.shuffle": "^4.2.7",
     "@types/node": "^22.14",
+    "@types/prettier": "^2.7.3",
     "@types/qrcode": "^1.4.2",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",

--- a/scripts/generateARBtokenlist.ts
+++ b/scripts/generateARBtokenlist.ts
@@ -104,10 +104,13 @@ const writeList = (list: AssetList): TE.TaskEither<Error, void> =>
     (c) => writeFile(PATH, c)
   )
 
+const options = prettier.resolveConfig.sync('./.prettierrc') ?? {}
+options.parser = 'typescript'
+
 const formatList = () =>
   FP.pipe(
     readFile(PATH, 'utf8'),
-    TE.chain((content) => writeFile(PATH, prettier.format(content, { filepath: PATH })))
+    TE.chain((content) => writeFile(PATH, prettier.format(content, options)))
   )
 
 const onError = (e: Error): T.Task<void> =>

--- a/scripts/generateARBtokenlist.ts
+++ b/scripts/generateARBtokenlist.ts
@@ -85,7 +85,7 @@ const createTemplate = (list: AssetList): string => {
      *
      */
 
-    import * as O from 'fp-ts/lib/Option'
+    import { option as O } from 'fp-ts'
     import {TokenAsset} from "@xchainjs/xchain-util";
     import {ARBChain} from "@xchainjs/xchain-arbitrum";
 

--- a/scripts/generateARBtokenlist.ts
+++ b/scripts/generateARBtokenlist.ts
@@ -2,15 +2,17 @@ import { ARBChain } from '@xchainjs/xchain-arbitrum'
 import { AnyAsset, assetFromString } from '@xchainjs/xchain-util'
 import ansis from 'ansis'
 import axios from 'axios'
-import * as IO from 'fp-ts/IO'
-import * as A from 'fp-ts/lib/Array'
-import * as C from 'fp-ts/lib/Console'
-import * as E from 'fp-ts/lib/Either'
-import * as FP from 'fp-ts/lib/function'
-import * as O from 'fp-ts/lib/Option'
-import * as TE from 'fp-ts/lib/TaskEither'
-import * as S from 'fp-ts/string'
-import * as T from 'fp-ts/Task'
+import {
+  io as IO,
+  array as A,
+  console as C,
+  either as E,
+  function as FP,
+  option as O,
+  taskEither as TE,
+  string as S,
+  task as T
+} from 'fp-ts'
 import { failure } from 'io-ts/lib/PathReporter'
 import prettier from 'prettier'
 

--- a/scripts/generateAVAXtokenlist.ts
+++ b/scripts/generateAVAXtokenlist.ts
@@ -93,10 +93,13 @@ const writeList = (list: AssetList): TE.TaskEither<Error, void> =>
     (c) => writeFile(PATH, c)
   )
 
+const options = prettier.resolveConfig.sync('./.prettierrc') ?? {}
+options.parser = 'typescript'
+
 const formatList = () =>
   FP.pipe(
     readFile(PATH, 'utf8'),
-    TE.chain((content) => writeFile(PATH, prettier.format(content, { filepath: PATH })))
+    TE.chain((content) => writeFile(PATH, prettier.format(content, options)))
   )
 
 const onError = (e: Error): T.Task<void> =>

--- a/scripts/generateAVAXtokenlist.ts
+++ b/scripts/generateAVAXtokenlist.ts
@@ -74,7 +74,7 @@ const createTemplate = (list: AssetList): string => {
      *
      */
 
-    import * as O from 'fp-ts/lib/Option'
+    import { option as O } from 'fp-ts'
     import {TokenAsset} from "@xchainjs/xchain-util";
     import {AVAXChain} from "@xchainjs/xchain-avax";
 

--- a/scripts/generateAVAXtokenlist.ts
+++ b/scripts/generateAVAXtokenlist.ts
@@ -2,15 +2,17 @@ import { AVAXChain } from '@xchainjs/xchain-avax'
 import { AnyAsset, assetFromString } from '@xchainjs/xchain-util'
 import ansis from 'ansis'
 import axios from 'axios'
-import * as IO from 'fp-ts/IO'
-import * as A from 'fp-ts/lib/Array'
-import * as C from 'fp-ts/lib/Console'
-import * as E from 'fp-ts/lib/Either'
-import * as FP from 'fp-ts/lib/function'
-import * as O from 'fp-ts/lib/Option'
-import * as TE from 'fp-ts/lib/TaskEither'
-import * as S from 'fp-ts/string'
-import * as T from 'fp-ts/Task'
+import {
+  io as IO,
+  array as A,
+  console as C,
+  either as E,
+  function as FP,
+  option as O,
+  taskEither as TE,
+  string as S,
+  task as T
+} from 'fp-ts'
 import { failure } from 'io-ts/lib/PathReporter'
 import prettier from 'prettier'
 

--- a/scripts/generateBASEtokenlist.ts
+++ b/scripts/generateBASEtokenlist.ts
@@ -2,14 +2,16 @@ import { BASEChain } from '@xchainjs/xchain-base'
 import { AnyAsset, assetFromStringEx } from '@xchainjs/xchain-util'
 import ansis from 'ansis'
 import axios from 'axios'
-import * as IO from 'fp-ts/IO'
-import * as C from 'fp-ts/lib/Console'
-import * as E from 'fp-ts/lib/Either'
-import * as FP from 'fp-ts/lib/function'
-import * as O from 'fp-ts/lib/Option'
-import * as TE from 'fp-ts/lib/TaskEither'
-import * as S from 'fp-ts/string'
-import * as T from 'fp-ts/Task'
+import {
+  io as IO,
+  console as C,
+  either as E,
+  function as FP,
+  option as O,
+  taskEither as TE,
+  string as S,
+  task as T
+} from 'fp-ts'
 import { failure } from 'io-ts/lib/PathReporter'
 import prettier from 'prettier'
 

--- a/scripts/generateBASEtokenlist.ts
+++ b/scripts/generateBASEtokenlist.ts
@@ -88,10 +88,13 @@ const writeList = (list: AssetList): TE.TaskEither<Error, void> =>
   FP.pipe(list, createTemplate, S.replace(/"chain":"BASE"/g, 'chain: BASEChain'), (c) => writeFile(PATH, c))
 
 // Format the generated file
+const options = prettier.resolveConfig.sync('./.prettierrc') ?? {}
+options.parser = 'typescript'
+
 const formatList = () =>
   FP.pipe(
     readFile(PATH, 'utf8'),
-    TE.chain((content) => writeFile(PATH, prettier.format(content, { filepath: PATH })))
+    TE.chain((content) => writeFile(PATH, prettier.format(content, options)))
   )
 
 // Error and success handlers

--- a/scripts/generateBASEtokenlist.ts
+++ b/scripts/generateBASEtokenlist.ts
@@ -58,7 +58,7 @@ const createTemplate = (list: AssetList): string => `
    * BASE_TOKEN_WHITELIST
    * This file has been generated - don't edit.
    */
-  import * as O from 'fp-ts/lib/Option'
+  import { option as O } from 'fp-ts'
   import { TokenAsset } from '@xchainjs/xchain-util';
   import { BASEChain } from '@xchainjs/xchain-base';
 

--- a/scripts/generateBSCtokenlist.ts
+++ b/scripts/generateBSCtokenlist.ts
@@ -105,10 +105,13 @@ const writeList = (list: AssetList): TE.TaskEither<Error, void> =>
     (c) => writeFile(PATH, c)
   )
 
+const options = prettier.resolveConfig.sync('./.prettierrc') ?? {}
+options.parser = 'typescript'
+
 const formatList = () =>
   FP.pipe(
     readFile(PATH, 'utf8'),
-    TE.chain((content) => writeFile(PATH, prettier.format(content, { filepath: PATH })))
+    TE.chain((content) => writeFile(PATH, prettier.format(content, options)))
   )
 
 const onError = (e: Error): T.Task<void> =>

--- a/scripts/generateBSCtokenlist.ts
+++ b/scripts/generateBSCtokenlist.ts
@@ -86,7 +86,7 @@ const createTemplate = (list: AssetList): string => {
      *
      */
 
-    import * as O from 'fp-ts/lib/Option'
+    import { option as O } from 'fp-ts'
     import {TokenAsset} from "@xchainjs/xchain-util";
     import {BSCChain} from "@xchainjs/xchain-bsc";
 

--- a/scripts/generateBSCtokenlist.ts
+++ b/scripts/generateBSCtokenlist.ts
@@ -2,15 +2,17 @@ import { BSCChain } from '@xchainjs/xchain-bsc'
 import { AnyAsset, assetFromString } from '@xchainjs/xchain-util'
 import ansis from 'ansis'
 import axios from 'axios'
-import * as IO from 'fp-ts/IO'
-import * as A from 'fp-ts/lib/Array'
-import * as C from 'fp-ts/lib/Console'
-import * as E from 'fp-ts/lib/Either'
-import * as FP from 'fp-ts/lib/function'
-import * as O from 'fp-ts/lib/Option'
-import * as TE from 'fp-ts/lib/TaskEither'
-import * as S from 'fp-ts/string'
-import * as T from 'fp-ts/Task'
+import {
+  io as IO,
+  array as A,
+  console as C,
+  either as E,
+  function as FP,
+  option as O,
+  taskEither as TE,
+  string as S,
+  task as T
+} from 'fp-ts'
 import { failure } from 'io-ts/lib/PathReporter'
 import prettier from 'prettier'
 

--- a/scripts/generateERC20Whitelist.ts
+++ b/scripts/generateERC20Whitelist.ts
@@ -86,7 +86,7 @@ const createTemplate = (list: AssetList): string => {
      *
      */
 
-    import * as O from 'fp-ts/lib/Option'
+    import { option as O } from 'fp-ts'
     import {TokenAsset} from "@xchainjs/xchain-util";
     import {ETHChain} from "@xchainjs/xchain-ethereum";
 

--- a/scripts/generateERC20Whitelist.ts
+++ b/scripts/generateERC20Whitelist.ts
@@ -105,10 +105,13 @@ const writeList = (list: AssetList): TE.TaskEither<Error, void> =>
     (c) => writeFile(PATH, c)
   )
 
+const options = prettier.resolveConfig.sync('./.prettierrc') ?? {}
+options.parser = 'typescript'
+
 const formatList = () =>
   FP.pipe(
     readFile(PATH, 'utf8'),
-    TE.chain((content) => writeFile(PATH, prettier.format(content, { filepath: PATH })))
+    TE.chain((content) => writeFile(PATH, prettier.format(content, options)))
   )
 
 const onError = (e: Error): T.Task<void> =>

--- a/scripts/generateERC20Whitelist.ts
+++ b/scripts/generateERC20Whitelist.ts
@@ -2,15 +2,17 @@ import { ETHChain } from '@xchainjs/xchain-ethereum'
 import { AnyAsset, assetFromString } from '@xchainjs/xchain-util'
 import ansis from 'ansis'
 import axios from 'axios'
-import * as IO from 'fp-ts/IO'
-import * as A from 'fp-ts/lib/Array'
-import * as C from 'fp-ts/lib/Console'
-import * as E from 'fp-ts/lib/Either'
-import * as FP from 'fp-ts/lib/function'
-import * as O from 'fp-ts/lib/Option'
-import * as TE from 'fp-ts/lib/TaskEither'
-import * as S from 'fp-ts/string'
-import * as T from 'fp-ts/Task'
+import {
+  io as IO,
+  array as A,
+  console as C,
+  either as E,
+  function as FP,
+  option as O,
+  taskEither as TE,
+  string as S,
+  task as T
+} from 'fp-ts'
 import { failure } from 'io-ts/lib/PathReporter'
 import prettier from 'prettier'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5053,6 +5053,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prettier@npm:^2.7.3":
+  version: 2.7.3
+  resolution: "@types/prettier@npm:2.7.3"
+  checksum: 10/cda84c19acc3bf327545b1ce71114a7d08efbd67b5030b9e8277b347fa57b05178045f70debe1d363ff7efdae62f237260713aafc2d7217e06fc99b048a88497
+  languageName: node
+  linkType: hard
+
 "@types/prop-types@npm:*":
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
@@ -6724,6 +6731,7 @@ __metadata:
     "@types/lodash": "npm:^4"
     "@types/lodash.shuffle": "npm:^4.2.7"
     "@types/node": "npm:^22.14"
+    "@types/prettier": "npm:^2.7.3"
     "@types/qrcode": "npm:^1.4.2"
     "@types/react": "npm:^18.0.15"
     "@types/react-dom": "npm:^18.0.6"


### PR DESCRIPTION
A directory import of CJS code from `'fp-ts/lib/Option'` isn't ESM-compatible.

```
find scripts/ -path '*generate*.ts' -exec sed -i -E -e "s|import \\* as ([A-Za-z]+) from 'fp-ts/?[lib]*/([A-Za-z]+)'$|import { \l\2 as \1 } from 'fp-ts'|" -e "s|iO|io|" {} + &&
eslint --fix scripts/ &&
yarn add @types/prettier@^2.7.3 --dev
```