### PR TITLE
chore: parse classnames with clsx

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -2325,7 +2325,7 @@ export const Swap = ({
 
     return (
       <>
-        <div className={clsx('flex w-full justify-between font-mainBold text-[14px]', showDetails ? 'pt-10px' : '')}>
+        <div className={clsx('flex w-full justify-between font-mainBold text-[14px]', { 'pt-10px': showDetails })}>
           <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'common.time.title' })}</div>
           <div className="text-text2 dark:text-text2d">{formatSwapTime(transactionTime)}</div>
         </div>
@@ -2552,8 +2552,8 @@ export const Swap = ({
                     <div
                       className={clsx(
                         'flex w-full justify-between font-mainBold text-[14px]',
-                        showDetails ? 'pt-10px' : '',
-                        isCausedSlippage ? 'text-error0 dark:text-error0d' : ''
+                        { 'pt-10px': showDetails },
+                        { 'text-error0 dark:text-error0d': isCausedSlippage }
                       )}>
                       <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'swap.slip.title' })}</div>
                       <div className="text-text2 dark:text-text2d">

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -2325,7 +2325,7 @@ export const Swap = ({
 
     return (
       <>
-        <div className={`flex w-full justify-between ${showDetails ? 'pt-10px' : ''} font-mainBold text-[14px]`}>
+        <div className={clsx('flex w-full justify-between font-mainBold text-[14px]', showDetails ? 'pt-10px' : '')}>
           <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'common.time.title' })}</div>
           <div className="text-text2 dark:text-text2d">{formatSwapTime(transactionTime)}</div>
         </div>
