### PR TITLE
add proper staple & bump aggregator package

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@mayaprotocol/zcash-js": "^1.0.7",
     "@reduxjs/toolkit": "^2.3.0",
     "@tanstack/react-table": "^8.21.3",
-    "@xchainjs/xchain-aggregator": "2.0.24",
+    "@xchainjs/xchain-aggregator": "2.0.25",
     "@xchainjs/xchain-arbitrum": "2.0.12",
     "@xchainjs/xchain-avax": "2.0.12",
     "@xchainjs/xchain-base": "1.0.12",

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -2,7 +2,7 @@ require('dotenv/config')
 const { writeFileSync, mkdtempSync, chmodSync, rmSync } = require('fs')
 const { tmpdir } = require('os')
 const { join } = require('path')
-const { notarize } = require('@electron/notarize')
+const { notarize, stapleApp } = require('@electron/notarize')
 
 /*
  Pre-requisites: https://github.com/electron/electron-notarize#prerequisites
@@ -98,7 +98,14 @@ module.exports = async function notarizing(context) {
       try {
         console.log(`Notarization attempt ${attempt}/${maxRetries}`)
         await notarize(options)
-        console.log('Notarization and stapling successful')
+        console.log('Notarization successful')
+
+        // Staple the notarized app
+        console.log('Starting stapling process...')
+        await stapleApp({ appPath: options.appPath })
+        console.log('Stapling successful')
+
+        console.log('Notarization and stapling completed successfully')
         return
       } catch (error) {
         lastError = error

--- a/yarn.lock
+++ b/yarn.lock
@@ -5586,9 +5586,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xchainjs/xchain-aggregator@npm:2.0.24":
-  version: 2.0.24
-  resolution: "@xchainjs/xchain-aggregator@npm:2.0.24"
+"@xchainjs/xchain-aggregator@npm:2.0.25":
+  version: 2.0.25
+  resolution: "@xchainjs/xchain-aggregator@npm:2.0.25"
   dependencies:
     "@chainflip/sdk": "npm:^1.10.1"
     "@trpc/server": "npm:^10.45.2"
@@ -5597,11 +5597,11 @@ __metadata:
     "@xchainjs/xchain-mayachain-amm": "npm:4.1.1"
     "@xchainjs/xchain-mayachain-query": "npm:2.1.1"
     "@xchainjs/xchain-thorchain": "npm:3.0.13"
-    "@xchainjs/xchain-thorchain-amm": "npm:3.0.21"
+    "@xchainjs/xchain-thorchain-amm": "npm:3.0.22"
     "@xchainjs/xchain-thorchain-query": "npm:2.0.13"
     "@xchainjs/xchain-util": "npm:2.0.5"
     "@xchainjs/xchain-wallet": "npm:2.0.17"
-  checksum: 10/81b9ef46d26b4fd1c5cb3fd3cc22f17ff08f14f535ab4a6bf6b99c46b282929728d7a2db223088042c42f12dc466c33600adf040b72fcadd81dfa00e97a78da9
+  checksum: 10/5d76dd149d844917fb49e825237d0ca7ade21f4263d2043fbbf73db9613b2c5e26a457717220987825838c81cac5355b9b73409c68fe52a4acfa274a97e6920e
   languageName: node
   linkType: hard
 
@@ -6067,9 +6067,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xchainjs/xchain-thorchain-amm@npm:3.0.21":
-  version: 3.0.21
-  resolution: "@xchainjs/xchain-thorchain-amm@npm:3.0.21"
+"@xchainjs/xchain-thorchain-amm@npm:3.0.22":
+  version: 3.0.22
+  resolution: "@xchainjs/xchain-thorchain-amm@npm:3.0.22"
   dependencies:
     "@xchainjs/xchain-avax": "npm:2.0.12"
     "@xchainjs/xchain-base": "npm:1.0.12"
@@ -6090,7 +6090,7 @@ __metadata:
     "@xchainjs/xchain-util": "npm:2.0.5"
     "@xchainjs/xchain-wallet": "npm:2.0.17"
     ethers: "npm:^6.14.3"
-  checksum: 10/81ec809d2453c4b8fe10aff04b424fff5cb62cc3d27aab1520e96aea6dc26e3b4e49207b1ed72b46b2414dd876c220df6685d17987fce4522139e7f7e85bc981
+  checksum: 10/394029c4242fe0aa5100bce13e0b1709dc53dffa6bab7d44220966d6104d3de181235cc00c50ab0dc1adb85b19b56f2ec65070b61c84857f8bc25da54d3ec1c9
   languageName: node
   linkType: hard
 
@@ -6718,7 +6718,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^7.18.0"
     "@vitejs/plugin-react": "npm:^4.4.1"
     "@vitest/ui": "npm:^3.1.3"
-    "@xchainjs/xchain-aggregator": "npm:2.0.24"
+    "@xchainjs/xchain-aggregator": "npm:2.0.25"
     "@xchainjs/xchain-arbitrum": "npm:2.0.12"
     "@xchainjs/xchain-avax": "npm:2.0.12"
     "@xchainjs/xchain-base": "npm:1.0.12"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated dependency: @xchainjs/xchain-aggregator to 2.0.25.
  * Improved macOS release process by stapling notarization to the app after successful notarization, enhancing offline launch reliability and Gatekeeper trust. Updated build logs to reflect notarization and stapling steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->