### PR TITLE
update evm chains to use proper gas estimation

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -695,11 +695,11 @@ export const Swap = ({
         () =>
           new CryptoAmount(
             swapFees.outFee.amount,
-            targetAsset.type === AssetType.SYNTH
+            swapFees.outFee.asset.type === AssetType.SYNTH
               ? AssetCacao
-              : targetAsset.type === AssetType.SECURED
+              : swapFees.outFee.asset.type === AssetType.SECURED
               ? AssetRuneNative
-              : targetAsset
+              : swapFees.outFee.asset
           ),
         (txDetails) => {
           const txOutFee = txDetails.fees.outboundFee
@@ -708,7 +708,7 @@ export const Swap = ({
       )
     )
     return swapOutFee
-  }, [oQuoteProtocol, swapFees.outFee.amount, targetAsset])
+  }, [oQuoteProtocol, swapFees.outFee.amount, swapFees.outFee.asset])
   const [outFeePriceValue, setOutFeePriceValue] = useState<CryptoAmount>(
     new CryptoAmount(swapFees.outFee.amount, targetAsset)
   )

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -629,33 +629,23 @@ export const Swap = ({
   // Price of swap IN fee
   const oPriceSwapInFee: O.Option<CryptoAmount> = useMemo(() => {
     const assetAmount = new CryptoAmount(swapFees.inFee.amount, swapFees.inFee.asset)
-    const result = FP.pipe(
-      isChainOfThor(assetAmount.asset.chain)
-        ? PoolHelpers.getUSDValue({
-            balance: { asset: assetAmount.asset, amount: assetAmount.baseAmount },
-            poolDetails: poolDetailsThor,
-            pricePool: pricePoolThor
-          })
-        : FP.pipe(
-            PoolHelpersMaya.getUSDValue({
-              balance: { asset: assetAmount.asset, amount: assetAmount.baseAmount },
-              poolDetails: poolDetailsMaya,
-              pricePool: pricePoolMaya
-            })
-          ),
-      O.getOrElse(() => baseAmount(0, amountToSwapMax1e8.decimal))
-    )
+    const usdValueOption = isChainOfThor(assetAmount.asset.chain)
+      ? PoolHelpers.getUSDValue({
+          balance: { asset: assetAmount.asset, amount: assetAmount.baseAmount },
+          poolDetails: poolDetailsThor,
+          pricePool: pricePoolThor
+        })
+      : PoolHelpersMaya.getUSDValue({
+          balance: { asset: assetAmount.asset, amount: assetAmount.baseAmount },
+          poolDetails: poolDetailsMaya,
+          pricePool: pricePoolMaya
+        })
 
-    return O.some(new CryptoAmount(result, pricePoolThor.asset))
-  }, [
-    amountToSwapMax1e8.decimal,
-    poolDetailsMaya,
-    poolDetailsThor,
-    pricePoolMaya,
-    pricePoolThor,
-    swapFees.inFee.amount,
-    swapFees.inFee.asset
-  ])
+    return FP.pipe(
+      usdValueOption,
+      O.map((result) => new CryptoAmount(result, pricePoolThor.asset))
+    )
+  }, [poolDetailsMaya, poolDetailsThor, pricePoolMaya, pricePoolThor, swapFees.inFee.amount, swapFees.inFee.asset])
 
   const priceSwapInFeeLabel = useMemo(() => {
     // Ensure swapFees is defined before proceeding
@@ -676,19 +666,24 @@ export const Swap = ({
 
     const price = FP.pipe(
       oPriceSwapInFee,
-      O.map(({ assetAmount, asset }) =>
-        eqAsset.equals(feeAsset, asset)
-          ? emptyString
-          : formatAssetAmountCurrency({
-              amount: assetAmount,
-              asset: asset,
-              decimal: isUSDAsset(asset) ? 2 : 6,
-              trimZeros: !isUSDAsset(asset)
-            })
-      ),
+      O.map(({ assetAmount, asset }) => {
+        if (eqAsset.equals(feeAsset, asset)) {
+          return emptyString
+        }
+
+        // Use more decimals for very small USD amounts to avoid showing $0.00
+        const isVerySmallUSDAmount = isUSDAsset(asset) && assetAmount.amount().lt(0.01)
+        const decimalPlaces = isUSDAsset(asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
+
+        return formatAssetAmountCurrency({
+          amount: assetAmount,
+          asset: asset,
+          decimal: decimalPlaces,
+          trimZeros: !isUSDAsset(asset) || isVerySmallUSDAmount
+        })
+      }),
       O.getOrElse(() => emptyString)
     )
-
     return price ? `${price} (${fee})` : fee
   }, [oPriceSwapInFee, swapFees])
 

--- a/src/renderer/components/wallet/txs/send/SendFormCOSMOS.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormCOSMOS.tsx
@@ -376,10 +376,13 @@ export const SendFormCOSMOS = (props: Props): JSX.Element => {
       return loadingString // or noDataString, depending on your needs
     }
 
+    // Use more decimals for very small USD amounts to avoid showing $0.00
+    const isFeeVerySmallUSDAmount = isUSDAsset(assetFee.asset) && assetFee.assetAmount.amount().lt(0.01)
+    const feeDecimalPlaces = isUSDAsset(assetFee.asset) ? (isFeeVerySmallUSDAmount ? 6 : 2) : 6
     const fee = formatAssetAmountCurrency({
       amount: assetFee.assetAmount,
       asset: assetFee.asset,
-      decimal: isUSDAsset(assetFee.asset) ? 2 : 6,
+      decimal: feeDecimalPlaces,
       trimZeros: !isUSDAsset(assetFee.asset)
     })
 
@@ -388,12 +391,17 @@ export const SendFormCOSMOS = (props: Props): JSX.Element => {
       O.map((cryptoAmount: CryptoAmount) =>
         eqAsset(asset, cryptoAmount.asset)
           ? ''
-          : formatAssetAmountCurrency({
-              amount: cryptoAmount.assetAmount,
-              asset: cryptoAmount.asset,
-              decimal: isUSDAsset(cryptoAmount.asset) ? 2 : 6,
-              trimZeros: !isUSDAsset(cryptoAmount.asset)
-            })
+          : (() => {
+              // Use more decimals for very small USD amounts to avoid showing $0.00
+              const isVerySmallUSDAmount = isUSDAsset(cryptoAmount.asset) && cryptoAmount.assetAmount.amount().lt(0.01)
+              const decimalPlaces = isUSDAsset(cryptoAmount.asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
+              return formatAssetAmountCurrency({
+                amount: cryptoAmount.assetAmount,
+                asset: cryptoAmount.asset,
+                decimal: decimalPlaces,
+                trimZeros: !isUSDAsset(cryptoAmount.asset)
+              })
+            })()
       ),
       O.getOrElse(() => '')
     )
@@ -406,33 +414,49 @@ export const SendFormCOSMOS = (props: Props): JSX.Element => {
       return loadingString // or noDataString, depending on your needs
     }
 
+    // Use more decimals for very small USD amounts to avoid showing $0.00
+    const assetAmount = baseToAsset(amountToSend)
+    const isVerySmallUSDAmount = isUSDAsset(asset) && assetAmount.amount().lt(0.01)
+    const decimalPlaces = isUSDAsset(asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
     const amount = formatAssetAmountCurrency({
-      amount: baseToAsset(amountToSend), // Find the value of swap slippage
+      amount: assetAmount, // Find the value of swap slippage
       asset: asset,
-      decimal: isUSDAsset(asset) ? 2 : 6,
+      decimal: decimalPlaces,
       trimZeros: !isUSDAsset(asset)
     })
 
     const price = isMayaAsset(asset)
       ? RD.isSuccess(amountToSendMayaPrice)
-        ? formatAssetAmountCurrency({
-            amount: amountToSendMayaPrice.value.assetAmount,
-            asset: amountToSendMayaPrice.value.asset,
-            decimal: isUSDAsset(amountToSendMayaPrice.value.asset) ? 2 : 6,
-            trimZeros: !isUSDAsset(amountToSendMayaPrice.value.asset)
-          })
+        ? (() => {
+            // Use more decimals for very small USD amounts to avoid showing $0.00
+            const isVerySmallUSDAmount =
+              isUSDAsset(amountToSendMayaPrice.value.asset) && amountToSendMayaPrice.value.assetAmount.amount().lt(0.01)
+            const decimalPlaces = isUSDAsset(amountToSendMayaPrice.value.asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
+            return formatAssetAmountCurrency({
+              amount: amountToSendMayaPrice.value.assetAmount,
+              asset: amountToSendMayaPrice.value.asset,
+              decimal: decimalPlaces,
+              trimZeros: !isUSDAsset(amountToSendMayaPrice.value.asset)
+            })
+          })()
         : ''
       : FP.pipe(
           O.some(amountPriceValue), // Assuming this is Option<CryptoAmount>
           O.map((cryptoAmount: CryptoAmount) =>
             eqAsset(asset, cryptoAmount.asset)
               ? ''
-              : formatAssetAmountCurrency({
-                  amount: cryptoAmount.assetAmount,
-                  asset: cryptoAmount.asset,
-                  decimal: isUSDAsset(cryptoAmount.asset) ? 2 : 6,
-                  trimZeros: !isUSDAsset(cryptoAmount.asset)
-                })
+              : (() => {
+                  // Use more decimals for very small USD amounts to avoid showing $0.00
+                  const isVerySmallUSDAmount =
+                    isUSDAsset(cryptoAmount.asset) && cryptoAmount.assetAmount.amount().lt(0.01)
+                  const decimalPlaces = isUSDAsset(cryptoAmount.asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
+                  return formatAssetAmountCurrency({
+                    amount: cryptoAmount.assetAmount,
+                    asset: cryptoAmount.asset,
+                    decimal: decimalPlaces,
+                    trimZeros: !isUSDAsset(cryptoAmount.asset)
+                  })
+                })()
           ),
           O.getOrElse(() => '')
         )

--- a/src/renderer/components/wallet/txs/send/SendFormEVM.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormEVM.tsx
@@ -439,10 +439,13 @@ export const SendFormEVM = (props: Props): JSX.Element => {
       return loadingString // or noDataString, depending on your needs
     }
 
+    // Use more decimals for very small USD amounts to avoid showing $0.00
+    const isFeeVerySmallUSDAmount = isUSDAsset(assetFee.asset) && assetFee.assetAmount.amount().lt(0.01)
+    const feeDecimalPlaces = isUSDAsset(assetFee.asset) ? (isFeeVerySmallUSDAmount ? 6 : 2) : 6
     const fee = formatAssetAmountCurrency({
       amount: assetFee.assetAmount,
       asset: assetFee.asset,
-      decimal: isUSDAsset(assetFee.asset) ? 2 : 6,
+      decimal: feeDecimalPlaces,
       trimZeros: !isUSDAsset(assetFee.asset)
     })
 
@@ -451,12 +454,17 @@ export const SendFormEVM = (props: Props): JSX.Element => {
       O.map((cryptoAmount: CryptoAmount) =>
         eqAsset(asset, cryptoAmount.asset)
           ? ''
-          : formatAssetAmountCurrency({
-              amount: cryptoAmount.assetAmount,
-              asset: cryptoAmount.asset,
-              decimal: isUSDAsset(cryptoAmount.asset) ? 2 : 6,
-              trimZeros: !isUSDAsset(cryptoAmount.asset)
-            })
+          : (() => {
+              // Use more decimals for very small USD amounts to avoid showing $0.00
+              const isVerySmallUSDAmount = isUSDAsset(cryptoAmount.asset) && cryptoAmount.assetAmount.amount().lt(0.01)
+              const decimalPlaces = isUSDAsset(cryptoAmount.asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
+              return formatAssetAmountCurrency({
+                amount: cryptoAmount.assetAmount,
+                asset: cryptoAmount.asset,
+                decimal: decimalPlaces,
+                trimZeros: !isUSDAsset(cryptoAmount.asset)
+              })
+            })()
       ),
       O.getOrElse(() => '')
     )
@@ -480,13 +488,18 @@ export const SendFormEVM = (props: Props): JSX.Element => {
             decimal: isUSDAsset(asset) ? 2 : 6,
             trimZeros: !isUSDAsset(asset)
           }),
-        (amount) =>
-          formatAssetAmountCurrency({
-            amount: baseToAsset(amount), // Find the value of swap slippage
+        (amount) => {
+          // Use more decimals for very small USD amounts to avoid showing $0.00
+          const assetAmount = baseToAsset(amount)
+          const isVerySmallUSDAmount = isUSDAsset(asset) && assetAmount.amount().lt(0.01)
+          const decimalPlaces = isUSDAsset(asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
+          return formatAssetAmountCurrency({
+            amount: assetAmount, // Find the value of swap slippage
             asset: asset,
-            decimal: isUSDAsset(asset) ? 2 : 6,
+            decimal: decimalPlaces,
             trimZeros: !isUSDAsset(asset)
           })
+        }
       )
     )
 
@@ -495,12 +508,17 @@ export const SendFormEVM = (props: Props): JSX.Element => {
       O.map((cryptoAmount: CryptoAmount) =>
         eqAsset(asset, cryptoAmount.asset)
           ? ''
-          : formatAssetAmountCurrency({
-              amount: cryptoAmount.assetAmount,
-              asset: cryptoAmount.asset,
-              decimal: isUSDAsset(cryptoAmount.asset) ? 2 : 6,
-              trimZeros: !isUSDAsset(cryptoAmount.asset)
-            })
+          : (() => {
+              // Use more decimals for very small USD amounts to avoid showing $0.00
+              const isVerySmallUSDAmount = isUSDAsset(cryptoAmount.asset) && cryptoAmount.assetAmount.amount().lt(0.01)
+              const decimalPlaces = isUSDAsset(cryptoAmount.asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
+              return formatAssetAmountCurrency({
+                amount: cryptoAmount.assetAmount,
+                asset: cryptoAmount.asset,
+                decimal: decimalPlaces,
+                trimZeros: !isUSDAsset(cryptoAmount.asset)
+              })
+            })()
       ),
       O.getOrElse(() => '')
     )

--- a/src/renderer/components/wallet/txs/send/SendFormUTXO.tsx
+++ b/src/renderer/components/wallet/txs/send/SendFormUTXO.tsx
@@ -456,15 +456,20 @@ export const SendFormUTXO = (props: Props): JSX.Element => {
       selectedFee,
       O.fold(
         () => O.none, // Return `O.none` if `selectedFee` is `None`
-        (fee) =>
-          O.some(
+        (fee) => {
+          // Use more decimals for very small USD amounts to avoid showing $0.00
+          const feeAmount = baseToAsset(fee)
+          const isVerySmallUSDAmount = isUSDAsset(asset) && feeAmount.amount().lt(0.01)
+          const decimalPlaces = isUSDAsset(asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
+          return O.some(
             formatAssetAmountCurrency({
-              amount: baseToAsset(fee),
+              amount: feeAmount,
               asset: asset,
-              decimal: isUSDAsset(asset) ? 2 : 6,
+              decimal: decimalPlaces,
               trimZeros: !isUSDAsset(asset)
             })
           )
+        }
       ),
       O.getOrElse(() => '')
     )
@@ -474,12 +479,17 @@ export const SendFormUTXO = (props: Props): JSX.Element => {
       O.map((cryptoAmount: CryptoAmount) =>
         eqAsset(asset, cryptoAmount.asset)
           ? ''
-          : formatAssetAmountCurrency({
-              amount: cryptoAmount.assetAmount,
-              asset: cryptoAmount.asset,
-              decimal: isUSDAsset(cryptoAmount.asset) ? 2 : 6,
-              trimZeros: !isUSDAsset(cryptoAmount.asset)
-            })
+          : (() => {
+              // Use more decimals for very small USD amounts to avoid showing $0.00
+              const isVerySmallUSDAmount = isUSDAsset(cryptoAmount.asset) && cryptoAmount.assetAmount.amount().lt(0.01)
+              const decimalPlaces = isUSDAsset(cryptoAmount.asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
+              return formatAssetAmountCurrency({
+                amount: cryptoAmount.assetAmount,
+                asset: cryptoAmount.asset,
+                decimal: decimalPlaces,
+                trimZeros: !isUSDAsset(cryptoAmount.asset)
+              })
+            })()
       ),
       O.getOrElse(() => '')
     )
@@ -492,10 +502,14 @@ export const SendFormUTXO = (props: Props): JSX.Element => {
       return loadingString // or noDataString, depending on your needs
     }
 
+    // Use more decimals for very small USD amounts to avoid showing $0.00
+    const assetAmount = baseToAsset(amountToSend)
+    const isVerySmallUSDAmount = isUSDAsset(asset) && assetAmount.amount().lt(0.01)
+    const decimalPlaces = isUSDAsset(asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
     const amount = formatAssetAmountCurrency({
-      amount: baseToAsset(amountToSend), // Find the value of swap slippage
+      amount: assetAmount, // Find the value of swap slippage
       asset: asset,
-      decimal: isUSDAsset(asset) ? 2 : 6,
+      decimal: decimalPlaces,
       trimZeros: !isUSDAsset(asset)
     })
 
@@ -504,12 +518,17 @@ export const SendFormUTXO = (props: Props): JSX.Element => {
       O.map((cryptoAmount: CryptoAmount) =>
         eqAsset(asset, cryptoAmount.asset)
           ? ''
-          : formatAssetAmountCurrency({
-              amount: cryptoAmount.assetAmount,
-              asset: cryptoAmount.asset,
-              decimal: isUSDAsset(cryptoAmount.asset) ? 2 : 6,
-              trimZeros: !isUSDAsset(cryptoAmount.asset)
-            })
+          : (() => {
+              // Use more decimals for very small USD amounts to avoid showing $0.00
+              const isVerySmallUSDAmount = isUSDAsset(cryptoAmount.asset) && cryptoAmount.assetAmount.amount().lt(0.01)
+              const decimalPlaces = isUSDAsset(cryptoAmount.asset) ? (isVerySmallUSDAmount ? 6 : 2) : 6
+              return formatAssetAmountCurrency({
+                amount: cryptoAmount.assetAmount,
+                asset: cryptoAmount.asset,
+                decimal: decimalPlaces,
+                trimZeros: !isUSDAsset(cryptoAmount.asset)
+              })
+            })()
       ),
       O.getOrElse(() => '')
     )

--- a/src/renderer/services/arb/fees.ts
+++ b/src/renderer/services/arb/fees.ts
@@ -85,13 +85,25 @@ export const createFeesService = (client$: Client$): FeesService => {
           O.fold(
             () => Rx.of(RD.initial),
             (client): FeesLD => {
-              // Get gas limit estimation
-              const gasLimit$ = client.estimateGasLimit({
-                asset: params.asset as CompatibleAsset,
-                amount: params.amount,
-                recipient: params.recipient,
-                memo: params.memo
-              })
+              // Get gas limit estimation with fallback for standalone Ledger or flaky RPCs
+              const gasLimit$ = Rx.from(
+                client.estimateGasLimit({
+                  asset: params.asset as CompatibleAsset,
+                  amount: params.amount,
+                  recipient: params.recipient,
+                  memo: params.memo
+                })
+              ).pipe(
+                RxOp.catchError((error) => {
+                  console.error('Gas limit estimation failed, using fallback:', error)
+                  // Use same fallback logic as in estimateAndCalculateFees
+                  const fallbackGasLimit =
+                    params.asset && isAethAsset(params.asset as Asset)
+                      ? new BigNumber(ETH_OUT_TX_GAS_LIMIT) // ARB native transfer
+                      : new BigNumber(ERC20_OUT_TX_GAS_LIMIT) // ERC20 token transfer
+                  return Rx.of(fallbackGasLimit)
+                })
+              )
 
               // Get gas prices - try THORNode first, fallback to client
               const gasPrices$: Rx.Observable<RD.RemoteData<Error, GasPrices>> = FP.pipe(

--- a/src/renderer/services/arb/fees.ts
+++ b/src/renderer/services/arb/fees.ts
@@ -1,7 +1,7 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { ARB_GAS_ASSET_DECIMAL } from '@xchainjs/xchain-arbitrum'
-import { Fees, FeeType, Protocol } from '@xchainjs/xchain-client'
-import { getFee, GasPrices, Client } from '@xchainjs/xchain-evm'
+import { Fees, FeeType } from '@xchainjs/xchain-client'
+import { getFee, GasPrices, Client, CompatibleAsset } from '@xchainjs/xchain-evm'
 import { Asset, baseAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import { function as FP, option as O } from 'fp-ts'
@@ -10,6 +10,7 @@ import * as RxOp from 'rxjs/operators'
 
 import { isAethAsset } from '../../helpers/assetHelper'
 import { observableState } from '../../helpers/stateHelper'
+import { getChainGasPrices$ } from '../chain/fees/nodeapi'
 import type { FeeLD } from '../chain/types'
 import type { FeesLD } from '../clients'
 import { ERC20_OUT_TX_GAS_LIMIT, ETH_OUT_TX_GAS_LIMIT, EVMZeroAddress } from '../evm/const'
@@ -39,7 +40,7 @@ export const createFeesService = (client$: Client$): FeesService => {
 
   async function estimateAndCalculateFees(client: Client, params: TxParams) {
     // Estimate gas prices
-    const gasPrices = await client.estimateGasPrices(Protocol.THORCHAIN)
+    const gasPrices = await client.estimateGasPrices()
     const { fast: fastGP, fastest: fastestGP, average: averageGP } = gasPrices
 
     // Estimate gas limit - with fallback for standalone ledger mode
@@ -76,37 +77,7 @@ export const createFeesService = (client$: Client$): FeesService => {
   /**
    * Fees for sending txs into pool on Arb
    **/
-  const poolInTxFees$ = ({ address, abi, func, params }: PoolInTxFeeParams): FeesLD =>
-    client$.pipe(
-      RxOp.switchMap((oClient) =>
-        FP.pipe(
-          oClient,
-          O.fold(
-            () => Rx.of(RD.initial),
-            (client): FeesLD =>
-              Rx.combineLatest([
-                client.estimateCall({ contractAddress: address, abi, funcName: func, funcParams: params }),
-                client.estimateGasPrices()
-              ]).pipe(
-                RxOp.map<[BigNumber, GasPrices], Fees>(([gasLimit, gasPrices]) => ({
-                  type: FeeType.PerByte,
-                  average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: ARB_GAS_ASSET_DECIMAL }),
-                  fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: ARB_GAS_ASSET_DECIMAL }),
-                  fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: ARB_GAS_ASSET_DECIMAL })
-                })),
-                RxOp.map(RD.success),
-                RxOp.catchError((error) => Rx.of(RD.failure(error))),
-                RxOp.startWith(RD.pending)
-              )
-          )
-        )
-      )
-    )
-
-  /**
-   * Fees for sending txs out of a pool on Arb
-   **/
-  const poolOutTxFee$ = (asset: Asset): FeesLD =>
+  const poolInTxFees$ = (params: PoolInTxFeeParams): FeesLD =>
     client$.pipe(
       RxOp.switchMap((oClient) =>
         FP.pipe(
@@ -114,16 +85,49 @@ export const createFeesService = (client$: Client$): FeesService => {
           O.fold(
             () => Rx.of(RD.initial),
             (client): FeesLD => {
-              const gasLimit = isAethAsset(asset) ? ETH_OUT_TX_GAS_LIMIT : ERC20_OUT_TX_GAS_LIMIT
-              return Rx.from(client.estimateGasPrices()).pipe(
-                RxOp.map<GasPrices, Fees>((gasPrices) => ({
-                  type: FeeType.PerByte,
-                  average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: ARB_GAS_ASSET_DECIMAL }),
-                  fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: ARB_GAS_ASSET_DECIMAL }),
-                  fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: ARB_GAS_ASSET_DECIMAL })
-                })),
-                RxOp.map(RD.success),
-                RxOp.catchError((error) => Rx.of(RD.failure(error))),
+              // Get gas limit estimation
+              const gasLimit$ = client.estimateGasLimit({
+                asset: params.asset as CompatibleAsset,
+                amount: params.amount,
+                recipient: params.recipient,
+                memo: params.memo
+              })
+
+              // Get gas prices - try THORNode first, fallback to client
+              const gasPrices$: Rx.Observable<RD.RemoteData<Error, GasPrices>> = FP.pipe(
+                getChainGasPrices$('ARB', ARB_GAS_ASSET_DECIMAL),
+                RxOp.map((rd) =>
+                  RD.isFailure(rd) ? RD.failure(new Error(String(rd.error))) : (rd as RD.RemoteData<Error, GasPrices>)
+                ),
+                RxOp.catchError(() =>
+                  // Fallback to client estimation if nodeapi fails
+                  Rx.from(client.estimateGasPrices()).pipe(
+                    RxOp.map(RD.success),
+                    RxOp.catchError((error) => Rx.of(RD.failure(new Error(String(error)))))
+                  )
+                )
+              )
+
+              return Rx.combineLatest([gasLimit$, gasPrices$]).pipe(
+                RxOp.switchMap(([gasLimit, gasPricesRD]) =>
+                  FP.pipe(
+                    gasPricesRD,
+                    RD.fold<Error, GasPrices, FeesLD>(
+                      () => Rx.of(RD.initial),
+                      () => Rx.of(RD.pending),
+                      (error) => Rx.of(RD.failure(error)),
+                      (gasPrices) =>
+                        Rx.of(
+                          RD.success({
+                            type: FeeType.PerByte,
+                            average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: ARB_GAS_ASSET_DECIMAL }),
+                            fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: ARB_GAS_ASSET_DECIMAL }),
+                            fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: ARB_GAS_ASSET_DECIMAL })
+                          })
+                        )
+                    )
+                  )
+                ),
                 RxOp.startWith(RD.pending)
               )
             }
@@ -180,7 +184,6 @@ export const createFeesService = (client$: Client$): FeesService => {
     fees$,
     reloadFees,
     poolInTxFees$,
-    poolOutTxFee$,
     approveFee$,
     reloadApproveFee
   }

--- a/src/renderer/services/arb/index.ts
+++ b/src/renderer/services/arb/index.ts
@@ -23,8 +23,7 @@ const {
   approveERC20Token$,
   isApprovedERC20Token$
 } = createTransactionService(client$, network$)
-const { reloadFees, fees$, poolInTxFees$, poolOutTxFee$, approveFee$, reloadApproveFee } =
-  createFeesService(enhancedClient$)
+const { reloadFees, fees$, poolInTxFees$, approveFee$, reloadApproveFee } = createFeesService(enhancedClient$)
 
 export {
   client$,
@@ -48,7 +47,6 @@ export {
   fees$,
   sendPoolTx$,
   poolInTxFees$,
-  poolOutTxFee$,
   approveFee$,
   reloadApproveFee,
   approveERC20Token$,

--- a/src/renderer/services/avax/fees.ts
+++ b/src/renderer/services/avax/fees.ts
@@ -85,13 +85,25 @@ export const createFeesService = (client$: Client$): FeesService => {
           O.fold(
             () => Rx.of(RD.initial),
             (client): FeesLD => {
-              // Get gas limit estimation
-              const gasLimit$ = client.estimateGasLimit({
-                asset: params.asset as CompatibleAsset,
-                amount: params.amount,
-                recipient: params.recipient,
-                memo: params.memo
-              })
+              // Get gas limit estimation with fallback for standalone Ledger or flaky RPCs
+              const gasLimit$ = Rx.from(
+                client.estimateGasLimit({
+                  asset: params.asset as CompatibleAsset,
+                  amount: params.amount,
+                  recipient: params.recipient,
+                  memo: params.memo
+                })
+              ).pipe(
+                RxOp.catchError((error) => {
+                  console.error('Gas limit estimation failed, using fallback:', error)
+                  // Use same fallback logic as in estimateAndCalculateFees
+                  const fallbackGasLimit =
+                    params.asset && isAvaxAsset(params.asset as Asset)
+                      ? new BigNumber(ETH_OUT_TX_GAS_LIMIT) // AVAX native transfer
+                      : new BigNumber(ERC20_OUT_TX_GAS_LIMIT) // ERC20 token transfer
+                  return Rx.of(fallbackGasLimit)
+                })
+              )
 
               // Get gas prices - try THORNode first, fallback to client
               const gasPrices$: Rx.Observable<RD.RemoteData<Error, GasPrices>> = FP.pipe(

--- a/src/renderer/services/avax/fees.ts
+++ b/src/renderer/services/avax/fees.ts
@@ -1,7 +1,7 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { AVAX_GAS_ASSET_DECIMAL } from '@xchainjs/xchain-avax'
-import { Fees, FeeType, Protocol } from '@xchainjs/xchain-client'
-import { getFee, GasPrices, Client } from '@xchainjs/xchain-evm'
+import { Fees, FeeType } from '@xchainjs/xchain-client'
+import { getFee, GasPrices, Client, CompatibleAsset } from '@xchainjs/xchain-evm'
 import { Asset, baseAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import { function as FP, option as O } from 'fp-ts'
@@ -10,6 +10,7 @@ import * as RxOp from 'rxjs/operators'
 
 import { isAvaxAsset } from '../../helpers/assetHelper'
 import { observableState } from '../../helpers/stateHelper'
+import { getChainGasPrices$ } from '../chain/fees/nodeapi'
 import type { FeeLD } from '../chain/types'
 import type { FeesLD } from '../clients'
 import { ERC20_OUT_TX_GAS_LIMIT, ETH_OUT_TX_GAS_LIMIT, EVMZeroAddress } from '../evm/const'
@@ -39,7 +40,7 @@ export const createFeesService = (client$: Client$): FeesService => {
 
   async function estimateAndCalculateFees(client: Client, params: TxParams) {
     // Estimate gas prices
-    const gasPrices = await client.estimateGasPrices(Protocol.THORCHAIN)
+    const gasPrices = await client.estimateGasPrices()
     const { fast: fastGP, fastest: fastestGP, average: averageGP } = gasPrices
 
     // Estimate gas limit - with fallback for standalone ledger mode
@@ -76,37 +77,7 @@ export const createFeesService = (client$: Client$): FeesService => {
   /**
    * Fees for sending txs into pool on Avax
    **/
-  const poolInTxFees$ = ({ address, abi, func, params }: PoolInTxFeeParams): FeesLD =>
-    client$.pipe(
-      RxOp.switchMap((oClient) =>
-        FP.pipe(
-          oClient,
-          O.fold(
-            () => Rx.of(RD.initial),
-            (client): FeesLD =>
-              Rx.combineLatest([
-                client.estimateCall({ contractAddress: address, abi, funcName: func, funcParams: params }),
-                client.estimateGasPrices()
-              ]).pipe(
-                RxOp.map<[BigNumber, GasPrices], Fees>(([gasLimit, gasPrices]) => ({
-                  type: FeeType.PerByte,
-                  average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: AVAX_GAS_ASSET_DECIMAL }),
-                  fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: AVAX_GAS_ASSET_DECIMAL }),
-                  fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: AVAX_GAS_ASSET_DECIMAL })
-                })),
-                RxOp.map(RD.success),
-                RxOp.catchError((error) => Rx.of(RD.failure(error))),
-                RxOp.startWith(RD.pending)
-              )
-          )
-        )
-      )
-    )
-
-  /**
-   * Fees for sending txs out of a pool on Avax
-   **/
-  const poolOutTxFee$ = (asset: Asset): FeesLD =>
+  const poolInTxFees$ = (params: PoolInTxFeeParams): FeesLD =>
     client$.pipe(
       RxOp.switchMap((oClient) =>
         FP.pipe(
@@ -114,16 +85,53 @@ export const createFeesService = (client$: Client$): FeesService => {
           O.fold(
             () => Rx.of(RD.initial),
             (client): FeesLD => {
-              const gasLimit = isAvaxAsset(asset) ? ETH_OUT_TX_GAS_LIMIT : ERC20_OUT_TX_GAS_LIMIT
-              return Rx.from(client.estimateGasPrices()).pipe(
-                RxOp.map<GasPrices, Fees>((gasPrices) => ({
-                  type: FeeType.PerByte,
-                  average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: AVAX_GAS_ASSET_DECIMAL }),
-                  fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: AVAX_GAS_ASSET_DECIMAL }),
-                  fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: AVAX_GAS_ASSET_DECIMAL })
-                })),
-                RxOp.map(RD.success),
-                RxOp.catchError((error) => Rx.of(RD.failure(error))),
+              // Get gas limit estimation
+              const gasLimit$ = client.estimateGasLimit({
+                asset: params.asset as CompatibleAsset,
+                amount: params.amount,
+                recipient: params.recipient,
+                memo: params.memo
+              })
+
+              // Get gas prices - try THORNode first, fallback to client
+              const gasPrices$: Rx.Observable<RD.RemoteData<Error, GasPrices>> = FP.pipe(
+                getChainGasPrices$('AVAX', AVAX_GAS_ASSET_DECIMAL),
+                RxOp.map((rd) =>
+                  RD.isFailure(rd) ? RD.failure(new Error(String(rd.error))) : (rd as RD.RemoteData<Error, GasPrices>)
+                ),
+                RxOp.catchError(() =>
+                  // Fallback to client estimation if nodeapi fails
+                  Rx.from(client.estimateGasPrices()).pipe(
+                    RxOp.map(RD.success),
+                    RxOp.catchError((error) => Rx.of(RD.failure(new Error(String(error)))))
+                  )
+                )
+              )
+
+              return Rx.combineLatest([gasLimit$, gasPrices$]).pipe(
+                RxOp.switchMap(([gasLimit, gasPricesRD]) =>
+                  FP.pipe(
+                    gasPricesRD,
+                    RD.fold<Error, GasPrices, FeesLD>(
+                      () => Rx.of(RD.initial),
+                      () => Rx.of(RD.pending),
+                      (error) => Rx.of(RD.failure(error)),
+                      (gasPrices) =>
+                        Rx.of(
+                          RD.success({
+                            type: FeeType.PerByte,
+                            average: getFee({
+                              gasPrice: gasPrices.average,
+                              gasLimit,
+                              decimals: AVAX_GAS_ASSET_DECIMAL
+                            }),
+                            fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: AVAX_GAS_ASSET_DECIMAL }),
+                            fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: AVAX_GAS_ASSET_DECIMAL })
+                          })
+                        )
+                    )
+                  )
+                ),
                 RxOp.startWith(RD.pending)
               )
             }
@@ -180,7 +188,6 @@ export const createFeesService = (client$: Client$): FeesService => {
     fees$,
     reloadFees,
     poolInTxFees$,
-    poolOutTxFee$,
     approveFee$,
     reloadApproveFee
   }

--- a/src/renderer/services/avax/index.ts
+++ b/src/renderer/services/avax/index.ts
@@ -23,8 +23,7 @@ const {
   approveERC20Token$,
   isApprovedERC20Token$
 } = createTransactionService(client$, network$)
-const { reloadFees, fees$, poolInTxFees$, poolOutTxFee$, approveFee$, reloadApproveFee } =
-  createFeesService(enhancedClient$)
+const { reloadFees, fees$, poolInTxFees$, approveFee$, reloadApproveFee } = createFeesService(enhancedClient$)
 
 export {
   client$,
@@ -48,7 +47,6 @@ export {
   fees$,
   sendPoolTx$,
   poolInTxFees$,
-  poolOutTxFee$,
   approveFee$,
   reloadApproveFee,
   approveERC20Token$,

--- a/src/renderer/services/base/fees.ts
+++ b/src/renderer/services/base/fees.ts
@@ -1,6 +1,6 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { BASE_GAS_ASSET_DECIMAL } from '@xchainjs/xchain-base'
-import { Fees, FeeType, Protocol } from '@xchainjs/xchain-client'
+import { Fees, FeeType } from '@xchainjs/xchain-client'
 import { getFee, GasPrices, Client } from '@xchainjs/xchain-evm'
 import { Asset, baseAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
@@ -10,6 +10,7 @@ import * as RxOp from 'rxjs/operators'
 
 import { isBASEAsset } from '../../helpers/assetHelper'
 import { observableState } from '../../helpers/stateHelper'
+import { getChainGasPrices$ } from '../chain/fees/nodeapi'
 import type { FeeLD } from '../chain/types'
 import type { FeesLD } from '../clients'
 import { ERC20_OUT_TX_GAS_LIMIT, ETH_OUT_TX_GAS_LIMIT, EVMZeroAddress } from '../evm/const'
@@ -39,7 +40,7 @@ export const createFeesService = (client$: Client$): FeesService => {
 
   async function estimateAndCalculateFees(client: Client, params: TxParams) {
     // Estimate gas prices
-    const gasPrices = await client.estimateGasPrices(Protocol.THORCHAIN)
+    const gasPrices = await client.estimateGasPrices()
     const { fast: fastGP, fastest: fastestGP, average: averageGP } = gasPrices
 
     // Estimate gas limit - with fallback for standalone ledger mode
@@ -76,37 +77,7 @@ export const createFeesService = (client$: Client$): FeesService => {
   /**
    * Fees for sending txs into pool on BASE
    **/
-  const poolInTxFees$ = ({ address, abi, func, params }: PoolInTxFeeParams): FeesLD =>
-    client$.pipe(
-      RxOp.switchMap((oClient) =>
-        FP.pipe(
-          oClient,
-          O.fold(
-            () => Rx.of(RD.initial),
-            (client): FeesLD =>
-              Rx.combineLatest([
-                client.estimateCall({ contractAddress: address, abi, funcName: func, funcParams: params }),
-                client.estimateGasPrices()
-              ]).pipe(
-                RxOp.map<[BigNumber, GasPrices], Fees>(([gasLimit, gasPrices]) => ({
-                  type: FeeType.PerByte,
-                  average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: BASE_GAS_ASSET_DECIMAL }),
-                  fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: BASE_GAS_ASSET_DECIMAL }),
-                  fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: BASE_GAS_ASSET_DECIMAL })
-                })),
-                RxOp.map(RD.success),
-                RxOp.catchError((error) => Rx.of(RD.failure(error))),
-                RxOp.startWith(RD.pending)
-              )
-          )
-        )
-      )
-    )
-
-  /**
-   * Fees for sending txs out of a pool on BASE
-   **/
-  const poolOutTxFee$ = (asset: Asset): FeesLD =>
+  const poolInTxFees$ = (params: PoolInTxFeeParams): FeesLD =>
     client$.pipe(
       RxOp.switchMap((oClient) =>
         FP.pipe(
@@ -114,16 +85,53 @@ export const createFeesService = (client$: Client$): FeesService => {
           O.fold(
             () => Rx.of(RD.initial),
             (client): FeesLD => {
-              const gasLimit = isBASEAsset(asset) ? ETH_OUT_TX_GAS_LIMIT : ERC20_OUT_TX_GAS_LIMIT
-              return Rx.from(client.estimateGasPrices()).pipe(
-                RxOp.map<GasPrices, Fees>((gasPrices) => ({
-                  type: FeeType.PerByte,
-                  average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: BASE_GAS_ASSET_DECIMAL }),
-                  fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: BASE_GAS_ASSET_DECIMAL }),
-                  fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: BASE_GAS_ASSET_DECIMAL })
-                })),
-                RxOp.map(RD.success),
-                RxOp.catchError((error) => Rx.of(RD.failure(error))),
+              // Get gas limit estimation
+              const gasLimit$ = client.estimateGasLimit({
+                asset: params.asset as Asset,
+                amount: params.amount,
+                recipient: params.recipient,
+                memo: params.memo
+              })
+
+              // Get gas prices - try THORNode first, fallback to client
+              const gasPrices$: Rx.Observable<RD.RemoteData<Error, GasPrices>> = FP.pipe(
+                getChainGasPrices$('BASE', BASE_GAS_ASSET_DECIMAL),
+                RxOp.map((rd) =>
+                  RD.isFailure(rd) ? RD.failure(new Error(String(rd.error))) : (rd as RD.RemoteData<Error, GasPrices>)
+                ),
+                RxOp.catchError(() =>
+                  // Fallback to client estimation if nodeapi fails
+                  Rx.from(client.estimateGasPrices()).pipe(
+                    RxOp.map(RD.success),
+                    RxOp.catchError((error) => Rx.of(RD.failure(new Error(String(error)))))
+                  )
+                )
+              )
+
+              return Rx.combineLatest([gasLimit$, gasPrices$]).pipe(
+                RxOp.switchMap(([gasLimit, gasPricesRD]) =>
+                  FP.pipe(
+                    gasPricesRD,
+                    RD.fold<Error, GasPrices, FeesLD>(
+                      () => Rx.of(RD.initial),
+                      () => Rx.of(RD.pending),
+                      (error) => Rx.of(RD.failure(error)),
+                      (gasPrices) =>
+                        Rx.of(
+                          RD.success({
+                            type: FeeType.PerByte,
+                            average: getFee({
+                              gasPrice: gasPrices.average,
+                              gasLimit,
+                              decimals: BASE_GAS_ASSET_DECIMAL
+                            }),
+                            fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: BASE_GAS_ASSET_DECIMAL }),
+                            fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: BASE_GAS_ASSET_DECIMAL })
+                          })
+                        )
+                    )
+                  )
+                ),
                 RxOp.startWith(RD.pending)
               )
             }
@@ -180,7 +188,6 @@ export const createFeesService = (client$: Client$): FeesService => {
     fees$,
     reloadFees,
     poolInTxFees$,
-    poolOutTxFee$,
     approveFee$,
     reloadApproveFee
   }

--- a/src/renderer/services/base/fees.ts
+++ b/src/renderer/services/base/fees.ts
@@ -85,13 +85,25 @@ export const createFeesService = (client$: Client$): FeesService => {
           O.fold(
             () => Rx.of(RD.initial),
             (client): FeesLD => {
-              // Get gas limit estimation
-              const gasLimit$ = client.estimateGasLimit({
-                asset: params.asset as Asset,
-                amount: params.amount,
-                recipient: params.recipient,
-                memo: params.memo
-              })
+              // Get gas limit estimation with fallback for standalone Ledger or flaky RPCs
+              const gasLimit$ = Rx.from(
+                client.estimateGasLimit({
+                  asset: params.asset as Asset,
+                  amount: params.amount,
+                  recipient: params.recipient,
+                  memo: params.memo
+                })
+              ).pipe(
+                RxOp.catchError((error) => {
+                  console.error('Gas limit estimation failed, using fallback:', error)
+                  // Use same fallback logic as in estimateAndCalculateFees
+                  const fallbackGasLimit =
+                    params.asset && isBASEAsset(params.asset as Asset)
+                      ? new BigNumber(ETH_OUT_TX_GAS_LIMIT) // BASE native transfer
+                      : new BigNumber(ERC20_OUT_TX_GAS_LIMIT) // ERC20 token transfer
+                  return Rx.of(fallbackGasLimit)
+                })
+              )
 
               // Get gas prices - try THORNode first, fallback to client
               const gasPrices$: Rx.Observable<RD.RemoteData<Error, GasPrices>> = FP.pipe(

--- a/src/renderer/services/base/index.ts
+++ b/src/renderer/services/base/index.ts
@@ -23,8 +23,7 @@ const {
   approveERC20Token$,
   isApprovedERC20Token$
 } = createTransactionService(client$, network$)
-const { reloadFees, fees$, poolInTxFees$, poolOutTxFee$, approveFee$, reloadApproveFee } =
-  createFeesService(enhancedClient$)
+const { reloadFees, fees$, poolInTxFees$, approveFee$, reloadApproveFee } = createFeesService(enhancedClient$)
 
 export {
   client$,
@@ -48,7 +47,6 @@ export {
   fees$,
   sendPoolTx$,
   poolInTxFees$,
-  poolOutTxFee$,
   approveFee$,
   reloadApproveFee,
   approveERC20Token$,

--- a/src/renderer/services/base/transaction.ts
+++ b/src/renderer/services/base/transaction.ts
@@ -95,7 +95,7 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
                       recipient: router,
                       gasPrice: gasPrices[params.feeOption],
                       isMemoEncoded: true,
-                      gasLimit: new BigNumber(160000)
+                      gasLimit: new BigNumber(200000)
                     })
                   )
                 )

--- a/src/renderer/services/bsc/fees.ts
+++ b/src/renderer/services/bsc/fees.ts
@@ -85,13 +85,25 @@ export const createFeesService = (client$: Client$): FeesService => {
           O.fold(
             () => Rx.of(RD.initial),
             (client): FeesLD => {
-              // Get gas limit estimation
-              const gasLimit$ = client.estimateGasLimit({
-                asset: params.asset as CompatibleAsset,
-                amount: params.amount,
-                recipient: params.recipient,
-                memo: params.memo
-              })
+              // Get gas limit estimation with fallback for standalone Ledger or flaky RPCs
+              const gasLimit$ = Rx.from(
+                client.estimateGasLimit({
+                  asset: params.asset as CompatibleAsset,
+                  amount: params.amount,
+                  recipient: params.recipient,
+                  memo: params.memo
+                })
+              ).pipe(
+                RxOp.catchError((error) => {
+                  console.error('Gas limit estimation failed, using fallback:', error)
+                  // Use same fallback logic as in estimateAndCalculateFees
+                  const fallbackGasLimit =
+                    params.asset && isBscAsset(params.asset as Asset)
+                      ? new BigNumber(ETH_OUT_TX_GAS_LIMIT) // BNB native transfer
+                      : new BigNumber(ERC20_OUT_TX_GAS_LIMIT) // BEP20 token transfer
+                  return Rx.of(fallbackGasLimit)
+                })
+              )
 
               // Get gas prices - try THORNode first, fallback to client
               const gasPrices$: Rx.Observable<RD.RemoteData<Error, GasPrices>> = FP.pipe(

--- a/src/renderer/services/bsc/fees.ts
+++ b/src/renderer/services/bsc/fees.ts
@@ -1,7 +1,7 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { BSC_GAS_ASSET_DECIMAL } from '@xchainjs/xchain-bsc'
-import { Fees, FeeType, Protocol } from '@xchainjs/xchain-client'
-import { getFee, GasPrices, Client } from '@xchainjs/xchain-evm'
+import { Fees, FeeType } from '@xchainjs/xchain-client'
+import { getFee, GasPrices, Client, CompatibleAsset } from '@xchainjs/xchain-evm'
 import { Asset, baseAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import { function as FP, option as O } from 'fp-ts'
@@ -10,6 +10,7 @@ import * as RxOp from 'rxjs/operators'
 
 import { isBscAsset } from '../../helpers/assetHelper'
 import { observableState } from '../../helpers/stateHelper'
+import { getChainGasPrices$ } from '../chain/fees/nodeapi'
 import type { FeeLD } from '../chain/types'
 import type { FeesLD } from '../clients'
 import { ERC20_OUT_TX_GAS_LIMIT, ETH_OUT_TX_GAS_LIMIT, EVMZeroAddress } from '../evm/const'
@@ -39,7 +40,7 @@ export const createFeesService = (client$: Client$): FeesService => {
 
   async function estimateAndCalculateFees(client: Client, params: TxParams) {
     // Estimate gas prices
-    const gasPrices = await client.estimateGasPrices(Protocol.THORCHAIN)
+    const gasPrices = await client.estimateGasPrices()
     const { fast: fastGP, fastest: fastestGP, average: averageGP } = gasPrices
 
     // Estimate gas limit - with fallback for standalone ledger mode
@@ -76,37 +77,7 @@ export const createFeesService = (client$: Client$): FeesService => {
   /**
    * Fees for sending txs into pool on Bsc
    **/
-  const poolInTxFees$ = ({ address, abi, func, params }: PoolInTxFeeParams): FeesLD =>
-    client$.pipe(
-      RxOp.switchMap((oClient) =>
-        FP.pipe(
-          oClient,
-          O.fold(
-            () => Rx.of(RD.initial),
-            (client): FeesLD =>
-              Rx.combineLatest([
-                client.estimateCall({ contractAddress: address, abi, funcName: func, funcParams: params }),
-                client.estimateGasPrices()
-              ]).pipe(
-                RxOp.map<[BigNumber, GasPrices], Fees>(([gasLimit, gasPrices]) => ({
-                  type: FeeType.PerByte,
-                  average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: BSC_GAS_ASSET_DECIMAL }),
-                  fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: BSC_GAS_ASSET_DECIMAL }),
-                  fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: BSC_GAS_ASSET_DECIMAL })
-                })),
-                RxOp.map(RD.success),
-                RxOp.catchError((error) => Rx.of(RD.failure(error))),
-                RxOp.startWith(RD.pending)
-              )
-          )
-        )
-      )
-    )
-
-  /**
-   * Fees for sending txs out of a pool on Bsc
-   **/
-  const poolOutTxFee$ = (asset: Asset): FeesLD =>
+  const poolInTxFees$ = (params: PoolInTxFeeParams): FeesLD =>
     client$.pipe(
       RxOp.switchMap((oClient) =>
         FP.pipe(
@@ -114,16 +85,49 @@ export const createFeesService = (client$: Client$): FeesService => {
           O.fold(
             () => Rx.of(RD.initial),
             (client): FeesLD => {
-              const gasLimit = isBscAsset(asset) ? ETH_OUT_TX_GAS_LIMIT : ERC20_OUT_TX_GAS_LIMIT
-              return Rx.from(client.estimateGasPrices()).pipe(
-                RxOp.map<GasPrices, Fees>((gasPrices) => ({
-                  type: FeeType.PerByte,
-                  average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: BSC_GAS_ASSET_DECIMAL }),
-                  fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: BSC_GAS_ASSET_DECIMAL }),
-                  fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: BSC_GAS_ASSET_DECIMAL })
-                })),
-                RxOp.map(RD.success),
-                RxOp.catchError((error) => Rx.of(RD.failure(error))),
+              // Get gas limit estimation
+              const gasLimit$ = client.estimateGasLimit({
+                asset: params.asset as CompatibleAsset,
+                amount: params.amount,
+                recipient: params.recipient,
+                memo: params.memo
+              })
+
+              // Get gas prices - try THORNode first, fallback to client
+              const gasPrices$: Rx.Observable<RD.RemoteData<Error, GasPrices>> = FP.pipe(
+                getChainGasPrices$('BSC', BSC_GAS_ASSET_DECIMAL),
+                RxOp.map((rd) =>
+                  RD.isFailure(rd) ? RD.failure(new Error(String(rd.error))) : (rd as RD.RemoteData<Error, GasPrices>)
+                ),
+                RxOp.catchError(() =>
+                  // Fallback to client estimation if nodeapi fails
+                  Rx.from(client.estimateGasPrices()).pipe(
+                    RxOp.map(RD.success),
+                    RxOp.catchError((error) => Rx.of(RD.failure(new Error(String(error)))))
+                  )
+                )
+              )
+
+              return Rx.combineLatest([gasLimit$, gasPrices$]).pipe(
+                RxOp.switchMap(([gasLimit, gasPricesRD]) =>
+                  FP.pipe(
+                    gasPricesRD,
+                    RD.fold<Error, GasPrices, FeesLD>(
+                      () => Rx.of(RD.initial),
+                      () => Rx.of(RD.pending),
+                      (error) => Rx.of(RD.failure(error)),
+                      (gasPrices) =>
+                        Rx.of(
+                          RD.success({
+                            type: FeeType.PerByte,
+                            average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: BSC_GAS_ASSET_DECIMAL }),
+                            fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: BSC_GAS_ASSET_DECIMAL }),
+                            fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: BSC_GAS_ASSET_DECIMAL })
+                          })
+                        )
+                    )
+                  )
+                ),
                 RxOp.startWith(RD.pending)
               )
             }
@@ -180,7 +184,6 @@ export const createFeesService = (client$: Client$): FeesService => {
     fees$,
     reloadFees,
     poolInTxFees$,
-    poolOutTxFee$,
     approveFee$,
     reloadApproveFee
   }

--- a/src/renderer/services/bsc/index.ts
+++ b/src/renderer/services/bsc/index.ts
@@ -23,8 +23,7 @@ const {
   approveERC20Token$,
   isApprovedERC20Token$
 } = createTransactionService(client$, network$)
-const { reloadFees, fees$, poolInTxFees$, poolOutTxFee$, approveFee$, reloadApproveFee } =
-  createFeesService(enhancedClient$)
+const { reloadFees, fees$, poolInTxFees$, approveFee$, reloadApproveFee } = createFeesService(enhancedClient$)
 
 export {
   client$,
@@ -48,7 +47,6 @@ export {
   fees$,
   sendPoolTx$,
   poolInTxFees$,
-  poolOutTxFee$,
   approveFee$,
   reloadApproveFee,
   approveERC20Token$,

--- a/src/renderer/services/chain/fees/common.ts
+++ b/src/renderer/services/chain/fees/common.ts
@@ -36,6 +36,7 @@ import * as RxOp from 'rxjs/operators'
 import { AssetRuneNative } from '../../../../shared/utils/asset'
 import { isChainOfThor } from '../../../../shared/utils/chain'
 import { isCacaoAsset, isRujiAsset, isRuneNativeAsset } from '../../../helpers/assetHelper'
+import { getChainAsset } from '../../../helpers/chainHelper'
 import { liveData } from '../../../helpers/rx/liveData'
 import * as ARB from '../../arb'
 import * as AVAX from '../../avax'
@@ -81,14 +82,14 @@ const {
 /**
  * Helper to get address address for a chain from inbound addresses
  */
-const getInboundAddress = (
+const getRouterAddress = (
   inboundAddresses: (ThorInboundAddress | MayaInboundAddress)[],
   chain: Chain
 ): O.Option<Address> => {
   return FP.pipe(
     inboundAddresses,
     A.findFirst((item) => item.chain === chain),
-    O.chain((item) => O.fromNullable(item.address))
+    O.chain((item) => O.fromNullable(item.router))
   )
 }
 
@@ -134,7 +135,11 @@ export const poolOutboundFee$ = (asset: AnyAsset): PoolFeeLD => {
       RxOp.catchError(() => {
         // Fallback to midgard if nodeapi or getDecimal fails
         const outboundFee = isChainOfThor(chain) ? outboundAssetFeeByChain$(chain) : outboundAssetFeeByChainMaya$(chain)
-        return outboundFee
+        // Ensure the returned fee uses the correct asset (the one we requested)
+        return FP.pipe(
+          outboundFee,
+          liveData.map((fee) => ({ amount: fee.amount, asset: getChainAsset(asset.chain) }))
+        )
       }),
       RxOp.startWith(RD.pending)
     )
@@ -210,7 +215,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
         RxOp.switchMap(([decimal, inboundAddressesRD]) =>
           RD.isSuccess(inboundAddressesRD)
             ? FP.pipe(
-                getInboundAddress(inboundAddressesRD.value, ETHChain),
+                getRouterAddress(inboundAddressesRD.value, ETHChain),
                 O.fold(
                   // Fallback to zero address if address not found
                   () =>
@@ -221,7 +226,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                         recipient: '0x0000000000000000000000000000000000000000',
                         memo
                       }),
-                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                      liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
                     ),
                   // Use actual address address for better estimation
                   (address) =>
@@ -232,7 +237,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                         recipient: address,
                         memo
                       }),
-                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                      liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
                     )
                 )
               )
@@ -244,7 +249,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                   recipient: '0x0000000000000000000000000000000000000000',
                   memo
                 }),
