### PR TITLE
 update gaia to use inbound address for swap fees

### DIFF
--- a/src/renderer/components/swap/Swap.utils.test.ts
+++ b/src/renderer/components/swap/Swap.utils.test.ts
@@ -318,7 +318,7 @@ describe('components/swap/utils', () => {
       expect(eqBaseAmount.equals(result, assetToBase(assetAmount(30, inAssetDecimal)))).toBeTruthy()
     })
 
-    it(`UTXO assets' min amount should be over estimated with 10k Sats`, () => {
+    it(`UTXO assets' min amount calculation`, () => {
       const inAssetDecimal = BTC_DECIMAL
       const params = {
         swapFees: {
@@ -341,32 +341,32 @@ describe('components/swap/utils', () => {
       //
       // Formula (success):
       // inboundFeeInBTC + outboundFeeInBTC
-      // 0.0001 + (0.01 * 1) = 0.0001 + 1 = 0.0101
+      // 0.0001 + (0.01 * 1) = 0.0001 + 0.01 = 0.0101
       //
       // Formula (failure):
       // inboundFeeInBTC + refundFeeInBTC
       // 0.0001 + (0.0003 * 1) = 0.0001 + 0.0003 = 0.0004
       //
       // Formula (minValue):
-      // 1,5 * max(success, failure)
-      // 1,5 * max(0.0101, 0.0004) = 1,5 * 0.0101 = 0.01515
-      // AND as this is UTXO asset overestimate with 10k Satoshis => 0.01515 + 10k Satoshis = 0.01525
+      // 1.5 * max(success, failure)
+      // 1.5 * max(0.0101, 0.0004) = 1.5 * 0.0101 = 0.01515
+      // UTXO safety buffer is no longer added in minAmountToSwapMax1e8
 
       const result = minAmountToSwapMax1e8(params)
-      expect(eqBaseAmount.equals(result, assetToBase(assetAmount(0.01525, inAssetDecimal)))).toBeTruthy()
+      expect(eqBaseAmount.equals(result, assetToBase(assetAmount(0.01515, inAssetDecimal)))).toBeTruthy()
     })
   })
 
   describe('maxAmountToSwapMax1e8', () => {
     it('balance to swap - with estimated fees', () => {
       const params = {
-        balanceAmountMax1e8: baseAmount(50000), // Increased to account for UTXO safety buffer
+        balanceAmountMax1e8: baseAmount(50000),
         asset: AssetBTC,
         feeAmount: baseAmount(100)
       }
       const result = maxAmountToSwapMax1e8(params)
-      // Expect accurate calculation: 50000 - 100 - 10000 (UTXO safety buffer) = 39900
-      expect(eqBaseAmount.equals(result, baseAmount(39900))).toBeTruthy()
+      // Expect calculation: 50000 - 100 = 49900 (no UTXO safety buffer in swap calculation)
+      expect(eqBaseAmount.equals(result, baseAmount(49900))).toBeTruthy()
     })
 
     it('balance to swap - with 1e18 based estimated fees', () => {

--- a/src/renderer/components/swap/Swap.utils.ts
+++ b/src/renderer/components/swap/Swap.utils.ts
@@ -1,11 +1,11 @@
 import { QuoteSwap } from '@xchainjs/xchain-mayachain-query'
 import { THORChain, TxDetails } from '@xchainjs/xchain-thorchain-query'
 import { AnyAsset, BaseAmount, baseAmount, Chain, CryptoAmount } from '@xchainjs/xchain-util'
-import { array as A, either as E, function as FP, option as O } from 'fp-ts'
+import { array as A, function as FP, option as O } from 'fp-ts'
 
 import { isLedgerWallet } from '../../../shared/utils/guard'
 import { ZERO_BASE_AMOUNT } from '../../const'
-import { isChainAsset, isUtxoAssetChain, max1e8BaseAmount, convertBaseAmountDecimal } from '../../helpers/assetHelper'
+import { isChainAsset, max1e8BaseAmount, convertBaseAmountDecimal } from '../../helpers/assetHelper'
 import { eqAsset, eqChain } from '../../helpers/fp/eq'
 import { priceFeeAmountForAsset } from '../../services/chain/fees/utils'
 import { SwapFees } from '../../services/chain/types'
@@ -113,12 +113,7 @@ export const minAmountToSwapMax1e8 = ({
     1.5,
     feeToCover.times,
     // transform fee decimal to be `max1e8`
-    max1e8BaseAmount,
-    // Zero amount is possible only in case there is not fees information loaded.
-    // Just to avoid blinking min value filter out zero min amounts too.
-    E.fromPredicate((amount) => amount.eq(0) || !isUtxoAssetChain(inAsset), FP.identity),
-    // increase min value by 10k satoshi (for meaningful UTXO assets' only)
-    E.getOrElse((amount) => amount.plus(10000))
+    max1e8BaseAmount
   )
 }
 
@@ -153,10 +148,7 @@ export const maxAmountToSwapMax1e8 = ({
       ? convertBaseAmountDecimal(estimatedFeeMax1e8, balanceAmountMax1e8.decimal)
       : estimatedFeeMax1e8
 
-  const utxoSafetyBuffer = isUtxoAssetChain(asset)
-    ? baseAmount(10000, balanceAmountMax1e8.decimal)
-    : baseAmount(0, balanceAmountMax1e8.decimal)
-  const maxAmountToSwap = balanceAmountMax1e8.minus(feeInBalanceDecimal).minus(utxoSafetyBuffer)
+  const maxAmountToSwap = balanceAmountMax1e8.minus(feeInBalanceDecimal)
   return maxAmountToSwap.gt(ZERO_BASE_AMOUNT) ? maxAmountToSwap : ZERO_BASE_AMOUNT
 }
 

--- a/src/renderer/services/chain/fees/common.ts
+++ b/src/renderer/services/chain/fees/common.ts
@@ -102,6 +102,33 @@ const getInboundAddresses$ = (chain: Chain) => {
 }
 
 /**
+ * Extrapolate fee from gas_rate using FeesWithRates relationship
+ * Uses the ratio between known rate and fee to calculate fee for given gas_rate
+ */
+const extrapolateFeeFromGasRate = (
+  gasRate: number,
+  feesWithRates: {
+    rates: { fast: number; fastest: number; average: number }
+    fees: { fast: BaseAmount; fastest: BaseAmount; average: BaseAmount }
+  }
+): BaseAmount => {
+  // Use 'fast' rate as reference since it's commonly used
+  const referenceRate = feesWithRates.rates.fast
+  const referenceFee = feesWithRates.fees.fast
+
+  if (referenceRate <= 0) {
+    // Fallback to the reference fee if rate is invalid
+    return referenceFee
+  }
+
+  // Calculate fee using the ratio: gasRate / referenceRate * referenceFee
+  const scaleFactor = gasRate / referenceRate
+  const calculatedFeeAmount = referenceFee.amount().multipliedBy(scaleFactor)
+
+  return baseAmount(calculatedFeeAmount, referenceFee.decimal)
+}
+
+/**
  * Fees for pool outbound txs (swap/deposit/withdraw/earn) tobefixed
  */
 export const poolOutboundFee$ = (asset: AnyAsset): PoolFeeLD => {
@@ -180,84 +207,156 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
   }
   switch (asset.chain) {
     case DOGEChain:
+      // Use gas_rate from inbound addresses with FeesWithRates ratio
       return FP.pipe(
-        DOGE.address$.pipe(
-          RxOp.switchMap(
-            O.fold(
-              () => Rx.of(RD.failure(new Error('No address available'))),
-              (address) =>
-                FP.pipe(
-                  DOGE.feesWithRates$(address.address, memo),
-                  liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
-                )
+        Rx.combineLatest([
+          getInboundAddresses$(DOGEChain),
+          // Get current FeesWithRates to establish rate-to-fee relationship
+          DOGE.address$.pipe(
+            RxOp.switchMap(
+              O.fold(
+                () => Rx.of(RD.initial),
+                (address) => DOGE.feesWithRates$(address.address, memo)
+              )
             )
-          ),
-          RxOp.catchError((error) => Rx.of(RD.failure(error))),
-          RxOp.startWith(RD.pending)
-        )
+          )
+        ]),
+        RxOp.switchMap(([inboundAddressesRD, feesWithRatesRD]) => {
+          if (RD.isSuccess(inboundAddressesRD) && RD.isSuccess(feesWithRatesRD)) {
+            const oChainFeeData = FP.pipe(
+              inboundAddressesRD.value,
+              A.findFirst((item) => item.chain === DOGEChain),
+              O.chain((data) => (data.gas_rate ? O.some({ gas_rate: Number(data.gas_rate) }) : O.none))
+            )
+
+            return FP.pipe(
+              oChainFeeData,
+              O.fold(
+                // Fallback to DOGE service fees if inbound data not available
+                () => Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast })),
+                (feeData) => {
+                  const extrapolatedFee = extrapolateFeeFromGasRate(feeData.gas_rate, feesWithRatesRD.value)
+                  return Rx.of(RD.success({ asset, amount: extrapolatedFee }))
+                }
+              )
+            )
+          }
+          // Fallback to DOGE service if either inbound addresses or fees failed
+          return RD.isSuccess(feesWithRatesRD)
+            ? Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast }))
+            : Rx.of(RD.failure(new Error('Failed to load fees')))
+        }),
+        RxOp.catchError(() => {
+          // Final fallback to DOGE service
+          return FP.pipe(
+            DOGE.address$.pipe(
+              RxOp.switchMap(
+                O.fold(
+                  () => Rx.of(RD.failure(new Error('No address available'))),
+                  (address) =>
+                    FP.pipe(
+                      DOGE.feesWithRates$(address.address, memo),
+                      liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
+                    )
+                )
+              )
+            )
+          )
+        }),
+        RxOp.startWith(RD.pending)
       )
 
     case LTCChain:
+      // Use gas_rate from inbound addresses with FeesWithRates ratio
       return FP.pipe(
-        LTC.address$.pipe(
-          RxOp.switchMap(
-            O.fold(
-              () => Rx.of(RD.failure(new Error('No address available'))),
-              (address) =>
-                FP.pipe(
-                  LTC.feesWithRates$(address.address, memo),
-                  liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
-                )
+        Rx.combineLatest([
+          getInboundAddresses$(LTCChain),
+          LTC.address$.pipe(
+            RxOp.switchMap(
+              O.fold(
+                () => Rx.of(RD.initial),
+                (address) => LTC.feesWithRates$(address.address, memo)
+              )
             )
-          ),
-          RxOp.catchError((error) => Rx.of(RD.failure(error))),
-          RxOp.startWith(RD.pending)
-        )
+          )
+        ]),
+        RxOp.switchMap(([inboundAddressesRD, feesWithRatesRD]) => {
+          if (RD.isSuccess(inboundAddressesRD) && RD.isSuccess(feesWithRatesRD)) {
+            const oChainFeeData = FP.pipe(
+              inboundAddressesRD.value,
+              A.findFirst((item) => item.chain === LTCChain),
+              O.chain((data) => (data.gas_rate ? O.some({ gas_rate: Number(data.gas_rate) }) : O.none))
+            )
+
+            return FP.pipe(
+              oChainFeeData,
+              O.fold(
+                () => Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast })),
+                (feeData) => {
+                  const extrapolatedFee = extrapolateFeeFromGasRate(feeData.gas_rate, feesWithRatesRD.value)
+                  return Rx.of(RD.success({ asset, amount: extrapolatedFee }))
+                }
+              )
+            )
+          }
+          return RD.isSuccess(feesWithRatesRD)
+            ? Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast }))
+            : Rx.of(RD.failure(new Error('Failed to load LTC fees')))
+        }),
+        RxOp.catchError(() => {
+          return FP.pipe(
+            LTC.address$.pipe(
+              RxOp.switchMap(
+                O.fold(
+                  () => Rx.of(RD.failure(new Error('No address available'))),
+                  (address) =>
+                    FP.pipe(
+                      LTC.feesWithRates$(address.address, memo),
+                      liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
+                    )
+                )
+              )
+            )
+          )
+        }),
+        RxOp.startWith(RD.pending)
       )
     case GAIAChain:
