### PR TITLE
update to elliptic 6.6.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9498,7 +9498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:6.5.4, elliptic@npm:^6.4.0, elliptic@npm:^6.4.1, elliptic@npm:^6.5.3, elliptic@npm:^6.5.4":
+"elliptic@npm:6.5.4":
   version: 6.5.4
   resolution: "elliptic@npm:6.5.4"
   dependencies:
@@ -9513,7 +9513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.6.1":
+"elliptic@npm:^6.4.0, elliptic@npm:^6.4.1, elliptic@npm:^6.5.3, elliptic@npm:^6.5.4, elliptic@npm:^6.6.1":
   version: 6.6.1
   resolution: "elliptic@npm:6.6.1"
   dependencies:


### PR DESCRIPTION
https://github.com/asgardex/asgardex-desktop/security/dependabot/17

[6.5.4](https://www.npmjs.com/package/elliptic/v/6.5.4), a version released in 2021, was still in use. It was vulnerable to an attack by a compromised RPC server.

https://github.com/indutny/elliptic/security/advisories/GHSA-vjh7-7g9h-fjfh

```
yarn why elliptic
├─ @cosmjs/crypto@npm:0.33.1
│  └─ elliptic@npm:6.6.1 (via npm:^6.6.1)
│
├─ @dashevo/dashcore-lib@npm:0.25.0
│  └─ elliptic@npm:6.5.4 (via npm:^6.5.4)
│
├─ @ethersproject/signing-key@npm:5.7.0
│  └─ elliptic@npm:6.5.4 (via npm:6.5.4)
│
├─ bitcore-lib-cash@npm:11.0.0
│  └─ elliptic@npm:6.5.4 (via npm:^6.5.3)
│
├─ browserify-sign@npm:4.2.1
│  └─ elliptic@npm:6.5.4 (via npm:^6.5.3)
│
├─ create-ecdh@npm:4.0.4
│  └─ elliptic@npm:6.5.4 (via npm:^6.5.3)
│
├─ foundry-primitives-xchainjs@https://github.com/xchainjs/foundry-primitives-js.git#commit=cc69da563d0a4b29adf70f1e75cccab1ca3752c0
│  └─ elliptic@npm:6.5.4 (via npm:^6.4.1)
│
├─ secp256k1@npm:4.0.3
│  └─ elliptic@npm:6.5.4 (via npm:^6.5.4)
│
└─ tiny-secp256k1@npm:1.1.6
   └─ elliptic@npm:6.5.4 (via npm:^6.4.0)
```

- The radix code was using it because `@radixdlt/radix-engine-toolkit` depends on `secp256k1`.

```
└─ @radixdlt/radix-engine-toolkit@npm:1.0.5
   └─ secp256k1@npm:4.0.3 (via npm:4.0.3)
```

- All EVM chains were previously using it through a dependency on `ethers 5.7.2`, up until xchainjs packages were updated in #790

- doge, litecoin, and dash were also previously depending on it through a dependency on `bitcoinjs-lib@npm:5.2.0`, but bitcoincash didn't, it was previously using the even older and abandoned `ecurve` package.

- bitcoin also previously depended on the vulnerable `bitcoinjs-lib` v5 before the Taproot update in #383 https://github.com/xchainjs/xchainjs-lib/pull/1277 to [`xchain-bitcoin 1.1.0`](https://github.com/xchainjs/xchainjs-lib/releases/tag/%40xchainjs/xchain-bitcoin%401.1.0) and newer

- `@cosmjs/crypto` (used for signing thorchain, mayachain, cosmos hub, and kuji transactions) was also using it before #790

- anything relying on `crypto-browserify` may have been using it (unclear what code that is, is it only used in the storybook build?).

- The dash library has its own [bespoke](https://github.com/dashpay/dashcore-lib/blob/c3c3fe5d4110b7191953983275e71cc48d94b9e7/docs/core-concepts/crypto.md) ECDSA implementation using the Point class from elliptic, so it doesn't use elliptic's vulnerable signing code.

 - bitcore also has the exact same [bespoke](https://github.com/bitpay/bitcore/blob/56468c3bd603a7e126ba14f3632c46d9f9ee5c5c/packages/bitcore-lib-cash/docs/crypto.md) ECDSA implementation, and is planning to remove elliptic https://github.com/bitpay/bitcore/issues/3666#issuecomment-2664180733