-                liveData.map((fees) => ({ asset, amount: fees.fast }))
+                liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
               )
         ),
         RxOp.catchError((error) => Rx.of(RD.failure(error))),
@@ -257,7 +262,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
         RxOp.switchMap(([decimal, inboundAddressesRD]) =>
           RD.isSuccess(inboundAddressesRD)
             ? FP.pipe(
-                getInboundAddress(inboundAddressesRD.value, ARBChain),
+                getRouterAddress(inboundAddressesRD.value, ARBChain),
                 O.fold(
                   // Fallback to zero address if address not found
                   () =>
@@ -268,7 +273,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                         recipient: '0x0000000000000000000000000000000000000000',
                         memo
                       }),
-                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                      liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
                     ),
                   // Use actual address address for better estimation
                   (address) =>
@@ -279,7 +284,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                         recipient: address,
                         memo
                       }),
-                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                      liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
                     )
                 )
               )
@@ -291,7 +296,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                   recipient: '0x0000000000000000000000000000000000000000',
                   memo
                 }),
-                liveData.map((fees) => ({ asset, amount: fees.fast }))
+                liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
               )
         ),
         RxOp.catchError((error) => Rx.of(RD.failure(error))),
@@ -304,7 +309,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
         RxOp.switchMap(([decimal, inboundAddressesRD]) =>
           RD.isSuccess(inboundAddressesRD)
             ? FP.pipe(
-                getInboundAddress(inboundAddressesRD.value, BASEChain),
+                getRouterAddress(inboundAddressesRD.value, BASEChain),
                 O.fold(
                   // Fallback to zero address if not found
                   () =>
@@ -315,7 +320,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                         recipient: '0x0000000000000000000000000000000000000000',
                         memo
                       }),
-                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                      liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
                     ),
                   // Use actual address address for better estimation
                   (address) =>
