### PR TITLE
chore: update swap tx modal

### DIFF
--- a/src/renderer/components/modal/tx/extra/SwapAssets.tsx
+++ b/src/renderer/components/modal/tx/extra/SwapAssets.tsx
@@ -1,8 +1,10 @@
 import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline'
 import { Network } from '@xchainjs/xchain-client'
+import { baseToAsset, formatAssetAmount } from '@xchainjs/xchain-util'
 import styled from 'styled-components'
 
 import { AssetData as UIAssetData } from '../../../uielements/assets/assetData'
+import { Label } from '../../../uielements/label'
 import * as Styled from './Common.styles'
 import * as C from './Common.types'
 
@@ -20,7 +22,6 @@ const SwapIconContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 8px;
 `
 
 const SwapAssetData = styled(UIAssetData)`
@@ -48,12 +49,22 @@ export const SwapAssets = (props: Props): JSX.Element => {
   return (
     <div className="flex flex-col items-center justify-center w-full">
       <Styled.StepLabel>{stepDescription}</Styled.StepLabel>
-      <SwapDataWrapper>
-        <SwapAssetData asset={source.asset} amount={source.amount} network={network} size="big" />
+      <SwapDataWrapper className="w-full !gap-1">
+        <div className="flex items-center justify-between w-full px-10">
+          <SwapAssetData asset={source.asset} network={network} size="small" />
+          <Label className="text-3xl" align="right">
+            {formatAssetAmount({ amount: baseToAsset(source.amount), trimZeros: true })}
+          </Label>
+        </div>
         <SwapIconContainer>
           <ArrowsRightLeftIcon className="w-8 h-8 text-gray-400 rotate-90" />
         </SwapIconContainer>
-        <SwapAssetData asset={target.asset} amount={target.amount} network={network} size="big" />
+        <div className="flex items-center justify-between w-full px-10">
+          <SwapAssetData asset={target.asset} network={network} size="small" />
+          <Label className="text-3xl" align="right">
+            {formatAssetAmount({ amount: baseToAsset(target.amount), trimZeros: true })}
+          </Label>
+        </div>
       </SwapDataWrapper>
     </div>
   )

--- a/src/renderer/components/uielements/modal/Modal.tsx
+++ b/src/renderer/components/uielements/modal/Modal.tsx
@@ -25,7 +25,7 @@ export type HeadlessModalProps = {
   children?: React.ReactNode
 }
 
-export const Modal: React.FC<HeadlessModalProps> = ({
+export const Modal = ({
   visible,
   title,
   onCancel,
@@ -40,7 +40,7 @@ export const Modal: React.FC<HeadlessModalProps> = ({
   okButtonProps,
   cancelButtonProps,
   children
-}) => {
+}: HeadlessModalProps) => {
   return (
     <Transition appear show={visible} as={Fragment}>
       <Dialog as="div" className={clsx('relative z-50', className)} onClose={onCancel ?? (() => {})}>
@@ -75,8 +75,8 @@ export const Modal: React.FC<HeadlessModalProps> = ({
                   panelClassName
                 )}>
                 {/* Header — uppercase, centered, primary bg like palette('primary',2) */}
-                <div className="relative bg-turquoise px-3.5 py-2.5 text-center uppercase">
-                  <DialogTitle as="h3" className="font-main text-sm tracking-wide text-white mb-0">
+                <div className="relative px-3.5 py-2.5 text-center uppercase">
+                  <DialogTitle as="h1" className="text-md tracking-wide font-main text-text2 dark:text-text2d mb-0">
                     {title}
                   </DialogTitle>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Swap dialog now shows source and target amounts as right-aligned labels next to each asset, with cleaner formatting (trimmed zeros) for improved readability.
  * Layout is more compact with two inline rows per side, making asset and amount pairing clearer.
  * Modal header refreshed: removed turquoise background and updated title styling/hierarchy for a cleaner look. All behaviors and interactions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->