### PR TITLE
Updated non render imports

### DIFF
--- a/src/main/electron.ts
+++ b/src/main/electron.ts
@@ -1,5 +1,9 @@
 import path, { join } from 'path'
 
+import * as dotenv from 'dotenv'
+
+dotenv.config()
+
 import { BrowserWindow, app, ipcMain, nativeImage } from 'electron'
 import electronDebug from 'electron-debug'
 import isDev from 'electron-is-dev'
@@ -34,8 +38,8 @@ import IPCMessages from './ipc/messages'
 import { setMenu } from './menu'
 import { sanitizePathSegment } from './utils/file'
 
-export const IS_DEV = isDev && import.meta.env.VITE_NODE_ENV !== 'production'
-export const PORT = import.meta.env.VITE_PORT || 3000
+export const IS_DEV = isDev && process.env.VITE_NODE_ENV !== 'production'
+export const PORT = process.env.VITE_PORT || '3000'
 
 export const APP_ROOT = join(__dirname, '..', '..')
 

--- a/src/shared/const.ts
+++ b/src/shared/const.ts
@@ -27,7 +27,7 @@ export const ASGARDEX_ADDRESS = 'thor1rr6rahhd4sy76a7rdxkjaen2q4k4pw2g06w7qp'
 
 export const ASGARDEX_AFFILIATE_FEE = 30
 export const ASGARDEX_TRADE_AFFILIATE_FEE = 15
-export const ASGARDEX_THORNAME = envOrDefault(import.meta.env.VITE_ASGARDEX_THORNAME, 'dx')
+export const ASGARDEX_THORNAME = envOrDefault(process.env.VITE_ASGARDEX_THORNAME, 'dx')
 
 export const getAsgardexThorname = (network: Network): string | undefined =>
   network === Network.Mainnet ? ASGARDEX_THORNAME : undefined

--- a/src/shared/mayaMidgard/const.ts
+++ b/src/shared/mayaMidgard/const.ts
@@ -4,14 +4,11 @@ import { envOrDefault } from '../utils/env'
 // expose env (needed to access ENVs by `envOrDefault`) in `main` thread)
 // require('dotenv').config()
 
-const TESTNET_URL = envOrDefault(import.meta.env.VITE_MIDGARD_TESTNET_URL, 'https://testnet.midgard.thorchain.info')
+const TESTNET_URL = envOrDefault(process.env.VITE_MIDGARD_TESTNET_URL, 'https://testnet.midgard.thorchain.info')
 
-const STAGENET_URL = envOrDefault(
-  import.meta.env.VITE_MIDGARD_MAYA_STAGENET_URL,
-  'https://stagenet.midgard.mayachain.info'
-)
+const STAGENET_URL = envOrDefault(process.env.VITE_MIDGARD_MAYA_STAGENET_URL, 'https://stagenet.midgard.mayachain.info')
 
