### PR TITLE
Centralize EnhancedClient logic

### DIFF
--- a/src/renderer/services/arb/balances.ts
+++ b/src/renderer/services/arb/balances.ts
@@ -1,43 +1,22 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { ARBChain } from '@xchainjs/xchain-arbitrum'
 import { Network } from '@xchainjs/xchain-client'
-import { function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
+import { function as FP } from 'fp-ts'
 import { of } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
-import * as RxOp from 'rxjs/operators'
 
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { ARBAssetsFallback, ArbAssetsTestnet } from '../../const'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
+import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`

--- a/src/renderer/services/avax/balances.ts
+++ b/src/renderer/services/avax/balances.ts
@@ -1,43 +1,22 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { AVAXChain } from '@xchainjs/xchain-avax'
 import { Network } from '@xchainjs/xchain-client'
-import { function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
+import { function as FP } from 'fp-ts'
 import { of } from 'rxjs'
-import * as RxOp from 'rxjs/operators'
 import { switchMap } from 'rxjs/operators'
 
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { AVAXAssetsFallback, AvaxAssetsTestnet } from '../../const'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
+import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`

--- a/src/renderer/services/base/balances.ts
+++ b/src/renderer/services/base/balances.ts
@@ -1,43 +1,22 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { BASEChain } from '@xchainjs/xchain-base'
 import { Network } from '@xchainjs/xchain-client'
-import { function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
+import { function as FP } from 'fp-ts'
 import { of } from 'rxjs'
 import { switchMap } from 'rxjs/operators'
-import * as RxOp from 'rxjs/operators'
 
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { BASEAssetsFallback } from '../../const'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
+import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`

--- a/src/renderer/services/bitcoin/balances.ts
+++ b/src/renderer/services/bitcoin/balances.ts
@@ -1,11 +1,7 @@
-import { option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
-import * as RxOp from 'rxjs/operators'
 import { HDMode, WalletBalanceType, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
+import { createEnhancedClient$ } from '../clients'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -18,26 +14,8 @@ const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observable
 
 /**
  * Enhanced client that falls back to read-only client for standalone ledger mode
- * When keystore is locked but we're in standalone ledger mode, use read-only client for balance queries
  */
-const enhancedClient$ = Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]).pipe(
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    // If we have a keystore client (unlocked wallet), use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 const resetReloadBalances = (walletType: WalletType) => {
   if (walletType === WalletType.Keystore) {

--- a/src/renderer/services/bitcoincash/balances.ts
+++ b/src/renderer/services/bitcoincash/balances.ts
@@ -1,36 +1,13 @@
-import { function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
-import * as RxOp from 'rxjs/operators'
-
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
+import { createEnhancedClient$ } from '../clients'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`

--- a/src/renderer/services/bsc/balances.ts
+++ b/src/renderer/services/bsc/balances.ts
@@ -2,10 +2,8 @@ import * as RD from '@devexperts/remote-data-ts'
 import { BSCChain } from '@xchainjs/xchain-bsc'
 import { Network } from '@xchainjs/xchain-client'
 import { AnyAsset } from '@xchainjs/xchain-util'
-import { array as A, function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
+import { array as A, function as FP } from 'fp-ts'
 import { of } from 'rxjs'
-import * as RxOp from 'rxjs/operators'
 import { switchMap } from 'rxjs/operators'
 
 import { HDMode, WalletType } from '../../../shared/wallet/types'
@@ -13,33 +11,15 @@ import { BSCAssetsFallBack, BscAssetsTestnet } from '../../const'
 import { liveData } from '../../helpers/rx/liveData'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
+import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode, WalletBalance } from '../wallet/types'
+import { WalletBalance } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`

--- a/src/renderer/services/clients/enhancedClient.ts
+++ b/src/renderer/services/clients/enhancedClient.ts
@@ -5,6 +5,9 @@ import * as RxOp from 'rxjs/operators'
 import { appWalletService } from '../wallet/appWallet'
 import { isStandaloneLedgerMode } from '../wallet/types'
 
+// Custom equality for Option types using reference equality on the wrapped value
+const optionEq = <C>() => O.getEq<C>({ equals: (a, b) => a === b })
+
 /**
  * Factory to create an enhanced client observable that:
  * 1. Uses keystore client when available (phrase unlocked)
@@ -32,6 +35,6 @@ export const createEnhancedClient$ = <C>(
       // No client available
       return O.none
     }),
-    RxOp.distinctUntilChanged(),
+    RxOp.distinctUntilChanged((prev, curr) => optionEq<C>().equals(prev, curr)),
     RxOp.shareReplay({ bufferSize: 1, refCount: true })
   )

--- a/src/renderer/services/clients/enhancedClient.ts
+++ b/src/renderer/services/clients/enhancedClient.ts
@@ -1,0 +1,37 @@
+import { option as O } from 'fp-ts'
+import * as Rx from 'rxjs'
+import * as RxOp from 'rxjs/operators'
+
+import { appWalletService } from '../wallet/appWallet'
+import { isStandaloneLedgerMode } from '../wallet/types'
+
+/**
+ * Factory to create an enhanced client observable that:
+ * 1. Uses keystore client when available (phrase unlocked)
+ * 2. Falls back to read-only client for standalone modes (Ledger)
+ * 3. Returns O.none when no client is available
+ *
+ * This centralizes wallet mode switching logic in one place.
+ */
+export const createEnhancedClient$ = <C>(
+  client$: Rx.Observable<O.Option<C>>,
+  readOnlyClient$: Rx.Observable<O.Option<C>>
+): Rx.Observable<O.Option<C>> =>
+  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]).pipe(
+    RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
+      // Keystore client available (has phrase) - use it
+      if (O.isSome(keystoreClient)) {
+        return keystoreClient
+      }
+
+      // Standalone mode (Ledger) - use read-only client
+      if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
+        return readOnlyClient
+      }
+
+      // No client available
+      return O.none
+    }),
+    RxOp.distinctUntilChanged(),
+    RxOp.shareReplay({ bufferSize: 1, refCount: true })
+  )

--- a/src/renderer/services/clients/index.ts
+++ b/src/renderer/services/clients/index.ts
@@ -1,5 +1,6 @@
 export * from './address'
 export * from './common'
+export * from './enhancedClient'
 export * from './types'
 export * from './balances'
 export * from './transaction'

--- a/src/renderer/services/cosmos/balances.ts
+++ b/src/renderer/services/cosmos/balances.ts
@@ -1,36 +1,13 @@
-import { function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
-import * as RxOp from 'rxjs/operators'
-
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
+import { createEnhancedClient$ } from '../clients'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`

--- a/src/renderer/services/dash/balances.ts
+++ b/src/renderer/services/dash/balances.ts
@@ -1,36 +1,13 @@
-import { function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
-import * as RxOp from 'rxjs/operators'
-
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
+import { createEnhancedClient$ } from '../clients'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`

--- a/src/renderer/services/doge/balances.ts
+++ b/src/renderer/services/doge/balances.ts
@@ -1,36 +1,13 @@
-import { function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
-import * as RxOp from 'rxjs/operators'
-
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
+import { createEnhancedClient$ } from '../clients'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`

--- a/src/renderer/services/ethereum/balances.ts
+++ b/src/renderer/services/ethereum/balances.ts
@@ -2,45 +2,22 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Network } from '@xchainjs/xchain-client'
 import { ETHChain } from '@xchainjs/xchain-ethereum'
 import { TokenAsset } from '@xchainjs/xchain-util'
-import { function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
+import { function as FP } from 'fp-ts'
 import { of } from 'rxjs'
-import * as RxOp from 'rxjs/operators'
 import { switchMap } from 'rxjs/operators'
 
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { ETHAssetsFallBack, ETHAssetsTestnet } from '../../const'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
+import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    const isStandalone = appWalletState && isStandaloneLedgerMode(appWalletState)
-
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (isStandalone && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`

--- a/src/renderer/services/litecoin/balances.ts
+++ b/src/renderer/services/litecoin/balances.ts
@@ -1,36 +1,13 @@
-import { function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
-import * as RxOp from 'rxjs/operators'
-
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
+import { createEnhancedClient$ } from '../clients'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`

--- a/src/renderer/services/ripple/balances.ts
+++ b/src/renderer/services/ripple/balances.ts
@@ -1,11 +1,7 @@
-import { option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
-import * as RxOp from 'rxjs/operators'
 import { HDMode, WalletBalanceType, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
+import { createEnhancedClient$ } from '../clients'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -18,26 +14,8 @@ const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observable
 
 /**
  * Enhanced client that falls back to read-only client for standalone ledger mode
- * When keystore is locked but we're in standalone ledger mode, use read-only client for balance queries
  */
-const enhancedClient$ = Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]).pipe(
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    // If we have a keystore client (unlocked wallet), use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 const resetReloadBalances = (walletType: WalletType) => {
   if (walletType === WalletType.Keystore) {

--- a/src/renderer/services/solana/balances.ts
+++ b/src/renderer/services/solana/balances.ts
@@ -1,38 +1,13 @@
-import { function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
-import * as RxOp from 'rxjs/operators'
-
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
+import { createEnhancedClient$ } from '../clients'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    const isStandalone = appWalletState && isStandaloneLedgerMode(appWalletState)
-
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (isStandalone && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`

--- a/src/renderer/services/thorchain/balances.ts
+++ b/src/renderer/services/thorchain/balances.ts
@@ -1,11 +1,7 @@
-import { option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
-import * as RxOp from 'rxjs/operators'
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
+import { createEnhancedClient$ } from '../clients'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -35,24 +31,7 @@ const reloadBalances = (walletType: WalletType) => {
 /**
  * Enhanced client that falls back to read-only client for standalone ledger mode
  */
-const enhancedClient$ = Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]).pipe(
-  RxOp.map(([client, readOnlyClient, appWalletState]) => {
-    // If we have a regular client, use it
-    if (O.isSome(client)) {
-      return client
-    }
-
-    // If we're in standalone ledger mode and have read-only client, use read-only
-    if (appWalletState && isStandaloneLedgerMode(appWalletState) && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 // State of balances loaded by Client
 // Removed this list

--- a/src/renderer/services/tron/balances.ts
+++ b/src/renderer/services/tron/balances.ts
@@ -2,45 +2,22 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Network } from '@xchainjs/xchain-client'
 import { TRONChain } from '@xchainjs/xchain-tron'
 import { TokenAsset } from '@xchainjs/xchain-util'
-import { function as FP, option as O } from 'fp-ts'
-import * as Rx from 'rxjs'
+import { function as FP } from 'fp-ts'
 import { of } from 'rxjs'
-import * as RxOp from 'rxjs/operators'
 import { switchMap } from 'rxjs/operators'
 
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { TRONAssetsFallBack } from '../../const'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
+import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
-import { appWalletService } from '../wallet/appWallet'
-import { isStandaloneLedgerMode } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
  * Enhanced client that switches between keystore and read-only client for standalone ledger mode
  */
-const enhancedClient$ = FP.pipe(
-  Rx.combineLatest([client$, readOnlyClient$, appWalletService.appWalletState$]),
-  RxOp.map(([keystoreClient, readOnlyClient, appWalletState]) => {
-    const isStandalone = appWalletState && isStandaloneLedgerMode(appWalletState)
-
-    // If keystore client is available, use it
-    if (O.isSome(keystoreClient)) {
-      return keystoreClient
-    }
-
-    // If keystore is locked but we're in standalone ledger mode, use read-only client
-    if (isStandalone && O.isSome(readOnlyClient)) {
-      return readOnlyClient
-    }
-
-    // Otherwise, no client available
-    return O.none
-  }),
-  RxOp.distinctUntilChanged(),
-  RxOp.shareReplay({ bufferSize: 1, refCount: true })
-)
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`


### PR DESCRIPTION
Removes duplicated logic in the chain transaction.ts files. 
This will allow wallet mode checking to be in one place. 

Summary of changes
  - Created src/renderer/services/clients/enhancedClient.ts (factory)                                           
  - Updated src/renderer/services/clients/index.ts (export)                                                     
  - Updated 15 chain balance files to use the factory                                                           
  - Skipped special cases (zcash, kuji, cardano, radix, mayachain)  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified client selection logic across all blockchain balance services into a single shared helper. This reduces duplicate logic, streamlines behavior for keystore vs read-only clients, and improves maintainability without changing external behavior or user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->