### PR TITLE
fix off-by-one error in dust threshold

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -1457,7 +1457,7 @@ export const Swap = ({
       O.fold(
         () => false,
         (quoteSwap) => {
-          return quoteSwap.dustThreshold.baseAmount.gt(convertBaseAmountDecimal(amountToSwapMax1e8, sourceAssetDecimal))
+          return quoteSwap.dustThreshold.baseAmount.gte(convertBaseAmountDecimal(amountToSwapMax1e8, sourceAssetDecimal))
         }
       )
     )


### PR DESCRIPTION
This fixes an off-by-one error in the dust threshold.
For example the dust amount for BTC is 10000 sats so the transaction amount needs to be at least 10001 sats.
Previously it allowed submitting a swap with 10000 sats, causing the money to be lost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dust threshold handling: swap amounts equal to the threshold are now treated as below the threshold.
  * The swap button is disabled and a warning is shown when the amount is at or below the dust threshold, preventing edge-case submissions.
  * Improves consistency of validation and messaging at boundary values without changing other behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->