@@ -326,7 +331,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                         recipient: address,
                         memo
                       }),
-                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                      liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
                     )
                 )
               )
@@ -338,7 +343,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                   recipient: '0x0000000000000000000000000000000000000000',
                   memo
                 }),
-                liveData.map((fees) => ({ asset, amount: fees.fast }))
+                liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
               )
         ),
         RxOp.catchError((error) => Rx.of(RD.failure(error))),
@@ -351,7 +356,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
         RxOp.switchMap(([decimal, inboundAddressesRD]) =>
           RD.isSuccess(inboundAddressesRD)
             ? FP.pipe(
-                getInboundAddress(inboundAddressesRD.value, AVAXChain),
+                getRouterAddress(inboundAddressesRD.value, AVAXChain),
                 O.fold(
                   // Fallback to zero address if address not found
                   () =>
@@ -362,7 +367,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                         recipient: '0x0000000000000000000000000000000000000000',
                         memo
                       }),
-                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                      liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
                     ),
                   // Use actual address address for better estimation
                   (address) =>
@@ -373,7 +378,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                         recipient: address,
                         memo
                       }),
-                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                      liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
                     )
                 )
               )
@@ -385,7 +390,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                   recipient: '0x0000000000000000000000000000000000000000',
                   memo
                 }),
