### PR TITLE
Fix bundle conflict with manual chunk

### DIFF
--- a/electron.vite.config.mjs
+++ b/electron.vite.config.mjs
@@ -59,19 +59,7 @@ export default defineConfig(async ({ mode }) => {
           output: {
             manualChunks: {
               vendor: ['react', 'react-dom', 'react-router-dom'],
-              crypto: ['crypto-browserify', 'stream-browserify', 'readable-stream'],
-              xchain: [
-                '@xchainjs/xchain-wallet',
-                '@xchainjs/xchain-doge',
-                '@xchainjs/xchain-litecoin',
-                '@xchainjs/xchain-bitcoin',
-                '@xchainjs/xchain-ethereum',
-                '@xchainjs/xchain-cosmos',
-                '@xchainjs/xchain-thorchain',
-                '@xchainjs/xchain-client',
-                '@xchainjs/xchain-crypto',
-                '@xchainjs/xchain-util'
-              ]
+              crypto: ['crypto-browserify', 'stream-browserify', 'readable-stream']
             }
           },
           plugins: [


### PR DESCRIPTION
This PR removes the manualChunks configuration that was grouping several Xchain-related packages into a single chunk. This grouping caused issues in the production build, breaking functionality related to trade assets and secured assets.

Removing the chunk resolves the issue, and the affected features now work correctly in production.