### PR TITLE
update radix's dependency on secp256k1 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,8 +227,8 @@
     "vitest": "^3.1.3"
   },
   "resolutions": {
-    "secp256k1": "4.0.3",
     "@types/react": "^18.3.22",
+    "secp256k1": "^5.0.1",
     "typescript": "^5.8.3",
     "bn.js": "4.12.0",
     "bigint-buffer": "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9513,7 +9513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.6.1":
+"elliptic@npm:^6.5.7, elliptic@npm:^6.6.1":
   version: 6.6.1
   resolution: "elliptic@npm:6.6.1"
   dependencies:
@@ -13242,6 +13242,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-addon-api@npm:^5.0.0":
+  version: 5.1.0
+  resolution: "node-addon-api@npm:5.1.0"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10/595f59ffb4630564f587c502119cbd980d302e482781021f3b479f5fc7e41cf8f2f7280fdc2795f32d148e4f3259bd15043c52d4a3442796aa6f1ae97b959636
+  languageName: node
+  linkType: hard
+
 "node-addon-api@npm:^6.0.0":
   version: 6.1.0
   resolution: "node-addon-api@npm:6.1.0"
@@ -15922,15 +15931,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"secp256k1@npm:4.0.3":
-  version: 4.0.3
-  resolution: "secp256k1@npm:4.0.3"
+"secp256k1@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "secp256k1@npm:5.0.1"
   dependencies:
-    elliptic: "npm:^6.5.4"
-    node-addon-api: "npm:^2.0.0"
+    elliptic: "npm:^6.5.7"
+    node-addon-api: "npm:^5.0.0"
     node-gyp: "npm:latest"
     node-gyp-build: "npm:^4.2.0"
-  checksum: 10/8b45820cd90fd2f95cc8fdb9bf8a71e572de09f2311911ae461a951ffa9e30c99186a129d0f1afeb380dd67eca0c10493f8a7513c39063fda015e99995088e3b
+  checksum: 10/63fbd35624be4fd9cf3d39e5f79c5471b4a8aea6944453b2bea7b100bb1c77a25c55e6e08e2210cdabdf478c4c62d34c408b34214f2afd9367e19a52a3a4236c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`@radixdlt/radix-engine-toolkit` doesn't use caret `^` semver for its dependencies so it's pinned to an outdated version of the library. https://github.com/radixdlt/typescript-radix-engine-toolkit/issues/21 And it's the only remaining user of secp256k1 in asgardex.

```sh
yarn why secp256k1
└─ @radixdlt/radix-engine-toolkit@npm:1.0.5
   └─ secp256k1@npm:4.0.3 (via npm:4.0.3)
```

The old `"resolution"` on 4.0.3 was created at a time when xchainjs libraries depended on secp256k1 5.0, deliberately downgrading it to 4 for a reason that wasn't explained in the PR #250, but xchainjs doesn't even depend on secp256k1 now, only radix code does.

This was `yarn why secp256k1` at the time before the resolution was added 5335a2105ce03e40d41798d8456d97d58a7ed029

```
├─ @cosmos-client/core@npm:0.46.1
│  └─ secp256k1@npm:4.0.3 (via npm:^4.0.2)
│
├─ @xchainjs/xchain-cosmos-sdk@npm:0.2.10
│  └─ secp256k1@npm:5.0.0 (via npm:^5.0.0)
│
├─ @xchainjs/xchain-cosmos@npm:1.1.3
│  └─ secp256k1@npm:5.0.0 (via npm:^5.0.0)
│
├─ @xchainjs/xchain-mayachain@npm:1.0.7
│  └─ secp256k1@npm:5.0.0 (via npm:^5.0.0)
│
├─ @xchainjs/xchain-thorchain@npm:1.0.10
│  └─ secp256k1@npm:5.0.0 (via npm:^5.0.0)
│
└─ hdkey@npm:2.1.0
   └─ secp256k1@npm:4.0.3 (via npm:^4.0.0)
```