@@ -2550,9 +2550,11 @@ export const Swap = ({
                   {/* Slippage */}
                   <>
                     <div
-                      className={`flex w-full justify-between ${
-                        showDetails ? 'pt-10px' : ''
-                      } font-mainBold text-[14px] ${isCausedSlippage ? 'text-error0 dark:text-error0d' : ''}`}>
+                      className={clsx(
+                        'flex w-full justify-between font-mainBold text-[14px]',
+                        showDetails ? 'pt-10px' : '',
+                        isCausedSlippage ? 'text-error0 dark:text-error0d' : ''
+                      )}>
                       <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'swap.slip.title' })}</div>
                       <div className="text-text2 dark:text-text2d">
                         {formatAssetAmountCurrency({
@@ -2569,7 +2571,7 @@ export const Swap = ({
                     {showDetails && (
                       <>
                         <div className="flex w-full justify-between pl-10px text-[12px]">
-                          <div className={`flex items-center `}>
+                          <div className="flex items-center">
                             {intl.formatMessage({ id: 'swap.slip.tolerance' })}
 
                             <InfoIcon
@@ -2582,7 +2584,7 @@ export const Swap = ({
                           </div>
                         </div>
                         <div className="flex w-full justify-between pl-10px text-[12px]">
-                          <div className={`flex items-center `}>
+                          <div className="flex items-center">
                             {intl.formatMessage({ id: 'swap.min.result.protected' })}
                             <InfoIcon
                               className="ml-[3px] h-[15px] w-[15px] text-inherit"
@@ -2677,7 +2679,7 @@ export const Swap = ({
                   {/* balances */}
                   {showDetails && (
                     <>
-                      <div className={`w-full pt-10px text-[14px]`}>
+                      <div className="w-full pt-10px text-[14px]">
                         <BaseButton
                           disabled={walletBalancesLoading}
                           className="group !p-0 !font-mainBold !text-text2 dark:!text-text2d"
@@ -2721,7 +2723,7 @@ export const Swap = ({
               <div className="w-full px-4 pb-4 font-main text-[12px] uppercase dark:border-gray1d">
                 <div className="font-main text-[14px] text-gray2 dark:text-gray2d">
                   {/* Rate */}
-                  <div className={`flex w-full justify-between font-mainBold text-[14px]`}>
+                  <div className="flex w-full justify-between font-mainBold text-[14px]">
                     <BaseButton
                       className="group !p-0 !font-mainBold !text-text2 dark:!text-text2d"
                       onClick={() =>

--- a/src/renderer/components/swap/TradeSwap.tsx
+++ b/src/renderer/components/swap/TradeSwap.tsx
@@ -26,6 +26,7 @@ import {
   TradeAsset
 } from '@xchainjs/xchain-util'
 import { Row } from 'antd'
+import clsx from 'clsx'
 import { array as A, function as FP, nonEmptyArray as NEA, option as O } from 'fp-ts'
 import debounce from 'lodash/debounce'
 import { useObservableState } from 'observable-hooks'
@@ -114,7 +115,8 @@ const ErrorLabel: React.FC<{
   children: React.ReactNode
   className?: string
 }> = ({ children, className }): JSX.Element => (
-  <div className={`mb-[14px] text-center font-main uppercase text-error0 dark:text-error0d ${className} text-[12px]`}>
+  <div
+    className={clsx('mb-[14px] text-center font-main uppercase text-error0 dark:text-error0d text-[12px]', className)}>
     {children}
   </div>
 )
@@ -1971,7 +1973,7 @@ export const TradeSwap = ({
               </div>
             }>
             {!isLocked(keystore) ? (
-              <div className={`w-full px-4 pb-4 font-main text-[12px] uppercase dark:border-gray1d`}>
+              <div className="w-full px-4 pb-4 font-main text-[12px] uppercase dark:border-gray1d">
                 <BaseButton
                   className="group flex w-full justify-between !p-0 font-mainSemiBold text-[16px] text-text2 hover:text-turquoise dark:text-text2d dark:hover:text-turquoise"
                   onClick={() => setShowDetails((current) => !current)}>
@@ -2028,9 +2030,11 @@ export const TradeSwap = ({
                   {/* Slippage */}
                   <>
                     <div
-                      className={`flex w-full justify-between ${
-                        showDetails ? 'pt-10px' : ''
-                      } font-mainBold text-[14px] ${isCausedSlippage ? 'text-error0 dark:text-error0d' : ''}`}>
+                      className={clsx(
+                        'flex w-full justify-between font-mainBold text-[14px]',
+                        showDetails ? 'pt-10px' : '',
+                        isCausedSlippage ? 'text-error0 dark:text-error0d' : ''
+                      )}>
                       <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'swap.slip.title' })}</div>
                       <div className="text-text2 dark:text-text2d">
                         {formatAssetAmountCurrency({
@@ -2047,7 +2051,7 @@ export const TradeSwap = ({
                     {showDetails && (
                       <>
                         <div className="flex w-full justify-between pl-10px text-[12px]">
-                          <div className={`flex items-center`}>
+                          <div className="flex items-center">
                             {intl.formatMessage({ id: 'swap.slip.tolerance' })}
                             <InfoIcon
                               className="ml-[3px] h-[15px] w-[15px] text-inherit"
@@ -2059,7 +2063,7 @@ export const TradeSwap = ({
                           </div>
                         </div>
                         <div className="flex w-full justify-between pl-10px text-[12px]">
-                          <div className={`flex items-center`}>
+                          <div className="flex items-center">
                             {intl.formatMessage({ id: 'swap.min.result.protected' })}
                             <InfoIcon
                               className="ml-[3px] h-[15px] w-[15px] text-inherit"
@@ -2074,9 +2078,10 @@ export const TradeSwap = ({
                   {/* Swap Time Inbound / swap / Outbound */}
                   <>
                     <div
-                      className={`flex w-full justify-between ${
+                      className={clsx(
+                        'flex w-full justify-between font-mainBold text-[14px]',
                         showDetails ? 'pt-10px' : ''
-                      } font-mainBold text-[14px]`}>
+                      )}>
                       <div className="text-text2 dark:text-text2d">
                         {intl.formatMessage({ id: 'common.time.title' })}
                       </div>
@@ -2202,7 +2207,7 @@ export const TradeSwap = ({
                 <div className="w-full px-4 pb-4 font-main text-[12px] uppercase dark:border-gray1d">
                   <div className="font-main text-[14px] text-gray2 dark:text-gray2d">
                     {/* Rate */}
-                    <div className={`flex w-full justify-between font-mainBold text-[14px]`}>
+                    <div className="flex w-full justify-between font-mainBold text-[14px]">
                       <BaseButton
                         className="group !p-0 !font-mainBold !text-text2 dark:!text-text2d"
                         onClick={() =>
@@ -2254,9 +2259,10 @@ export const TradeSwap = ({
                     {/* Transaction time */}
                     <>
                       <div
-                        className={`flex w-full justify-between ${
+                        className={clsx(
+                          'flex w-full justify-between font-mainBold text-[14px]',
                           showDetails ? 'pt-10px' : ''
-                        } font-mainBold text-[14px]`}>
+                        )}>
                         <div className="text-text2 dark:text-text2d">
                           {intl.formatMessage({ id: 'common.time.title' })}
                         </div>
@@ -2265,7 +2271,7 @@ export const TradeSwap = ({
                         </div>
                       </div>
                       <div className="flex w-full justify-between pl-10px text-[12px]">
-                        <div className={`flex items-center text-text2 dark:text-text2d`}>
+                        <div className="flex items-center text-text2 dark:text-text2d">
                           {intl.formatMessage({ id: 'common.inbound.time' })}
                         </div>
                         <div className="text-text2 dark:text-text2d">
@@ -2273,7 +2279,7 @@ export const TradeSwap = ({
                         </div>
                       </div>
                       <div className="flex w-full justify-between pl-10px text-[12px]">
-                        <div className={`flex items-center text-text2 dark:text-text2d`}>
+                        <div className="flex items-center text-text2 dark:text-text2d">
                           {intl.formatMessage({ id: 'common.streaming.time' })}
                         </div>
                         <div className="text-text2 dark:text-text2d">
@@ -2281,7 +2287,7 @@ export const TradeSwap = ({
                         </div>
                       </div>
                       <div className="flex w-full justify-between pl-10px text-[12px]">
-                        <div className={`flex items-center text-text2 dark:text-text2d`}>
+                        <div className="flex items-center text-text2 dark:text-text2d">
                           {intl.formatMessage({ id: 'common.outbound.time' })}
                         </div>
                         <div className="text-text2 dark:text-text2d">
@@ -2289,7 +2295,7 @@ export const TradeSwap = ({
                         </div>
                       </div>
                       <div className="flex w-full justify-between pl-10px text-[12px]">
-                        <div className={`flex items-center text-text2 dark:text-text2d`}>
+                        <div className="flex items-center text-text2 dark:text-text2d">
                           {intl.formatMessage(
                             { id: 'common.confirmation.time' },
                             { chain: targetAsset.type === AssetType.SYNTH ? THORChain : targetAsset.chain }

--- a/src/renderer/components/uielements/assets/assetAddress/AssetAddress.tsx
+++ b/src/renderer/components/uielements/assets/assetAddress/AssetAddress.tsx
@@ -22,7 +22,7 @@ export const AssetAddress = (props: Props) => {
       <AssetIcon asset={asset} size={size} network={network} />
       <div className="w-full overflow-hidden">
         <Styled.AddressEllipsis
-          className={`${classNameAddress}`}
+          className={classNameAddress}
           address={address}
           iconSize={size}
           chain={asset.chain}

--- a/src/renderer/components/uielements/assets/assetInput/AssetInput.tsx
+++ b/src/renderer/components/uielements/assets/assetInput/AssetInput.tsx
@@ -168,7 +168,7 @@ export const AssetInput = (props: Props): JSX.Element => {
 
         <div className="flex flex-col">
           <AssetSelect
-            className={`h-full ${ASSET_SELECT_BUTTON_WIDTH}`}
+            className={clsx('h-full', ASSET_SELECT_BUTTON_WIDTH)}
             onSelect={onChangeAsset}
             asset={asset}
             assets={assets}

--- a/src/renderer/components/uielements/assets/assetMenu/AssetMenu.tsx
+++ b/src/renderer/components/uielements/assets/assetMenu/AssetMenu.tsx
@@ -210,7 +210,7 @@ export const AssetMenu = (props: Props): JSX.Element => {
   return (
     <Dialog
       as="div"
-      className={`relative z-10 ${className}`}
+      className={clsx('relative z-10', className)}
       initialFocus={inputSearchRef}
       transition
       open={open}

--- a/src/renderer/components/uielements/button/ActionButton.tsx
+++ b/src/renderer/components/uielements/button/ActionButton.tsx
@@ -31,7 +31,7 @@ export const ActionButton = ({
       <div className={clsx('flex w-full justify-start space-x-2', className)}>
         {actions.map(({ label, callback, disabled = false }, index) => (
           <FlatButton
-            className={`group ${btnClassName}`} // Use FlatButton or TextButton as needed
+            className={clsx('group', btnClassName)} // Use FlatButton or TextButton as needed
             size={size}
             disabled={disabled}
             key={index}

--- a/src/renderer/components/uielements/button/BaseButton.tsx
+++ b/src/renderer/components/uielements/button/BaseButton.tsx
@@ -67,7 +67,7 @@ export const BaseButton = (props: BaseButtonProps): JSX.Element => {
       )}
       {...restProps}>
       {loading && (
-        <LoadingIcon className={`${iconSize[size]} ${iconMargin[size]} animate-spin group-hover:opacity-70`} />
+        <LoadingIcon className={clsx(iconSize[size], iconMargin[size], 'animate-spin group-hover:opacity-70')} />
       )}
       {children}
     </button>

--- a/src/renderer/components/uielements/button/BorderButton.tsx
+++ b/src/renderer/components/uielements/button/BorderButton.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { BaseButton, BaseButtonProps } from './BaseButton'
 import { borderSize, dropShadow, borderColor } from './Button.shared'
 import type { Color } from './Button.types'
@@ -29,18 +30,18 @@ export const BorderButton = (props: Props): JSX.Element => {
     <BaseButton
       size={size}
       disabled={disabled}
-      className={`
-      rounded-full
-      ${borderSize[size]}
-      bg-bg0 dark:bg-bg0d
-        ${textColor[color]}
-        ${borderColor[color]}
-        ${transparent && 'bg-tranparent'}
-        ${!disabled && `hover:${dropShadow[size]}`}
-        ${!disabled && 'hover:border-opacity-85'}
-        ${!disabled && 'hover:scale-105'}
-        ${className}
-      `}
+      className={clsx(
+        'rounded-full',
+        borderSize[size],
+        'bg-bg0 dark:bg-bg0d',
+        textColor[color],
+        borderColor[color],
+        !disabled ? `hover:${dropShadow[size]}` : '',
+        { 'bg-tranparent': transparent },
+        { 'hover:border-opacity-85': !disabled },
+        { 'hover:scale-105': !disabled },
+        className
+      )}
       {...restProps}>
       {children}
     </BaseButton>

--- a/src/renderer/components/uielements/button/BorderButton.tsx
+++ b/src/renderer/components/uielements/button/BorderButton.tsx
@@ -37,7 +37,7 @@ export const BorderButton = (props: Props): JSX.Element => {
         textColor[color],
         borderColor[color],
         !disabled ? `hover:${dropShadow[size]}` : '',
-        { 'bg-tranparent': transparent },
+        { 'bg-transparent': transparent },
         { 'hover:border-opacity-85': !disabled },
         { 'hover:scale-105': !disabled },
         className

--- a/src/renderer/components/uielements/button/Button.tsx
+++ b/src/renderer/components/uielements/button/Button.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import clsx from 'clsx'
 import { ButtonWrapper } from './Button.styles'
 import type { ButtonProps } from './Button.types'
 
@@ -23,7 +24,7 @@ export const Button: React.ForwardRefExoticComponent<ButtonProps> = React.forwar
     return (
       <ButtonWrapper
         ref={ref}
-        className={`${className} btn-wrapper ${focusedStyle}`}
+        className={clsx(className, 'btn-wrapper', focusedStyle)}
         type="primary"
         weight={weight}
         color={color}

--- a/src/renderer/components/uielements/button/CheckButton.tsx
+++ b/src/renderer/components/uielements/button/CheckButton.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react'
 
 import { CheckCircleIcon } from '@heroicons/react/24/outline'
+import clsx from 'clsx'
 import { function as FP } from 'fp-ts'
 
 import { Color, Size } from './Button.types'
@@ -60,13 +61,13 @@ export const CheckButton = (props: Props): JSX.Element => {
       size={size}
       onClick={onClickHandler}
       disabled={disabled}
-      className={`w-min-auto !px-0 ${className}`}>
+      className={clsx('w-min-auto !px-0', className)}>
       <div className="flex items-center justify-between">
-        <div className={`${iconSize[size]} mr-5px`}>
+        <div className={clsx(iconSize[size], 'mr-5px')}>
           {checked ? (
-            <CheckCircleIcon className={`h-full w-full`} />
+            <CheckCircleIcon className="h-full w-full" />
           ) : (
-            <div className={`h-full w-full rounded-full border ${borderColor[color]}`}></div>
+            <div className={clsx('h-full w-full rounded-full border', borderColor[color])}></div>
           )}
         </div>
         {children}

--- a/src/renderer/components/uielements/button/FlatButton.tsx
+++ b/src/renderer/components/uielements/button/FlatButton.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { BaseButton, BaseButtonProps } from './BaseButton'
 import * as S from './Button.shared'
 import type { Color } from './Button.types'
@@ -29,18 +30,16 @@ export const FlatButton = (props: Props): JSX.Element => {
     <BaseButton
       size={size}
       disabled={disabled}
-      className={`
-      rounded-full
-        ${textColor[color]}
-        ${bgColor[color]}
-        ${S.borderSize[size]}
-        ${textColor[color]}
-        ${borderColor[color]}
-        ${!disabled && `hover:${S.dropShadow[size]}`}
-        ${!disabled && 'hover:border-opacity-85'}
-        ${!disabled && 'hover:scale-105'}
-        ${className}
-      `}
+      className={clsx(
+        'rounded-full',
+        textColor[color],
+        bgColor[color],
+        S.borderSize[size],
+        textColor[color],
+        borderColor[color],
+        !disabled ? `hover:${S.dropShadow[size]} hover:border-opacity-85 hover:scale-105` : '',
+        className
+      )}
       {...restProps}>
       {children}
     </BaseButton>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved consistency and readability of CSS class name assignments across multiple components by adopting the `clsx` utility for conditional and combined class names.
  * Simplified class name handling by replacing template literals with direct string or `clsx` usage, resulting in cleaner and more maintainable code.
  * No changes to application logic, behavior, or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->