### PR TITLE
feat: add restore wallet from phrase option

### DIFF
--- a/src/renderer/components/wallet/unlock/UnlockForm.tsx
+++ b/src/renderer/components/wallet/unlock/UnlockForm.tsx
@@ -151,6 +151,10 @@ export const UnlockForm = ({ keystore, unlock, removeKeystore, changeKeystore$, 
     navigate(walletRoutes.imports.keystore.path())
   }, [navigate])
 
+  const importPhraseHandler = useCallback(() => {
+    navigate(walletRoutes.imports.phrase.path())
+  }, [navigate])
+
   const useLedgerOnlyHandler = useCallback(() => {
     navigate(walletRoutes.ledgerChainSelect.path())
   }, [navigate])
@@ -258,7 +262,15 @@ export const UnlockForm = ({ keystore, unlock, removeKeystore, changeKeystore$, 
                   color="primary"
                   onClick={importWalletHandler}
                   disabled={unlocking}>
-                  {intl.formatMessage({ id: 'wallet.action.import' })}
+                  {intl.formatMessage({ id: 'wallet.action.import' })} {intl.formatMessage({ id: 'common.keystore' })}
+                </BorderButton>
+                <BorderButton
+                  className="mr-20px w-full min-w-[200px] sm:mb-0"
+                  size="normal"
+                  color="primary"
+                  onClick={importPhraseHandler}
+                  disabled={unlocking}>
+                  {intl.formatMessage({ id: 'wallet.action.import' })} {intl.formatMessage({ id: 'common.phrase' })}
                 </BorderButton>
               </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “Import Phrase” option on the unlock screen for faster phrase-based wallet setup.
  * Import actions are disabled while unlocking to prevent accidental interactions.

* **Improvements**
  * Renamed the existing import option to “Import Keystore” for clarity.
  * Unified styling of “Import Keystore” and “Import Phrase” buttons for a consistent look and feel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->