-      // Use gas_rate from inbound addresses for more accurate fees
+      // Use gas_rate from inbound addresses with FeesWithRates ratio
       return FP.pipe(
-        Rx.from(getDecimal(asset)),
-        RxOp.switchMap((decimal) =>
-          FP.pipe(
-            getInboundAddresses$(GAIAChain),
-            liveData.map((inboundAddresses) => {
-              const oChainFeeData = FP.pipe(
-                inboundAddresses,
-                A.findFirst((item) => item.chain === GAIAChain),
-                O.chain((data) =>
-                  data.gas_rate
-                    ? O.some({
-                        gas_rate: data.gas_rate,
-                        gas_rate_units: data.gas_rate_units
-                      })
-                    : O.none
-                )
-              )
+        Rx.combineLatest([getInboundAddresses$(GAIAChain), COSMOS.fees$()]),
+        RxOp.switchMap(([inboundAddressesRD, feesRD]) => {
+          if (RD.isSuccess(inboundAddressesRD) && RD.isSuccess(feesRD)) {
+            const oChainFeeData = FP.pipe(
+              inboundAddressesRD.value,
+              A.findFirst((item) => item.chain === GAIAChain),
+              O.chain((data) => (data.gas_rate ? O.some({ gas_rate: Number(data.gas_rate) }) : O.none))
+            )
 
-              return FP.pipe(
-                oChainFeeData,
-                O.fold(
-                  // Fallback to generic COSMOS fees if inbound data not available
-                  () => ({ asset, amount: baseAmount(5000, decimal) }), // Default fallback
-                  (feeData) => ({
-                    asset,
-                    amount: baseAmount(feeData.gas_rate, decimal)
-                  })
-                )
+            return FP.pipe(
+              oChainFeeData,
+              O.fold(
+                () => Rx.of(RD.success({ asset, amount: feesRD.value.fast })),
+                (feeData) => {
+                  // For COSMOS chains, we need to estimate gas units for the transaction
+                  // A typical Cosmos tx with memo uses approximately 200,000 gas units
+                  const GAS_UNITS_ESTIMATE = 200000
+                  const calculatedFee = feeData.gas_rate * GAS_UNITS_ESTIMATE
+                  return Rx.of(
+                    RD.success({
+                      asset,
+                      amount: baseAmount(calculatedFee, feesRD.value.fast.decimal)
+                    })
+                  )
+                }
               )
-            }),
-            liveData.chainOnError(() => {
-              // Final fallback to COSMOS service
-              return FP.pipe(
-                COSMOS.fees$(),
-                liveData.map((fees) => ({ asset, amount: fees.fast }))
-              )
-            })
-          )
-        ),
+            )
+          }
+          return RD.isSuccess(feesRD)
+            ? Rx.of(RD.success({ asset, amount: feesRD.value.fast }))
+            : Rx.of(RD.failure(new Error('Failed to load GAIA fees')))
+        }),
         RxOp.catchError(() => {
-          // If getDecimal fails, fallback to COSMOS service
           return FP.pipe(
             COSMOS.fees$(),
             liveData.map((fees) => ({ asset, amount: fees.fast }))
@@ -501,38 +600,114 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
         RxOp.startWith(RD.pending)
       )
     case BTCChain:
+      // Use gas_rate from inbound addresses with FeesWithRates ratio
       return FP.pipe(
-        BTC.address$.pipe(
-          RxOp.switchMap(
-            O.fold(
-              () => Rx.of(RD.failure(new Error('No address available'))),
-              (address) =>
-                FP.pipe(
-                  BTC.feesWithRates$(address.address, memo),
-                  liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
-                )
+        Rx.combineLatest([
+          getInboundAddresses$(BTCChain),
+          BTC.address$.pipe(
+            RxOp.switchMap(
+              O.fold(
+                () => Rx.of(RD.initial),
+                (address) => BTC.feesWithRates$(address.address, memo)
+              )
             )
-          ),
-          RxOp.catchError((error) => Rx.of(RD.failure(error))),
-          RxOp.startWith(RD.pending)
-        )
+          )
+        ]),
+        RxOp.switchMap(([inboundAddressesRD, feesWithRatesRD]) => {
+          if (RD.isSuccess(inboundAddressesRD) && RD.isSuccess(feesWithRatesRD)) {
+            const oChainFeeData = FP.pipe(
+              inboundAddressesRD.value,
+              A.findFirst((item) => item.chain === BTCChain),
+              O.chain((data) => (data.gas_rate ? O.some({ gas_rate: Number(data.gas_rate) }) : O.none))
+            )
+
+            return FP.pipe(
+              oChainFeeData,
+              O.fold(
+                () => Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast })),
+                (feeData) => {
+                  const extrapolatedFee = extrapolateFeeFromGasRate(feeData.gas_rate, feesWithRatesRD.value)
+                  return Rx.of(RD.success({ asset, amount: extrapolatedFee }))
+                }
+              )
+            )
+          }
+          return RD.isSuccess(feesWithRatesRD)
+            ? Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast }))
+            : Rx.of(RD.failure(new Error('Failed to load BTC fees')))
+        }),
+        RxOp.catchError(() => {
+          return FP.pipe(
+            BTC.address$.pipe(
+              RxOp.switchMap(
+                O.fold(
+                  () => Rx.of(RD.failure(new Error('No address available'))),
+                  (address) =>
+                    FP.pipe(
+                      BTC.feesWithRates$(address.address, memo),
+                      liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
+                    )
+                )
+              )
+            )
+          )
+        }),
+        RxOp.startWith(RD.pending)
       )
     case BCHChain:
+      // Use gas_rate from inbound addresses with FeesWithRates ratio
       return FP.pipe(
-        BCH.address$.pipe(
-          RxOp.switchMap(
-            O.fold(
-              () => Rx.of(RD.failure(new Error('No address available'))),
-              (address) =>
-                FP.pipe(
-                  BCH.feesWithRates$(address.address, memo),
-                  liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
-                )
+        Rx.combineLatest([
+          getInboundAddresses$(BCHChain),
+          BCH.address$.pipe(
+            RxOp.switchMap(
+              O.fold(
+                () => Rx.of(RD.initial),
+                (address) => BCH.feesWithRates$(address.address, memo)
+              )
             )
-          ),
-          RxOp.catchError((error) => Rx.of(RD.failure(error))),
-          RxOp.startWith(RD.pending)
-        )
+          )
+        ]),
+        RxOp.switchMap(([inboundAddressesRD, feesWithRatesRD]) => {
+          if (RD.isSuccess(inboundAddressesRD) && RD.isSuccess(feesWithRatesRD)) {
+            const oChainFeeData = FP.pipe(
+              inboundAddressesRD.value,
+              A.findFirst((item) => item.chain === BCHChain),
+              O.chain((data) => (data.gas_rate ? O.some({ gas_rate: Number(data.gas_rate) }) : O.none))
+            )
+
+            return FP.pipe(
+              oChainFeeData,
+              O.fold(
+                () => Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast })),
+                (feeData) => {
+                  const extrapolatedFee = extrapolateFeeFromGasRate(feeData.gas_rate, feesWithRatesRD.value)
+                  return Rx.of(RD.success({ asset, amount: extrapolatedFee }))
+                }
+              )
+            )
+          }
+          return RD.isSuccess(feesWithRatesRD)
+            ? Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast }))
+            : Rx.of(RD.failure(new Error('Failed to load BCH fees')))
+        }),
+        RxOp.catchError(() => {
+          return FP.pipe(
+            BCH.address$.pipe(
+              RxOp.switchMap(
+                O.fold(
+                  () => Rx.of(RD.failure(new Error('No address available'))),
+                  (address) =>
+                    FP.pipe(
+                      BCH.feesWithRates$(address.address, memo),
+                      liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
+                    )
+                )
+              )
+            )
+          )
+        }),
+        RxOp.startWith(RD.pending)
       )
     case THORChain:
       return FP.pipe(
@@ -585,38 +760,114 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
         liveData.map((fees) => ({ asset, amount: fees.fast }))
       )
     case DASHChain:
