### PR TITLE
chore: hide synth from asset select

### DIFF
--- a/src/renderer/components/uielements/assets/assetMenu/AssetMenu.tsx
+++ b/src/renderer/components/uielements/assets/assetMenu/AssetMenu.tsx
@@ -32,7 +32,6 @@ export enum ExtendedAssetType {
   All = 'all',
   Favorite = 'favorite',
   Native = AssetType.NATIVE,
-  Synth = AssetType.SYNTH,
   Secured = AssetType.SECURED
 }
 
@@ -44,10 +43,6 @@ export const filterButtons = [
   {
     text: 'Native',
     type: ExtendedAssetType.Native
-  },
-  {
-    text: 'Synth',
-    type: ExtendedAssetType.Synth
   },
   {
     text: 'Secured',
@@ -91,10 +86,9 @@ export const AssetMenu = (props: Props): JSX.Element => {
         assets,
         A.filter((asset) => {
           // if synth asset is disabled for To Asset type
-          if (synthDisabled && asset.type === AssetType.SYNTH) return false
+          if (asset.type === AssetType.SYNTH) return false
 
           if (activeFilter === ExtendedAssetType.Native && asset.type !== AssetType.NATIVE) return false
-          if (activeFilter === ExtendedAssetType.Synth && asset.type !== AssetType.SYNTH) return false
           if (activeFilter === ExtendedAssetType.Secured && asset.type !== AssetType.SECURED) return false
 
           if (searchValue) {
@@ -105,7 +99,7 @@ export const AssetMenu = (props: Props): JSX.Element => {
           return true
         })
       ),
-    [activeFilter, assets, searchValue, synthDisabled]
+    [activeFilter, assets, searchValue]
   )
 
   const renderAssets = useMemo(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed Synth filter option from the asset menu
  * Synth assets are now permanently excluded from asset selection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->