-                liveData.map((fees) => ({ asset, amount: fees.fast }))
+                liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
               )
         ),
         RxOp.catchError((error) => Rx.of(RD.failure(error))),
@@ -398,7 +403,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
         RxOp.switchMap(([decimal, inboundAddressesRD]) =>
           RD.isSuccess(inboundAddressesRD)
             ? FP.pipe(
-                getInboundAddress(inboundAddressesRD.value, BSCChain),
+                getRouterAddress(inboundAddressesRD.value, BSCChain),
                 O.fold(
                   // Fallback to zero address if address not found
                   () =>
@@ -409,7 +414,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                         recipient: '0x0000000000000000000000000000000000000000',
                         memo
                       }),
-                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                      liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
                     ),
                   // Use actual address address for better estimation
                   (address) =>
@@ -420,7 +425,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                         recipient: address,
                         memo
                       }),
-                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                      liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
                     )
                 )
               )
@@ -432,7 +437,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                   recipient: '0x0000000000000000000000000000000000000000',
                   memo
                 }),
-                liveData.map((fees) => ({ asset, amount: fees.fast }))
+                liveData.map((fees) => ({ asset: getChainAsset(asset.chain), amount: fees.fast }))
               )
         ),
         RxOp.catchError((error) => Rx.of(RD.failure(error))),