+      // Use gas_rate from inbound addresses with FeesWithRates ratio
       return FP.pipe(
-        DASH.address$.pipe(
-          RxOp.switchMap(
-            O.fold(
-              () => Rx.of(RD.failure(new Error('No address available'))),
-              (address) =>
-                FP.pipe(
-                  DASH.feesWithRates$(address.address, memo),
-                  liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
-                )
+        Rx.combineLatest([
+          getInboundAddresses$(DASHChain),
+          DASH.address$.pipe(
+            RxOp.switchMap(
+              O.fold(
+                () => Rx.of(RD.initial),
+                (address) => DASH.feesWithRates$(address.address, memo)
+              )
             )
-          ),
-          RxOp.catchError((error) => Rx.of(RD.failure(error))),
-          RxOp.startWith(RD.pending)
-        )
+          )
+        ]),
+        RxOp.switchMap(([inboundAddressesRD, feesWithRatesRD]) => {
+          if (RD.isSuccess(inboundAddressesRD) && RD.isSuccess(feesWithRatesRD)) {
+            const oChainFeeData = FP.pipe(
+              inboundAddressesRD.value,
+              A.findFirst((item) => item.chain === DASHChain),
+              O.chain((data) => (data.gas_rate ? O.some({ gas_rate: Number(data.gas_rate) }) : O.none))
+            )
+
+            return FP.pipe(
+              oChainFeeData,
+              O.fold(
+                () => Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast })),
+                (feeData) => {
+                  const extrapolatedFee = extrapolateFeeFromGasRate(feeData.gas_rate, feesWithRatesRD.value)
+                  return Rx.of(RD.success({ asset, amount: extrapolatedFee }))
+                }
+              )
+            )
+          }
+          return RD.isSuccess(feesWithRatesRD)
+            ? Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast }))
+            : Rx.of(RD.failure(new Error('Failed to load DASH fees')))
+        }),
+        RxOp.catchError(() => {
+          return FP.pipe(
+            DASH.address$.pipe(
+              RxOp.switchMap(
+                O.fold(
+                  () => Rx.of(RD.failure(new Error('No address available'))),
+                  (address) =>
+                    FP.pipe(
+                      DASH.feesWithRates$(address.address, memo),
+                      liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
+                    )
+                )
+              )
+            )
+          )
+        }),
+        RxOp.startWith(RD.pending)
       )
     case ZECChain:
+      // Use gas_rate from inbound addresses with FeesWithRates ratio
       return FP.pipe(
-        ZEC.address$.pipe(
-          RxOp.switchMap(
-            O.fold(
-              () => Rx.of(RD.failure(new Error('No address available'))),
-              (address) =>
-                FP.pipe(
-                  ZEC.feesWithRates$(address.address, memo),
-                  liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
-                )
+        Rx.combineLatest([
+          getInboundAddresses$(ZECChain),
+          ZEC.address$.pipe(
+            RxOp.switchMap(
+              O.fold(
+                () => Rx.of(RD.initial),
+                (address) => ZEC.feesWithRates$(address.address, memo)
+              )
             )
-          ),
-          RxOp.catchError((error) => Rx.of(RD.failure(error))),
-          RxOp.startWith(RD.pending)
-        )
+          )
+        ]),
+        RxOp.switchMap(([inboundAddressesRD, feesWithRatesRD]) => {
+          if (RD.isSuccess(inboundAddressesRD) && RD.isSuccess(feesWithRatesRD)) {
+            const oChainFeeData = FP.pipe(
+              inboundAddressesRD.value,
+              A.findFirst((item) => item.chain === ZECChain),
+              O.chain((data) => (data.gas_rate ? O.some({ gas_rate: Number(data.gas_rate) }) : O.none))
+            )
+
+            return FP.pipe(
+              oChainFeeData,
+              O.fold(
+                () => Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast })),
+                (feeData) => {
+                  const extrapolatedFee = extrapolateFeeFromGasRate(feeData.gas_rate, feesWithRatesRD.value)
+                  return Rx.of(RD.success({ asset, amount: extrapolatedFee }))
+                }
+              )
+            )
+          }
+          return RD.isSuccess(feesWithRatesRD)
+            ? Rx.of(RD.success({ asset, amount: feesWithRatesRD.value.fees.fast }))
+            : Rx.of(RD.failure(new Error('Failed to load ZEC fees')))
+        }),
+        RxOp.catchError(() => {
+          return FP.pipe(
+            ZEC.address$.pipe(
+              RxOp.switchMap(
+                O.fold(
+                  () => Rx.of(RD.failure(new Error('No address available'))),
+                  (address) =>
+                    FP.pipe(
+                      ZEC.feesWithRates$(address.address, memo),
+                      liveData.map((fees) => ({ asset, amount: fees.fees.fast }))
+                    )
+                )
+              )
+            )
+          )
+        }),
+        RxOp.startWith(RD.pending)
       )
     default:
       return FP.pipe(

--- a/src/renderer/services/chain/fees/common.ts
+++ b/src/renderer/services/chain/fees/common.ts
@@ -215,9 +215,55 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
         )
       )
     case GAIAChain:
+      // Use gas_rate from inbound addresses for more accurate fees
       return FP.pipe(
-        COSMOS.fees$(),
-        liveData.map((fees) => ({ asset, amount: fees.fast }))
+        Rx.from(getDecimal(asset)),
+        RxOp.switchMap((decimal) =>
+          FP.pipe(
+            getInboundAddresses$(GAIAChain),
+            liveData.map((inboundAddresses) => {
+              const oChainFeeData = FP.pipe(
+                inboundAddresses,
+                A.findFirst((item) => item.chain === GAIAChain),
+                O.chain((data) =>
+                  data.gas_rate
+                    ? O.some({
+                        gas_rate: data.gas_rate,
+                        gas_rate_units: data.gas_rate_units
+                      })
+                    : O.none
+                )
+              )
+
+              return FP.pipe(
+                oChainFeeData,
+                O.fold(
+                  // Fallback to generic COSMOS fees if inbound data not available
+                  () => ({ asset, amount: baseAmount(5000, decimal) }), // Default fallback
+                  (feeData) => ({
+                    asset,
+                    amount: baseAmount(feeData.gas_rate, decimal)
+                  })
+                )
+              )
+            }),
+            liveData.chainOnError(() => {
+              // Final fallback to COSMOS service
+              return FP.pipe(
+                COSMOS.fees$(),
+                liveData.map((fees) => ({ asset, amount: fees.fast }))
+              )
+            })
+          )
+        ),
+        RxOp.catchError(() => {
+          // If getDecimal fails, fallback to COSMOS service
+          return FP.pipe(
+            COSMOS.fees$(),
+            liveData.map((fees) => ({ asset, amount: fees.fast }))
+          )
+        }),
+        RxOp.startWith(RD.pending)
       )
     case ETHChain:
       // Use poolInTxFees$ with actual address address for accurate gas estimation