-const MAINNET_URL = envOrDefault(import.meta.env.VITE_MIDGARD_MAYA_MAINNET_URL, 'https://midgard.mayachain.info')
+const MAINNET_URL = envOrDefault(process.env.VITE_MIDGARD_MAYA_MAINNET_URL, 'https://midgard.mayachain.info')
 
 export const DEFAULT_MIDGARD_MAYA_URLS: ApiUrls = {
   mainnet: MAINNET_URL,

--- a/src/shared/mayachain/const.ts
+++ b/src/shared/mayachain/const.ts
@@ -5,13 +5,13 @@ import { envOrDefault } from '../utils/env'
 // require('dotenv').config()
 
 export const DEFAULT_MAYANODE_RPC_URLS: ApiUrls = {
-  mainnet: envOrDefault(import.meta.env.VITE_MAINNET_MAYANODE_RPC, 'https://tendermint.mayachain.info'),
-  stagenet: envOrDefault(import.meta.env.VITE_STAGENET_MAYANODE_RPC, 'https://tendermint.mayachain.info'),
-  testnet: envOrDefault(import.meta.env.VITE_TESTNET_MAYANODE_RPC, 'https://tendermint.mayachain.info')
+  mainnet: envOrDefault(process.env.VITE_MAINNET_MAYANODE_RPC, 'https://tendermint.mayachain.info'),
+  stagenet: envOrDefault(process.env.VITE_STAGENET_MAYANODE_RPC, 'https://tendermint.mayachain.info'),
+  testnet: envOrDefault(process.env.VITE_TESTNET_MAYANODE_RPC, 'https://tendermint.mayachain.info')
 }
 
 export const DEFAULT_MAYANODE_API_URLS: ApiUrls = {
-  mainnet: envOrDefault(import.meta.env.VITE_MAINNET_MAYANODE_API, 'https://mayanode.mayachain.info'),
-  stagenet: envOrDefault(import.meta.env.VITE_STAGENET_MAYANODE_API, 'https://stagenet.mayanode.mayachain.info'),
-  testnet: envOrDefault(import.meta.env.VITE_TESTNET_MAYANODE_API, 'https://testnet.mayanode.mayachain.info')
+  mainnet: envOrDefault(process.env.VITE_MAINNET_MAYANODE_API, 'https://mayanode.mayachain.info'),
+  stagenet: envOrDefault(process.env.VITE_STAGENET_MAYANODE_API, 'https://stagenet.mayanode.mayachain.info'),
+  testnet: envOrDefault(process.env.VITE_TESTNET_MAYANODE_API, 'https://testnet.mayanode.mayachain.info')
 }

--- a/src/shared/midgard/const.ts
+++ b/src/shared/midgard/const.ts
@@ -4,11 +4,11 @@ import { envOrDefault } from '../utils/env'
 // expose env (needed to access ENVs by `envOrDefault`) in `main` thread)
 // require('dotenv').config()
 
-const TESTNET_URL = envOrDefault(import.meta.env.VITE_MIDGARD_TESTNET_URL, 'https://testnet.midgard.thorchain.info')
+const TESTNET_URL = envOrDefault(process.env.VITE_MIDGARD_TESTNET_URL, 'https://testnet.midgard.thorchain.info')
 
-const STAGENET_URL = envOrDefault(import.meta.env.VITE_MIDGARD_STAGENET_URL, 'https://stagenet-midgard.ninerealms.com')
+const STAGENET_URL = envOrDefault(process.env.VITE_MIDGARD_STAGENET_URL, 'https://stagenet-midgard.ninerealms.com')
 
-const MAINNET_URL = envOrDefault(import.meta.env.VITE_MIDGARD_MAINNET_URL, 'https://midgard.ninerealms.com')
+const MAINNET_URL = envOrDefault(process.env.VITE_MIDGARD_MAINNET_URL, 'https://midgard.ninerealms.com')
 
 export const DEFAULT_MIDGARD_URLS: ApiUrls = {
   mainnet: MAINNET_URL,

--- a/src/shared/thorchain/const.ts
+++ b/src/shared/thorchain/const.ts
@@ -5,13 +5,13 @@ import { envOrDefault } from '../utils/env'
 // require('dotenv').config()
 
 export const DEFAULT_THORNODE_RPC_URLS: ApiUrls = {
-  mainnet: envOrDefault(import.meta.env.VITE_MAINNET_THORNODE_RPC, 'https://rpc.ninerealms.com'),
-  stagenet: envOrDefault(import.meta.env.VITE_STAGENET_THORNODE_RPC, 'https://stagenet-rpc.ninerealms.com'),
-  testnet: envOrDefault(import.meta.env.VITE_TESTNET_THORNODE_RPC, 'https://rpc.ninerealms.com')
+  mainnet: envOrDefault(process.env.VITE_MAINNET_THORNODE_RPC, 'https://rpc.ninerealms.com'),
+  stagenet: envOrDefault(process.env.VITE_STAGENET_THORNODE_RPC, 'https://stagenet-rpc.ninerealms.com'),
+  testnet: envOrDefault(process.env.VITE_TESTNET_THORNODE_RPC, 'https://rpc.ninerealms.com')
 }
 
 export const DEFAULT_THORNODE_API_URLS: ApiUrls = {
-  mainnet: envOrDefault(import.meta.env.VITE_MAINNET_THORNODE_API, 'https://thornode.ninerealms.com'),
-  stagenet: envOrDefault(import.meta.env.VITE_STAGENET_THORNODE_API, 'https://stagenet-thornode.ninerealms.com'),
-  testnet: envOrDefault(import.meta.env.VITE_TESTNET_THORNODE_API, 'https://testnet.thornode.thorchain.info')
+  mainnet: envOrDefault(process.env.VITE_MAINNET_THORNODE_API, 'https://thornode.ninerealms.com'),
+  stagenet: envOrDefault(process.env.VITE_STAGENET_THORNODE_API, 'https://stagenet-thornode.ninerealms.com'),
+  testnet: envOrDefault(process.env.VITE_TESTNET_THORNODE_API, 'https://testnet.thornode.thorchain.info')
 }


### PR DESCRIPTION
This PR replaces usage of `import.meta.env.VITE_*` in the Electron main process with `process.env.VITE_*`

Reason
- import.meta.env is a Vite feature only available in the renderer process.
- Attempting to use it in the main process (Node context) leads to a TS1470 error: 

This was found in https://github.com/asgardex/asgardex-desktop/pull/767 which currently errors.

Changes
- Added dotenv.config() in electron.ts.
- Replaced import.meta.env.* with process.env.* in Electron main code. Code within `src/render` is unchanged. 
- Ensures compatibility with CommonJS output in Electron main.

References
- https://www.npmjs.com/package/dotenv
- https://vite.dev/guide/env-and-mode.html#node-env-and-modes
- https://stackoverflow.com/questions/70709987/how-to-load-environment-variables-from-env-file-using-vite