--- a/src/renderer/services/chain/fees/common.ts
+++ b/src/renderer/services/chain/fees/common.ts
@@ -29,7 +29,7 @@ import {
   isSynthAsset
 } from '@xchainjs/xchain-util'
 import { ZECChain } from '@xchainjs/xchain-zcash'
-import { function as FP, option as O } from 'fp-ts'
+import { function as FP, option as O, array as A } from 'fp-ts'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
@@ -52,6 +52,8 @@ import * as ETH from '../../ethereum'
 import * as KUJI from '../../kuji'
 import * as LTC from '../../litecoin'
 import * as MAYA from '../../mayachain'
+import { inboundAddressesShared$ as mayaInboundAddresses$ } from '../../mayachain'
+import { InboundAddress as MayaInboundAddress } from '../../mayachain/types'
 import { service as midgardMayaService } from '../../midgard/mayaMigard/service'
 import { service as midgardService } from '../../midgard/thorMidgard/service'
 import * as XRD from '../../radix'
@@ -59,9 +61,13 @@ import * as XRP from '../../ripple'
 import * as SOL from '../../solana'
 import { ZERO_ADDRESS } from '../../solana/fees'
 import * as THOR from '../../thorchain'
+import { inboundAddressesShared$ as thorInboundAddresses$ } from '../../thorchain'
+import { InboundAddress as ThorInboundAddress } from '../../thorchain/types'
 import { FeesWithRatesLD } from '../../utxo/types'
 import * as ZEC from '../../zcash'