--- a/src/renderer/services/chain/fees/common.ts
+++ b/src/renderer/services/chain/fees/common.ts
@@ -339,9 +339,7 @@ export const poolInboundFee$ = (asset: AnyAsset, memo: string): PoolFeeLD => {
                 () => Rx.of(RD.success({ asset, amount: feesRD.value.fast })),
                 (feeData) => {
                   // For COSMOS chains, we need to estimate gas units for the transaction
-                  // A typical Cosmos tx with memo uses approximately 200,000 gas units
-                  const GAS_UNITS_ESTIMATE = 200000
-                  const calculatedFee = feeData.gas_rate * GAS_UNITS_ESTIMATE
+                  const calculatedFee = feeData.gas_rate
                   return Rx.of(
                     RD.success({
                       asset,

--- a/src/shared/const.ts
+++ b/src/shared/const.ts
@@ -25,7 +25,7 @@ export const ASGARDEX_IDENTIFIER = 999
 
 export const ASGARDEX_ADDRESS = 'thor1rr6rahhd4sy76a7rdxkjaen2q4k4pw2g06w7qp'
 
-export const ASGARDEX_AFFILIATE_FEE = 30
+export const ASGARDEX_AFFILIATE_FEE = 0
 export const ASGARDEX_TRADE_AFFILIATE_FEE = 15
 export const ASGARDEX_THORNAME = envOrDefault(import.meta.env.VITE_ASGARDEX_THORNAME, 'dx')
 

--- a/src/shared/const.ts
+++ b/src/shared/const.ts
@@ -25,7 +25,7 @@ export const ASGARDEX_IDENTIFIER = 999
 
 export const ASGARDEX_ADDRESS = 'thor1rr6rahhd4sy76a7rdxkjaen2q4k4pw2g06w7qp'
 
-export const ASGARDEX_AFFILIATE_FEE = 0
+export const ASGARDEX_AFFILIATE_FEE = 30
 export const ASGARDEX_TRADE_AFFILIATE_FEE = 15
 export const ASGARDEX_THORNAME = envOrDefault(import.meta.env.VITE_ASGARDEX_THORNAME, 'dx')
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dynamic, data-driven fee estimation using inbound gas rates for multiple chains (GAIA, BTC, BCH, DOGE, LTC, DASH, ZEC) to improve accuracy.
  - Swap amount logic simplified: UTXO safety buffer removed, min/max swap calculations use consistent base conversion and fee subtraction.

- Bug Fixes
  - More robust fallback handling for fee retrieval to ensure reliable fee display when network data is missing or errors occur.

- Chores
  - Affiliate fee on mainnet set to 0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->