+import { getDecimal } from '../decimal'
 import { PoolFeeLD } from '../types'
+import { getChainOutboundFee$, getChainNodeProtocol, NodeProtocol } from './nodeapi'
 
 const {
   pools: { outboundAssetFeeByChain$ }
@@ -69,6 +75,30 @@ const {
 const {
   pools: { outboundAssetFeeByChain$: outboundAssetFeeByChainMaya$ }
 } = midgardMayaService
+
+// Import inbound addresses observables
+
+/**
+ * Helper to get address address for a chain from inbound addresses
+ */
+const getInboundAddress = (
+  inboundAddresses: (ThorInboundAddress | MayaInboundAddress)[],
+  chain: Chain
+): O.Option<Address> => {
+  return FP.pipe(
+    inboundAddresses,
+    A.findFirst((item) => item.chain === chain),
+    O.chain((item) => O.fromNullable(item.address))
+  )
+}
+
+/**
+ * Get inbound addresses observable based on chain protocol
+ */
+const getInboundAddresses$ = (chain: Chain) => {
+  const protocol = getChainNodeProtocol(chain)
+  return protocol === NodeProtocol.THORCHAIN ? thorInboundAddresses$ : mayaInboundAddresses$
+}
 
 /**
  * Fees for pool outbound txs (swap/deposit/withdraw/earn) tobefixed
@@ -92,8 +122,22 @@ export const poolOutboundFee$ = (asset: AnyAsset): PoolFeeLD => {
     )
   } else {
     const { chain } = asset
-    const outboundFee = isChainOfThor(chain) ? outboundAssetFeeByChain$(chain) : outboundAssetFeeByChainMaya$(chain)
-    return outboundFee
+    // First try to get authoritative fee from THORNode/MAYANode
+    return FP.pipe(
+      Rx.from(getDecimal(asset)),
+      RxOp.switchMap((decimal) =>
+        FP.pipe(
+          getChainOutboundFee$(chain, decimal),
+          liveData.map((amount) => ({ amount, asset }))
+        )
+      ),
+      RxOp.catchError(() => {
+        // Fallback to midgard if nodeapi or getDecimal fails
+        const outboundFee = isChainOfThor(chain) ? outboundAssetFeeByChain$(chain) : outboundAssetFeeByChainMaya$(chain)
+        return outboundFee
+      }),
+      RxOp.startWith(RD.pending)
+    )
   }
 }
 /**
@@ -160,89 +204,239 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
         liveData.map((fees) => ({ asset, amount: fees.fast }))
       )
     case ETHChain:
+      // Use poolInTxFees$ with actual address address for accurate gas estimation
       return FP.pipe(
-        ETH.address$.pipe(
-          RxOp.switchMap(
-            O.fold(
-              () => Rx.of(RD.failure(new Error('No address available'))),
-              (address) =>
-                FP.pipe(
-                  ETH.fees$({ amount: baseAmount(1), recipient: address.address }),
-                  liveData.map((fees) => ({ asset, amount: fees.fast }))
+        Rx.combineLatest([Rx.from(getDecimal(asset)), getInboundAddresses$(ETHChain)]),
+        RxOp.switchMap(([decimal, inboundAddressesRD]) =>
+          RD.isSuccess(inboundAddressesRD)
+            ? FP.pipe(
+                getInboundAddress(inboundAddressesRD.value, ETHChain),
+                O.fold(
+                  // Fallback to zero address if address not found
+                  () =>
+                    FP.pipe(
+                      ETH.poolInTxFees$({
+                        asset,
+                        amount: baseAmount(1, decimal),
+                        recipient: '0x0000000000000000000000000000000000000000',
+                        memo
+                      }),
+                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                    ),
+                  // Use actual address address for better estimation
+                  (address) =>
+                    FP.pipe(
+                      ETH.poolInTxFees$({
+                        asset,
+                        amount: baseAmount(1, decimal),
+                        recipient: address,
+                        memo
+                      }),
+                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                    )
                 )
-            )
-          ),
-          RxOp.catchError((error) => Rx.of(RD.failure(error))),
-          RxOp.startWith(RD.pending)
-        )
+              )
+            : // If inbound addresses not loaded, use fallback
+              FP.pipe(
+                ETH.poolInTxFees$({
+                  asset,
+                  amount: baseAmount(1, decimal),
+                  recipient: '0x0000000000000000000000000000000000000000',
+                  memo
+                }),
+                liveData.map((fees) => ({ asset, amount: fees.fast }))
+              )
+        ),
+        RxOp.catchError((error) => Rx.of(RD.failure(error))),
+        RxOp.startWith(RD.pending)
       )
     case ARBChain:
+      // Use poolInTxFees$ with actual address address for accurate gas estimation
       return FP.pipe(
-        ARB.address$.pipe(
-          RxOp.switchMap(
-            O.fold(
-              () => Rx.of(RD.failure(new Error('No address available'))),
-              (address) =>
-                FP.pipe(
-                  ARB.fees$({ amount: baseAmount(1), recipient: address.address }),
-                  liveData.map((fees) => ({ asset, amount: fees.fast }))
+        Rx.combineLatest([Rx.from(getDecimal(asset)), getInboundAddresses$(ARBChain)]),
+        RxOp.switchMap(([decimal, inboundAddressesRD]) =>
+          RD.isSuccess(inboundAddressesRD)
+            ? FP.pipe(
+                getInboundAddress(inboundAddressesRD.value, ARBChain),
+                O.fold(
+                  // Fallback to zero address if address not found
+                  () =>
+                    FP.pipe(
+                      ARB.poolInTxFees$({
+                        asset,
+                        amount: baseAmount(1, decimal),
+                        recipient: '0x0000000000000000000000000000000000000000',
+                        memo
+                      }),
+                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                    ),
+                  // Use actual address address for better estimation
+                  (address) =>
+                    FP.pipe(
+                      ARB.poolInTxFees$({
+                        asset,
+                        amount: baseAmount(1, decimal),
+                        recipient: address,
+                        memo
+                      }),
+                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                    )
                 )
-            )
-          ),
-          RxOp.catchError((error) => Rx.of(RD.failure(error))),
-          RxOp.startWith(RD.pending)
-        )
+              )
+            : // If inbound addresses not loaded, use fallback
+              FP.pipe(
+                ARB.poolInTxFees$({
+                  asset,
+                  amount: baseAmount(1, decimal),
+                  recipient: '0x0000000000000000000000000000000000000000',
+                  memo
+                }),
+                liveData.map((fees) => ({ asset, amount: fees.fast }))
+              )
+        ),
+        RxOp.catchError((error) => Rx.of(RD.failure(error))),
+        RxOp.startWith(RD.pending)
       )
     case BASEChain:
+      // Use poolInTxFees$ with actual address for accurate gas estimation
       return FP.pipe(
-        BASE.address$.pipe(
-          RxOp.switchMap(
-            O.fold(
-              () => Rx.of(RD.failure(new Error('No address available'))),
-              (address) =>
-                FP.pipe(
-                  BASE.fees$({ amount: baseAmount(1), recipient: address.address }),
-                  liveData.map((fees) => ({ asset, amount: fees.fast }))
+        Rx.combineLatest([Rx.from(getDecimal(asset)), getInboundAddresses$(BASEChain)]),
+        RxOp.switchMap(([decimal, inboundAddressesRD]) =>
+          RD.isSuccess(inboundAddressesRD)
+            ? FP.pipe(
+                getInboundAddress(inboundAddressesRD.value, BASEChain),
+                O.fold(
+                  // Fallback to zero address if not found
+                  () =>
+                    FP.pipe(
+                      BASE.poolInTxFees$({
+                        asset,
+                        amount: baseAmount(1, decimal),
+                        recipient: '0x0000000000000000000000000000000000000000',
+                        memo
+                      }),
+                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                    ),
+                  // Use actual address address for better estimation
+                  (address) =>
+                    FP.pipe(
+                      BASE.poolInTxFees$({
+                        asset,
+                        amount: baseAmount(1, decimal),
+                        recipient: address,
+                        memo
+                      }),
+                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                    )
                 )
-            )
-          ),
-          RxOp.catchError((error) => Rx.of(RD.failure(error))),
-          RxOp.startWith(RD.pending)
-        )
+              )
+            : // If inbound addresses not loaded, use fallback
+              FP.pipe(
+                BASE.poolInTxFees$({
+                  asset,
+                  amount: baseAmount(1, decimal),
+                  recipient: '0x0000000000000000000000000000000000000000',
+                  memo
+                }),
+                liveData.map((fees) => ({ asset, amount: fees.fast }))
+              )
+        ),
+        RxOp.catchError((error) => Rx.of(RD.failure(error))),
+        RxOp.startWith(RD.pending)
       )
     case AVAXChain:
+      // Use poolInTxFees$ with actual address address for accurate gas estimation
       return FP.pipe(
-        AVAX.address$.pipe(
-          RxOp.switchMap(
-            O.fold(
-              () => Rx.of(RD.failure(new Error('No address available'))),
-              (address) =>
-                FP.pipe(
-                  AVAX.fees$({ amount: baseAmount(1), recipient: address.address }),
-                  liveData.map((fees) => ({ asset, amount: fees.fast }))
+        Rx.combineLatest([Rx.from(getDecimal(asset)), getInboundAddresses$(AVAXChain)]),
+        RxOp.switchMap(([decimal, inboundAddressesRD]) =>
+          RD.isSuccess(inboundAddressesRD)
+            ? FP.pipe(
+                getInboundAddress(inboundAddressesRD.value, AVAXChain),
+                O.fold(
+                  // Fallback to zero address if address not found
+                  () =>
+                    FP.pipe(
+                      AVAX.poolInTxFees$({
+                        asset,
+                        amount: baseAmount(1, decimal),
+                        recipient: '0x0000000000000000000000000000000000000000',
+                        memo
+                      }),
+                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                    ),
+                  // Use actual address address for better estimation
+                  (address) =>
+                    FP.pipe(
+                      AVAX.poolInTxFees$({
+                        asset,
+                        amount: baseAmount(1, decimal),
+                        recipient: address,
+                        memo
+                      }),
+                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                    )
                 )
-            )
-          ),
-          RxOp.catchError((error) => Rx.of(RD.failure(error))),
-          RxOp.startWith(RD.pending)
-        )
+              )
+            : // If inbound addresses not loaded, use fallback
+              FP.pipe(
+                AVAX.poolInTxFees$({
+                  asset,
+                  amount: baseAmount(1, decimal),
+                  recipient: '0x0000000000000000000000000000000000000000',
+                  memo
+                }),
+                liveData.map((fees) => ({ asset, amount: fees.fast }))
+              )
+        ),
+        RxOp.catchError((error) => Rx.of(RD.failure(error))),
+        RxOp.startWith(RD.pending)
       )
     case BSCChain:
+      // Use poolInTxFees$ with actual address address for accurate gas estimation
       return FP.pipe(
-        BSC.address$.pipe(
-          RxOp.switchMap(
-            O.fold(
-              () => Rx.of(RD.failure(new Error('No address available'))),
-              (address) =>
-                FP.pipe(
-                  BSC.fees$({ amount: baseAmount(1), recipient: address.address }),
-                  liveData.map((fees) => ({ asset, amount: fees.fast }))
+        Rx.combineLatest([Rx.from(getDecimal(asset)), getInboundAddresses$(BSCChain)]),
+        RxOp.switchMap(([decimal, inboundAddressesRD]) =>
+          RD.isSuccess(inboundAddressesRD)
+            ? FP.pipe(
+                getInboundAddress(inboundAddressesRD.value, BSCChain),
+                O.fold(
+                  // Fallback to zero address if address not found
+                  () =>
+                    FP.pipe(
+                      BSC.poolInTxFees$({
+                        asset,
+                        amount: baseAmount(1, decimal),
+                        recipient: '0x0000000000000000000000000000000000000000',
+                        memo
+                      }),
+                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                    ),
+                  // Use actual address address for better estimation
+                  (address) =>
+                    FP.pipe(
+                      BSC.poolInTxFees$({
+                        asset,
+                        amount: baseAmount(1, decimal),
+                        recipient: address,
+                        memo
+                      }),
+                      liveData.map((fees) => ({ asset, amount: fees.fast }))
+                    )
                 )
-            )
-          ),
-          RxOp.catchError((error) => Rx.of(RD.failure(error))),
-          RxOp.startWith(RD.pending)
-        )
+              )
+            : // If inbound addresses not loaded, use fallback
+              FP.pipe(
+                BSC.poolInTxFees$({
+                  asset,
+                  amount: baseAmount(1, decimal),
+                  recipient: '0x0000000000000000000000000000000000000000',
+                  memo
+                }),
+                liveData.map((fees) => ({ asset, amount: fees.fast }))
+              )
+        ),
+        RxOp.catchError((error) => Rx.of(RD.failure(error))),
+        RxOp.startWith(RD.pending)
       )
     case BTCChain:
       return FP.pipe(

--- a/src/renderer/services/chain/fees/common.ts
+++ b/src/renderer/services/chain/fees/common.ts
@@ -129,11 +129,22 @@ export const poolOutboundFee$ = (asset: AnyAsset): PoolFeeLD => {
       RxOp.switchMap((decimal) =>
         FP.pipe(
           getChainOutboundFee$(chain, decimal),
-          liveData.map((amount) => ({ amount, asset }))
+          liveData.map((amount) => ({ amount, asset: getChainAsset(asset.chain) })),
+          liveData.chainOnError(() => {
+            // Fallback to midgard if nodeapi fails with RD.failure
+            const outboundFee = isChainOfThor(chain)
+              ? outboundAssetFeeByChain$(chain)
+              : outboundAssetFeeByChainMaya$(chain)
+            // Ensure the returned fee uses the correct asset (the one we requested)
+            return FP.pipe(
+              outboundFee,
+              liveData.map((fee) => ({ amount: fee.amount, asset: getChainAsset(asset.chain) }))
+            )
+          })
         )
       ),
       RxOp.catchError(() => {
-        // Fallback to midgard if nodeapi or getDecimal fails
+        // Fallback to midgard if getDecimal fails (thrown error)
         const outboundFee = isChainOfThor(chain) ? outboundAssetFeeByChain$(chain) : outboundAssetFeeByChainMaya$(chain)
         // Ensure the returned fee uses the correct asset (the one we requested)
         return FP.pipe(

--- a/src/renderer/services/chain/fees/nodeapi.ts
+++ b/src/renderer/services/chain/fees/nodeapi.ts
@@ -1,0 +1,250 @@
+import { FeeOption } from '@xchainjs/xchain-client'
+import { baseAmount, Chain } from '@xchainjs/xchain-util'
+import { function as FP, option as O, array as A } from 'fp-ts'
+
+import { isChainOfMaya } from '../../../../shared/utils/chain'
+import { liveData } from '../../../helpers/rx/liveData'
+import { inboundAddressesShared$ as mayaInboundAddresses$ } from '../../mayachain'
+import { InboundAddress as MayaInboundAddress } from '../../mayachain/types'
+import { inboundAddressesShared$ as thorInboundAddresses$ } from '../../thorchain'
+import { InboundAddress as ThorInboundAddress } from '../../thorchain/types'
+
+export enum NodeProtocol {
+  THORCHAIN = 'THORCHAIN',
+  MAYACHAIN = 'MAYACHAIN'
+}
+
+type InboundAddress = ThorInboundAddress | MayaInboundAddress
+
+/**
+ * Determines which node protocol serves a given chain
+ * Uses the centralized chain mapping from shared/utils/chain.ts
+ */
+export const getChainNodeProtocol = (chain: Chain): NodeProtocol => {
+  return isChainOfMaya(chain) ? NodeProtocol.MAYACHAIN : NodeProtocol.THORCHAIN
+}
+
+export type ChainFeeData = {
+  chain: Chain
+  gas_rate: string
+  gas_rate_units?: string
+  outbound_fee: string
+  outbound_tx_size?: string
+}
+
+/**
+ * Converts gas rate from THORNode/MAYANode format to the appropriate unit for each chain
+ * @param chain The blockchain chain
+ * @param gasRate The gas rate value from the API
+ * @param gasRateUnits The gas rate units from the API
+ * @returns The converted gas rate for the chain's native unit
+ */
+export const convertNodeGasRate = (chain: Chain, gasRate: number, gasRateUnits?: string): number => {
+  switch (chain) {
+    case 'AVAX':
+      // nAVAX = nano AVAX = 10^-9 AVAX = gwei equivalent
+      // Already in the right unit for EVM client
+      if (gasRateUnits && gasRateUnits !== 'nAVAX') {
+        console.warn(`Unexpected gas_rate_units for AVAX: ${gasRateUnits}`)
+      }
+      return gasRate
+
+    case 'ETH':
+      // Already in gwei, which is what EVM client expects
+      if (gasRateUnits && gasRateUnits !== 'gwei') {
+        console.warn(`Unexpected gas_rate_units for ETH: ${gasRateUnits}`)
+      }
+      return gasRate
+
+    case 'BSC':
+      // Already in gwei, which is what EVM client expects
+      if (gasRateUnits && gasRateUnits !== 'gwei') {
+        console.warn(`Unexpected gas_rate_units for BSC: ${gasRateUnits}`)
+      }
+      return gasRate
+
+    case 'BASE':
+      // BASE returns mwei (10^-3 wei), but EVM client expects gwei (10^-9 wei)
+      // Need to convert: mwei to gwei = divide by 10^6
+      if (gasRateUnits === 'mwei') {
+        return gasRate / 1e3
+      }
+      console.warn(`Unexpected gas_rate_units for BASE: ${gasRateUnits}`)
+      return gasRate
+
+    case 'ARB':
+      // ARB returns centigwei (10^-2 gwei = 0.01 gwei), but EVM client expects gwei
+      // Need to convert: centigwei to gwei = divide by 100
+      if (gasRateUnits === 'centigwei') {
+        return gasRate / 100
+      }
+      console.warn(`Unexpected gas_rate_units for ARB: ${gasRateUnits}`)
+      return gasRate
+
+    case 'BTC':
+    case 'BCH':
+    case 'LTC':
+    case 'DOGE':
+      // UTXO chains return satsperbyte, which is what clients expect
+      if (gasRateUnits && gasRateUnits !== 'satsperbyte') {
+        console.warn(`Unexpected gas_rate_units for ${chain}: ${gasRateUnits}`)
+      }
+      return gasRate
+
+    case 'DASH':
+    case 'ZEC':
+      // Assuming satsperbyte like other UTXO chains
+      return gasRate
+
+    case 'GAIA':
+      // Returns uatom (micro atom), which is the smallest unit
+      if (gasRateUnits && gasRateUnits !== 'uatom') {
+        console.warn(`Unexpected gas_rate_units for GAIA: ${gasRateUnits}`)
+      }
+      return gasRate
+
+    case 'THOR':
+    case 'MAYA':
+    case 'KUJI':
+      // Cosmos-based chains return in smallest unit
+      return gasRate
+
+    case 'XRP':
+      // Returns in drops (smallest unit)
+      if (gasRateUnits && gasRateUnits !== 'drop') {
+        console.warn(`Unexpected gas_rate_units for XRP: ${gasRateUnits}`)
+      }
+      return gasRate
+
+    case 'SOL':
+      // Solana returns in lamports (smallest unit)
+      return gasRate
+
+    case 'XRD':
+      // Radix returns in smallest unit
+      return gasRate
+
+    default:
+      console.warn(`Unknown chain ${chain} with gas_rate_units: ${gasRateUnits}`)
+      return gasRate
+  }
+}
+
+/**
+ * Extracts fee data for a specific chain from inbound addresses response
+ */
+export const getChainFeeData = (inboundAddresses: InboundAddress[], chain: Chain): O.Option<ChainFeeData> => {
+  const chainData = A.findFirst((item: InboundAddress) => item.chain === chain)(inboundAddresses)
+
+  return FP.pipe(
+    chainData,
+    O.chain((data) =>
+      data.gas_rate
+        ? O.some({
+            chain,
+            gas_rate: data.gas_rate,
+            gas_rate_units: data.gas_rate_units,
+            outbound_fee: data.outbound_fee || '0',
+            outbound_tx_size: data.outbound_tx_size
+          })
+        : O.none
+    )
+  )
+}
+
+/**
+ * Gets gas prices for a chain using THORNode or MAYANode inbound addresses
+ */
+export const getNodeGasPrices$ = (
+  chain: Chain,
+  protocol: NodeProtocol = NodeProtocol.THORCHAIN,
+  decimals: number = 18
+) => {
+  const inboundAddresses$ = protocol === NodeProtocol.THORCHAIN ? thorInboundAddresses$ : mayaInboundAddresses$
+  const nodeName = protocol === NodeProtocol.THORCHAIN ? 'THORNode' : 'MAYANode'
+
+  return FP.pipe(
+    inboundAddresses$,
+    liveData.map((inboundAddresses) => {
+      const oChainFeeData = getChainFeeData(inboundAddresses, chain)
+
+      return FP.pipe(
+        oChainFeeData,
+        O.fold(
+          () => {
+            throw new Error(`No fee data available for chain ${chain} from ${nodeName}`)
+          },
+          (feeData) => {
+            const gasRateNum = Number(feeData.gas_rate)
+            const convertedRate = convertNodeGasRate(chain, gasRateNum, feeData.gas_rate_units)
+
+            // For EVM chains, convertedRate is in gwei and we need to convert to smallest unit (wei)
+            // For UTXO chains, the rate is already in satoshis per byte
+            const isEVMChain = ['ETH', 'BSC', 'AVAX', 'ARB', 'BASE'].includes(chain)
+
+            if (isEVMChain) {
+              // Convert gwei to wei by multiplying by 10^9
+              const rateInWei = convertedRate * Math.pow(10, 9)
+              const gasPrices = {
+                [FeeOption.Average]: baseAmount(rateInWei, decimals),
+                [FeeOption.Fast]: baseAmount(Math.ceil(rateInWei * 1.5), decimals),
+                [FeeOption.Fastest]: baseAmount(Math.ceil(rateInWei * 2), decimals)
+              }
+              return gasPrices
+            } else {
+              // For non-EVM chains, use the rate as-is
+              const gasPrices = {
+                [FeeOption.Average]: baseAmount(convertedRate, decimals),
+                [FeeOption.Fast]: baseAmount(Math.ceil(convertedRate * 1.5), decimals),
+                [FeeOption.Fastest]: baseAmount(Math.ceil(convertedRate * 2), decimals)
+              }
+              return gasPrices
+            }
+          }
+        )
+      )
+    })
+  )
+}
+
+/**
+ * Gets outbound fee for a chain using THORNode or MAYANode inbound addresses
+ */
+export const getNodeOutboundFee$ = (
+  chain: Chain,
+  protocol: NodeProtocol = NodeProtocol.THORCHAIN,
+  assetDecimals: number = 18
+) => {
+  const inboundAddresses$ = protocol === NodeProtocol.THORCHAIN ? thorInboundAddresses$ : mayaInboundAddresses$
+
+  return FP.pipe(
+    inboundAddresses$,
+    liveData.map((inboundAddresses) => {
+      const oChainFeeData = getChainFeeData(inboundAddresses, chain)
+
+      return FP.pipe(
+        oChainFeeData,
+        O.fold(
+          () => baseAmount(0, assetDecimals),
+          (feeData) => baseAmount(feeData.outbound_fee, assetDecimals)
+        )
+      )
+    })
+  )
+}
+
+/**
+ * Convenience function to get gas prices using the appropriate node protocol for the chain
+ */
+export const getChainGasPrices$ = (chain: Chain, decimals: number = 18) => {
+  const protocol = getChainNodeProtocol(chain)
+  return getNodeGasPrices$(chain, protocol, decimals)
+}
+
+/**
+ * Convenience function to get outbound fees using the appropriate node protocol for the chain
+ */
+export const getChainOutboundFee$ = (chain: Chain, assetDecimals: number = 18) => {
+  const protocol = getChainNodeProtocol(chain)
+  return getNodeOutboundFee$(chain, protocol, assetDecimals)
+}

--- a/src/renderer/services/ethereum/fees.ts
+++ b/src/renderer/services/ethereum/fees.ts
@@ -82,13 +82,25 @@ export const createFeesService = (client$: Client$): FeesService => {
           O.fold(
             () => Rx.of(RD.initial),
             (client): FeesLD => {
-              // Get gas limit estimation
-              const gasLimit$ = client.estimateGasLimit({
-                asset: params.asset as CompatibleAsset,
-                amount: params.amount,
-                recipient: params.recipient,
-                memo: params.memo
-              })
+              // Get gas limit estimation with fallback for standalone Ledger or flaky RPCs
+              const gasLimit$ = Rx.from(
+                client.estimateGasLimit({
+                  asset: params.asset as CompatibleAsset,
+                  amount: params.amount,
+                  recipient: params.recipient,
+                  memo: params.memo
+                })
+              ).pipe(
+                RxOp.catchError((error) => {
+                  console.error('Gas limit estimation failed, using fallback:', error)
+                  // Use same fallback logic as in estimateAndCalculateFees
+                  const fallbackGasLimit =
+                    params.asset && isEthAsset(params.asset as Asset)
+                      ? new BigNumber(ETH_OUT_TX_GAS_LIMIT) // ETH native transfer
+                      : new BigNumber(ERC20_OUT_TX_GAS_LIMIT) // ERC20 token transfer
+                  return Rx.of(fallbackGasLimit)
+                })
+              )
 
               // Get gas prices - try THORNode first, fallback to client
               const gasPrices$: Rx.Observable<RD.RemoteData<Error, GasPrices>> = FP.pipe(

--- a/src/renderer/services/ethereum/fees.ts
+++ b/src/renderer/services/ethereum/fees.ts
@@ -1,7 +1,7 @@
 import * as RD from '@devexperts/remote-data-ts'
-import { Fees, FeeType, Protocol } from '@xchainjs/xchain-client'
+import { Fees, FeeType } from '@xchainjs/xchain-client'
 import { ETH_GAS_ASSET_DECIMAL } from '@xchainjs/xchain-ethereum'
-import { getFee, GasPrices, Client } from '@xchainjs/xchain-evm'
+import { getFee, GasPrices, Client, CompatibleAsset } from '@xchainjs/xchain-evm'
 import { Asset } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import { function as FP, option as O } from 'fp-ts'
@@ -10,6 +10,7 @@ import * as RxOp from 'rxjs/operators'
 
 import { isEthAsset } from '../../helpers/assetHelper'
 import { observableState } from '../../helpers/stateHelper'
+import { getChainGasPrices$ } from '../chain/fees/nodeapi'
 import type { FeeLD } from '../chain/types'
 import type { FeesLD } from '../clients'
 import { ERC20_OUT_TX_GAS_LIMIT, ETH_OUT_TX_GAS_LIMIT } from '../evm/const'
@@ -36,7 +37,7 @@ export const createFeesService = (client$: Client$): FeesService => {
 
   async function estimateAndCalculateFees(client: Client, params: TxParams) {
     // Estimate gas prices
-    const gasPrices = await client.estimateGasPrices(Protocol.THORCHAIN)
+    const gasPrices = await client.estimateGasPrices()
     const { fast: fastGP, fastest: fastestGP, average: averageGP } = gasPrices
 
     // Estimate gas limit - with fallback for standalone ledger mode
@@ -73,37 +74,7 @@ export const createFeesService = (client$: Client$): FeesService => {
   /**
    * Fees for sending txs into pool on Ethereum
    **/
-  const poolInTxFees$ = ({ address, abi, func, params }: PoolInTxFeeParams): FeesLD =>
-    client$.pipe(
-      RxOp.switchMap((oClient) =>
-        FP.pipe(
-          oClient,
-          O.fold(
-            () => Rx.of(RD.initial),
-            (client): FeesLD =>
-              Rx.combineLatest([
-                client.estimateCall({ contractAddress: address, abi, funcName: func, funcParams: params }),
-                client.estimateGasPrices()
-              ]).pipe(
-                RxOp.map<[BigNumber, GasPrices], Fees>(([gasLimit, gasPrices]) => ({
-                  type: FeeType.PerByte,
-                  average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: ETH_GAS_ASSET_DECIMAL }),
-                  fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: ETH_GAS_ASSET_DECIMAL }),
-                  fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: ETH_GAS_ASSET_DECIMAL })
-                })),
-                RxOp.map(RD.success),
-                RxOp.catchError((error) => Rx.of(RD.failure(error))),
-                RxOp.startWith(RD.pending)
-              )
-          )
-        )
-      )
-    )
-
-  /**
-   * Fees for sending txs out of a pool on Ethereum
-   **/
-  const poolOutTxFee$ = (asset: Asset): FeesLD =>
+  const poolInTxFees$ = (params: PoolInTxFeeParams): FeesLD =>
     client$.pipe(
       RxOp.switchMap((oClient) =>
         FP.pipe(
@@ -111,16 +82,49 @@ export const createFeesService = (client$: Client$): FeesService => {
           O.fold(
             () => Rx.of(RD.initial),
             (client): FeesLD => {
-              const gasLimit = isEthAsset(asset) ? ETH_OUT_TX_GAS_LIMIT : ERC20_OUT_TX_GAS_LIMIT
-              return Rx.from(client.estimateGasPrices()).pipe(
-                RxOp.map<GasPrices, Fees>((gasPrices) => ({
-                  type: FeeType.PerByte,
-                  average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: ETH_GAS_ASSET_DECIMAL }),
-                  fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: ETH_GAS_ASSET_DECIMAL }),
-                  fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: ETH_GAS_ASSET_DECIMAL })
-                })),
-                RxOp.map(RD.success),
-                RxOp.catchError((error) => Rx.of(RD.failure(error))),
+              // Get gas limit estimation
+              const gasLimit$ = client.estimateGasLimit({
+                asset: params.asset as CompatibleAsset,
+                amount: params.amount,
+                recipient: params.recipient,
+                memo: params.memo
+              })
+
+              // Get gas prices - try THORNode first, fallback to client
+              const gasPrices$: Rx.Observable<RD.RemoteData<Error, GasPrices>> = FP.pipe(
+                getChainGasPrices$('ETH', ETH_GAS_ASSET_DECIMAL),
+                RxOp.map((rd) =>
+                  RD.isFailure(rd) ? RD.failure(new Error(String(rd.error))) : (rd as RD.RemoteData<Error, GasPrices>)
+                ),
+                RxOp.catchError(() =>
+                  // Fallback to client estimation if nodeapi fails
+                  Rx.from(client.estimateGasPrices()).pipe(
+                    RxOp.map(RD.success),
+                    RxOp.catchError((error) => Rx.of(RD.failure(new Error(String(error)))))
+                  )
+                )
+              )
+
+              return Rx.combineLatest([gasLimit$, gasPrices$]).pipe(
+                RxOp.switchMap(([gasLimit, gasPricesRD]) =>
+                  FP.pipe(
+                    gasPricesRD,
+                    RD.fold<Error, GasPrices, FeesLD>(
+                      () => Rx.of(RD.initial),
+                      () => Rx.of(RD.pending),
+                      (error) => Rx.of(RD.failure(error)),
+                      (gasPrices) =>
+                        Rx.of(
+                          RD.success({
+                            type: FeeType.PerByte,
+                            average: getFee({ gasPrice: gasPrices.average, gasLimit, decimals: ETH_GAS_ASSET_DECIMAL }),
+                            fast: getFee({ gasPrice: gasPrices.fast, gasLimit, decimals: ETH_GAS_ASSET_DECIMAL }),
+                            fastest: getFee({ gasPrice: gasPrices.fastest, gasLimit, decimals: ETH_GAS_ASSET_DECIMAL })
+                          })
+                        )
+                    )
+                  )
+                ),
                 RxOp.startWith(RD.pending)
               )
             }
@@ -177,7 +181,6 @@ export const createFeesService = (client$: Client$): FeesService => {
     fees$,
     reloadFees,
     poolInTxFees$,
-    poolOutTxFee$,
     approveFee$,
     reloadApproveFee
   }

--- a/src/renderer/services/ethereum/index.ts
+++ b/src/renderer/services/ethereum/index.ts
@@ -23,8 +23,7 @@ const {
   approveERC20Token$,
   isApprovedERC20Token$
 } = createTransactionService(client$, network$)
-const { reloadFees, fees$, poolInTxFees$, poolOutTxFee$, approveFee$, reloadApproveFee } =
-  createFeesService(enhancedClient$)
+const { reloadFees, fees$, poolInTxFees$, approveFee$, reloadApproveFee } = createFeesService(enhancedClient$)
 
 export {
   client$,
@@ -48,7 +47,6 @@ export {
   fees$,
   sendPoolTx$,
   poolInTxFees$,
-  poolOutTxFee$,
   approveFee$,
   reloadApproveFee,
   approveERC20Token$,

--- a/src/renderer/services/evm/types.ts
+++ b/src/renderer/services/evm/types.ts
@@ -2,7 +2,6 @@ import * as RD from '@devexperts/remote-data-ts'
 import { FeeOption, Network, XChainClient } from '@xchainjs/xchain-client'
 import ClientKeystore, { TxParams as BaseEvmTxParams } from '@xchainjs/xchain-evm'
 import { Address, AnyAsset, Asset, BaseAmount, TokenAsset } from '@xchainjs/xchain-util'
-import { InterfaceAbi } from 'ethers'
 import { option as O } from 'fp-ts'
 
 import { HDMode, WalletType } from '../../../shared/wallet/types'
@@ -57,10 +56,10 @@ export type ApproveParams = {
 export type IsApproveParams = { contractAddress: Address; spenderAddress: Address; fromAddress: Address }
 
 export type PoolInTxFeeParams = {
-  address: Address
-  abi: InterfaceAbi
-  func: string
-  params: Array<unknown>
+  asset: AnyAsset
+  amount: BaseAmount
+  recipient: Address
+  memo?: string
 }
 
 export type IsApprovedRD = RD.RemoteData<ApiError, boolean>
@@ -83,7 +82,6 @@ export type TxParams = {
 
 export type FeesService = {
   poolInTxFees$: (params: PoolInTxFeeParams) => C.FeesLD
-  poolOutTxFee$: (asset: Asset) => C.FeesLD
   approveFee$: ApproveFeeHandler
   reloadApproveFee: LoadApproveFeeHandler
   reloadFees: (params: TxParams) => void

--- a/src/renderer/services/mayachain/mayanode.ts
+++ b/src/renderer/services/mayachain/mayanode.ts
@@ -115,7 +115,10 @@ export const createMayanodeService$ = (network$: Network$, clientUrl$: ClientUrl
               chain_trading_paused: item.chain_trading_paused,
               chain_lp_actions_paused: item.chain_lp_actions_paused,
               outbound_fee: item.outbound_fee,
-              halted: item.halted || false // provide a default value if halted is undefined
+              halted: item.halted || false, // provide a default value if halted is undefined
+              gas_rate: item.gas_rate,
+              gas_rate_units: item.gas_rate_units,
+              outbound_tx_size: item.outbound_tx_size
             }))
             return RD.success(data)
           }),

--- a/src/renderer/services/thorchain/thornode.ts
+++ b/src/renderer/services/thorchain/thornode.ts
@@ -129,7 +129,10 @@ export const createThornodeService$ = (network$: Network$, clientUrl$: ClientUrl
               chain_lp_actions_paused: item.chain_lp_actions_paused,
               outbound_fee: item.outbound_fee,
               dust_threshold: item.dust_threshold,
-              halted: item.halted || false // provide a default value if halted is undefined
+              halted: item.halted || false, // provide a default value if halted is undefined
+              gas_rate: item.gas_rate,
+              gas_rate_units: item.gas_rate_units,
+              outbound_tx_size: item.outbound_tx_size
             }))
             return RD.success(data)
           }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Use chain node gas prices (with fallback) for more accurate fee estimates and node-backed outbound/inbound fees.
  - Inbound-address–aware fee estimation for ETH, ARB, BASE, AVAX and BSC.

- Bug Fixes
  - Corrected max swappable amount by aligning fee/balance decimals (including UTXO safety buffer).
  - Avoids misleading $0.00 by using higher precision for very small USD amounts across send/swap flows.
  - Swap fee label now shows loading/missing states and handles missing USD values gracefully.

- Chores
  - Increased pool deposit gas limit to 200,000.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->