### PR TITLE
Refactor/unified balance pattern: centralize wallet type logic for trigger selection     

### DIFF
--- a/src/renderer/services/arb/balances.ts
+++ b/src/renderer/services/arb/balances.ts
@@ -11,6 +11,7 @@ import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -27,7 +28,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -35,7 +36,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -56,12 +57,15 @@ const balances$: ({
   walletIndex: number
   hdMode: HDMode
 }) => C.WalletBalancesLD = ({ walletType, walletAccount, walletIndex, hdMode }) => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
   return FP.pipe(
     getUserAssetsByChain$(ARBChain),
     switchMap((assets) => {
       return C.balances$({
         client$: enhancedClient$,
-        trigger$: reloadBalances$,
+        trigger$,
         assets: assets,
         walletType,
         walletAccount,
@@ -76,7 +80,7 @@ const balances$: ({
         // Retry with fallback assets
         return C.balances$({
           client$: enhancedClient$,
-          trigger$: reloadBalances$,
+          trigger$,
           assets: ARBAssetsFallback,
           walletType,
           walletAccount,

--- a/src/renderer/services/avax/balances.ts
+++ b/src/renderer/services/avax/balances.ts
@@ -11,6 +11,7 @@ import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -27,7 +28,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -35,7 +36,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -55,12 +56,15 @@ const balances$: ({
   walletIndex: number
   hdMode: HDMode
 }) => C.WalletBalancesLD = ({ walletType, walletAccount, walletIndex, hdMode }) => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
   return FP.pipe(
     getUserAssetsByChain$(AVAXChain),
     switchMap((assets) => {
       return C.balances$({
         client$: enhancedClient$,
-        trigger$: reloadBalances$,
+        trigger$,
         assets: assets,
         walletType,
         walletAccount,
@@ -75,7 +79,7 @@ const balances$: ({
         // Retry with fallback assets
         return C.balances$({
           client$: enhancedClient$,
-          trigger$: reloadBalances$,
+          trigger$,
           assets: AVAXAssetsFallback,
           walletType,
           walletAccount,

--- a/src/renderer/services/base/balances.ts
+++ b/src/renderer/services/base/balances.ts
@@ -11,6 +11,7 @@ import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -27,7 +28,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -35,7 +36,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -56,12 +57,15 @@ const balances$: ({
   walletIndex: number
   hdMode: HDMode
 }) => C.WalletBalancesLD = ({ walletType, walletAccount, walletIndex, hdMode }) => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
   return FP.pipe(
     getUserAssetsByChain$(BASEChain),
     switchMap((assets) => {
       return C.balances$({
         client$: enhancedClient$,
-        trigger$: reloadBalances$,
+        trigger$,
         assets: assets,
         walletType,
         walletAccount,
@@ -76,7 +80,7 @@ const balances$: ({
         // Retry with fallback assets
         return C.balances$({
           client$: enhancedClient$,
-          trigger$: reloadBalances$,
+          trigger$,
           assets: BASEAssetsFallback,
           walletType,
           walletAccount,

--- a/src/renderer/services/bitcoin/balances.ts
+++ b/src/renderer/services/bitcoin/balances.ts
@@ -2,6 +2,7 @@ import { HDMode, WalletBalanceType, WalletType } from '../../../shared/wallet/ty
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -18,7 +19,7 @@ const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observable
 const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -26,7 +27,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -45,16 +46,20 @@ const balances$ = ({
   walletIndex: number
   walletBalanceType: WalletBalanceType
   hdMode: HDMode
-}): C.WalletBalancesLD =>
-  C.balances$({
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
+  return C.balances$({
     client$: enhancedClient$,
-    trigger$: reloadBalances$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType
   })
+}
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = (walletBalanceType: WalletBalanceType) =>

--- a/src/renderer/services/bitcoincash/balances.ts
+++ b/src/renderer/services/bitcoincash/balances.ts
@@ -2,6 +2,7 @@ import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -18,7 +19,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -26,7 +27,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -43,16 +44,20 @@ const balances$ = ({
   walletAccount: number
   walletIndex: number
   hdMode: HDMode
-}): C.WalletBalancesLD =>
-  C.balances$({
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
+  return C.balances$({
     client$: enhancedClient$,
-    trigger$: reloadBalances$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType: 'all'
   })
+}
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = C.balancesByAddress$({

--- a/src/renderer/services/bsc/balances.ts
+++ b/src/renderer/services/bsc/balances.ts
@@ -13,7 +13,7 @@ import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
-import { WalletBalance } from '../wallet/types'
+import { isKeystoreReloadTrigger, WalletBalance } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -30,7 +30,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -38,7 +38,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -70,12 +70,15 @@ const balances$: ({
   walletIndex: number
   hdMode: HDMode
 }) => C.WalletBalancesLD = ({ walletType, walletAccount, walletIndex, hdMode }) => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
   return FP.pipe(
     getUserAssetsByChain$(BSCChain),
     switchMap((assets) => {
       return C.balances$({
         client$: enhancedClient$,
-        trigger$: reloadBalances$,
+        trigger$,
         assets: assets,
         walletType,
         walletAccount,
@@ -91,7 +94,7 @@ const balances$: ({
         // Retry with fallback assets
         return C.balances$({
           client$: enhancedClient$,
-          trigger$: reloadBalances$,
+          trigger$,
           assets: BSCAssetsFallBack,
           walletType,
           walletAccount,

--- a/src/renderer/services/cosmos/balances.ts
+++ b/src/renderer/services/cosmos/balances.ts
@@ -2,6 +2,7 @@ import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -18,7 +19,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -26,7 +27,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -44,16 +45,20 @@ const balances$ = ({
   walletAccount: number
   walletIndex: number
   hdMode: HDMode
-}): C.WalletBalancesLD =>
-  C.balances$({
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
+  return C.balances$({
     client$: enhancedClient$,
-    trigger$: reloadBalances$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType: 'all'
   })
+}
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = C.balancesByAddress$({

--- a/src/renderer/services/dash/balances.ts
+++ b/src/renderer/services/dash/balances.ts
@@ -2,6 +2,7 @@ import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -18,7 +19,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -26,7 +27,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -44,16 +45,20 @@ const balances$ = ({
   walletAccount: number
   walletIndex: number
   hdMode: HDMode
-}): C.WalletBalancesLD =>
-  C.balances$({
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
+  return C.balances$({
     client$: enhancedClient$,
-    trigger$: reloadBalances$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType: 'all'
   })
+}
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = C.balancesByAddress$({

--- a/src/renderer/services/doge/balances.ts
+++ b/src/renderer/services/doge/balances.ts
@@ -2,6 +2,7 @@ import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -18,7 +19,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -26,7 +27,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -44,16 +45,20 @@ const balances$ = ({
   walletAccount: number
   walletIndex: number
   hdMode: HDMode
-}): C.WalletBalancesLD =>
-  C.balances$({
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
+  return C.balances$({
     client$: enhancedClient$,
-    trigger$: reloadBalances$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType: 'all'
   })
+}
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = C.balancesByAddress$({

--- a/src/renderer/services/ethereum/balances.ts
+++ b/src/renderer/services/ethereum/balances.ts
@@ -12,6 +12,7 @@ import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -28,7 +29,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -36,7 +37,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -56,12 +57,15 @@ const balances$: ({
   walletIndex: number
   hdMode: HDMode
 }) => C.WalletBalancesLD = ({ walletType, walletAccount, walletIndex, hdMode }) => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
   return FP.pipe(
     getUserAssetsByChain$(ETHChain),
     switchMap((assets) => {
       return C.balances$({
         client$: enhancedClient$,
-        trigger$: reloadBalances$,
+        trigger$,
         assets: assets,
         walletType,
         walletAccount,
@@ -74,7 +78,7 @@ const balances$: ({
       RD.isFailure(balanceResult)
         ? C.balances$({
             client$: enhancedClient$,
-            trigger$: reloadBalances$,
+            trigger$,
             assets: ETHAssetsFallBack,
             walletType,
             walletAccount,

--- a/src/renderer/services/litecoin/balances.ts
+++ b/src/renderer/services/litecoin/balances.ts
@@ -2,6 +2,7 @@ import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -18,7 +19,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -26,7 +27,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -44,16 +45,20 @@ const balances$ = ({
   walletAccount: number
   walletIndex: number
   hdMode: HDMode
-}): C.WalletBalancesLD =>
-  C.balances$({
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
+  return C.balances$({
     client$: enhancedClient$,
-    trigger$: reloadBalances$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType: 'all'
   })
+}
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = C.balancesByAddress$({

--- a/src/renderer/services/ripple/balances.ts
+++ b/src/renderer/services/ripple/balances.ts
@@ -2,6 +2,7 @@ import { HDMode, WalletBalanceType, WalletType } from '../../../shared/wallet/ty
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -18,7 +19,7 @@ const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observable
 const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -26,7 +27,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -46,16 +47,20 @@ const balances$ = ({
   walletIndex: number
   walletBalanceType: WalletBalanceType
   hdMode: HDMode
-}): C.WalletBalancesLD =>
-  C.balances$({
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
+  return C.balances$({
     client$: enhancedClient$,
-    trigger$: reloadBalances$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType
   })
+}
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = (walletBalanceType: WalletBalanceType) =>

--- a/src/renderer/services/thorchain/balances.ts
+++ b/src/renderer/services/thorchain/balances.ts
@@ -2,6 +2,7 @@ import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -13,7 +14,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -21,7 +22,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -45,16 +46,20 @@ const balances$ = ({
   walletAccount: number
   walletIndex: number
   hdMode: HDMode
-}): C.WalletBalancesLD =>
-  C.balances$({
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
+  return C.balances$({
     client$: enhancedClient$,
-    trigger$: reloadBalances$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType: 'all'
   })
+}
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = C.balancesByAddress$({

--- a/src/renderer/services/tron/balances.ts
+++ b/src/renderer/services/tron/balances.ts
@@ -12,6 +12,7 @@ import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
 import { getUserAssetsByChain$ } from '../storage/userChainTokens'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$, readOnlyClient$ } from './common'
 
 /**
@@ -28,7 +29,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -36,7 +37,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -56,12 +57,15 @@ const balances$: ({
   walletIndex: number
   hdMode: HDMode
 }) => C.WalletBalancesLD = ({ walletType, walletAccount, walletIndex, hdMode }) => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
   return FP.pipe(
     getUserAssetsByChain$(TRONChain),
     switchMap((assets) => {
       return C.balances$({
         client$: enhancedClient$,
-        trigger$: reloadBalances$,
+        trigger$,
         assets: assets,
         walletType,
         walletAccount,
@@ -74,7 +78,7 @@ const balances$: ({
       RD.isFailure(balanceResult)
         ? C.balances$({
             client$: enhancedClient$,
-            trigger$: reloadBalances$,
+            trigger$,
             assets: TRONAssetsFallBack,
             walletType,
             walletAccount,

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -26,7 +26,6 @@ import * as RxOp from 'rxjs/operators'
 
 import { isSupportedChain } from '../../../shared/utils/chain'
 import { HDMode, WalletAddress, WalletBalanceType, WalletType } from '../../../shared/wallet/types'
-import { DEFAULT_WALLET_TYPE } from '../../const'
 import { eqBalancesRD } from '../../helpers/fp/eq'
 import { sequenceTOptionFromArray } from '../../helpers/fpHelpers'
 import { liveData } from '../../helpers/rx/liveData'
@@ -82,30 +81,35 @@ export const createBalancesService = ({
   appWalletService: import('./types').AppWalletService
   isStandaloneLedgerMode: (state: import('./types').AppWalletState) => boolean
 }): BalancesService => {
-  // reload all balances
+  // reload all balances - derives wallet type from appWalletState$
   const reloadBalances: FP.Lazy<void> = () => {
-    userChains$.pipe(RxOp.take(1)).subscribe((enabledChains) => {
-      if (enabledChains.includes(BTCChain)) BTC.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(DASHChain)) DASH.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(BCHChain)) BCH.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(ETHChain)) ETH.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(ARBChain)) ARB.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(AVAXChain)) AVAX.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(BASEChain)) BASE.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(BSCChain)) BSC.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(THORChain)) THOR.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(MAYAChain)) MAYA.reloadBalances()
-      if (enabledChains.includes(LTCChain)) LTC.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(DOGEChain)) DOGE.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(GAIAChain)) COSMOS.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(KUJIChain)) KUJI.reloadBalances()
-      if (enabledChains.includes(ADAChain)) ADA.reloadBalances()
-      if (enabledChains.includes(XRPChain)) XRP.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(RadixChain)) XRD.reloadBalances()
-      if (enabledChains.includes(SOLChain)) SOL.reloadBalances()
-      if (enabledChains.includes(TRONChain)) TRON.reloadBalances(DEFAULT_WALLET_TYPE)
-      if (enabledChains.includes(ZECChain)) ZEC.reloadBalances(DEFAULT_WALLET_TYPE)
-    })
+    Rx.combineLatest([userChains$, appWalletService.appWalletState$])
+      .pipe(RxOp.take(1))
+      .subscribe(([enabledChains, appWalletState]) => {
+        // Derive wallet type from app wallet state
+        const walletType = isStandaloneLedgerMode(appWalletState) ? WalletType.Ledger : WalletType.Keystore
+
+        if (enabledChains.includes(BTCChain)) BTC.reloadBalances(walletType)
+        if (enabledChains.includes(DASHChain)) DASH.reloadBalances(walletType)
+        if (enabledChains.includes(BCHChain)) BCH.reloadBalances(walletType)
+        if (enabledChains.includes(ETHChain)) ETH.reloadBalances(walletType)
+        if (enabledChains.includes(ARBChain)) ARB.reloadBalances(walletType)
+        if (enabledChains.includes(AVAXChain)) AVAX.reloadBalances(walletType)
+        if (enabledChains.includes(BASEChain)) BASE.reloadBalances(walletType)
+        if (enabledChains.includes(BSCChain)) BSC.reloadBalances(walletType)
+        if (enabledChains.includes(THORChain)) THOR.reloadBalances(walletType)
+        if (enabledChains.includes(MAYAChain)) MAYA.reloadBalances()
+        if (enabledChains.includes(LTCChain)) LTC.reloadBalances(walletType)
+        if (enabledChains.includes(DOGEChain)) DOGE.reloadBalances(walletType)
+        if (enabledChains.includes(GAIAChain)) COSMOS.reloadBalances(walletType)
+        if (enabledChains.includes(KUJIChain)) KUJI.reloadBalances()
+        if (enabledChains.includes(ADAChain)) ADA.reloadBalances()
+        if (enabledChains.includes(XRPChain)) XRP.reloadBalances(walletType)
+        if (enabledChains.includes(RadixChain)) XRD.reloadBalances()
+        if (enabledChains.includes(SOLChain)) SOL.reloadBalances()
+        if (enabledChains.includes(TRONChain)) TRON.reloadBalances(walletType)
+        if (enabledChains.includes(ZECChain)) ZEC.reloadBalances(walletType)
+      })
   }
 
   // Returns lazy functions to reload balances by given chain

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -62,7 +62,8 @@ import {
   KeystoreState,
   ChainBalance,
   GetLedgerAddressHandler,
-  StandaloneLedgerState
+  StandaloneLedgerState,
+  getWalletTypeFromState
 } from './types'
 import { hasImportedKeystore } from './util'
 
@@ -86,8 +87,7 @@ export const createBalancesService = ({
     Rx.combineLatest([userChains$, appWalletService.appWalletState$])
       .pipe(RxOp.take(1))
       .subscribe(([enabledChains, appWalletState]) => {
-        // Derive wallet type from app wallet state
-        const walletType = isStandaloneLedgerMode(appWalletState) ? WalletType.Ledger : WalletType.Keystore
+        const walletType = getWalletTypeFromState(appWalletState)
 
         if (enabledChains.includes(BTCChain)) BTC.reloadBalances(walletType)
         if (enabledChains.includes(DASHChain)) DASH.reloadBalances(walletType)

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -30,7 +30,6 @@ import { DEFAULT_WALLET_TYPE } from '../../const'
 import { eqBalancesRD } from '../../helpers/fp/eq'
 import { sequenceTOptionFromArray } from '../../helpers/fpHelpers'
 import { liveData } from '../../helpers/rx/liveData'
-import { addressFromOptionalWalletAddress } from '../../helpers/walletHelper'
 import { Network$ } from '../app/types'
 import * as ARB from '../arb'
 import * as AVAX from '../avax'
@@ -445,95 +444,82 @@ export const createBalancesService = ({
   }
 
   /**
-   * Transforms THOR balances into `ChainBalances`
+   * Factory to create a chain balance observable that uses dynamic wallet type from addressUI$
    */
-  const thorChainBalance$: ChainBalance$ = THOR.addressUI$.pipe(
-    RxOp.switchMap((oWalletAddress) =>
-      FP.pipe(
-        oWalletAddress,
-        O.fold(
-          () =>
-            Rx.of({
-              walletType: WalletType.Keystore,
-              chain: THORChain,
-              walletAddress: O.none,
-              walletAccount: 0,
-              walletIndex: 0,
-              balances: RD.initial,
-              balancesType: 'all' as const
-            }),
-          (walletAddress) =>
-            getChainBalance$({
-              chain: THORChain,
-              walletType: walletAddress.type, // Use dynamic wallet type from address
-              walletAccount: walletAddress.walletAccount,
-              walletIndex: walletAddress.walletIndex,
-              hdMode: walletAddress.hdMode,
-              walletBalanceType: 'all'
-            }).pipe(
-              RxOp.map((balances) => ({
-                walletType: walletAddress.type, // Use dynamic wallet type
-                chain: THORChain,
-                walletAddress: O.some(walletAddress.address),
+  const createChainBalance$ = ({
+    chain,
+    addressUI$,
+    walletBalanceType
+  }: {
+    chain: Chain
+    addressUI$: Rx.Observable<O.Option<WalletAddress>>
+    walletBalanceType: WalletBalanceType
+  }): ChainBalance$ =>
+    addressUI$.pipe(
+      RxOp.switchMap((oWalletAddress) =>
+        FP.pipe(
+          oWalletAddress,
+          O.fold(
+            () =>
+              Rx.of({
+                walletType: WalletType.Keystore,
+                chain,
+                walletAddress: O.none,
+                walletAccount: 0,
+                walletIndex: 0,
+                balances: RD.initial,
+                balancesType: walletBalanceType
+              }),
+            (walletAddress) =>
+              getChainBalance$({
+                chain,
+                walletType: walletAddress.type,
                 walletAccount: walletAddress.walletAccount,
                 walletIndex: walletAddress.walletIndex,
-                balances,
-                balancesType: 'all' as const
-              }))
-            )
+                hdMode: walletAddress.hdMode,
+                walletBalanceType
+              }).pipe(
+                RxOp.map((balances) => ({
+                  walletType: walletAddress.type,
+                  chain,
+                  walletAddress: O.some(walletAddress.address),
+                  walletAccount: walletAddress.walletAccount,
+                  walletIndex: walletAddress.walletIndex,
+                  balances,
+                  balancesType: walletBalanceType
+                }))
+              )
+          )
         )
       )
     )
-  )
+
+  /**
+   * Transforms THOR balances into `ChainBalances`
+   */
+  const thorChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: THORChain,
+    addressUI$: THOR.addressUI$,
+    walletBalanceType: 'all'
+  })
+
   /**
    * Transforms SOL balances into `ChainBalances`
    */
-  const solChainBalance$: ChainBalance$ = Rx.combineLatest([
-    SOL.addressUI$,
-    getChainBalance$({
-      chain: SOLChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: SOLChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const solChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: SOLChain,
+    addressUI$: SOL.addressUI$,
+    walletBalanceType: 'all'
+  })
 
   /**
    * Transforms MAYA balances into `ChainBalances`
    */
-  const mayaChainBalance$: ChainBalance$ = Rx.combineLatest([
-    MAYA.addressUI$,
-    getChainBalance$({
-      chain: MAYAChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: MAYAChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const mayaChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: MAYAChain,
+    addressUI$: MAYA.addressUI$,
+    walletBalanceType: 'all'
+  })
 
   /**
    * Factory to create a stream of ledger balances by given chain
@@ -624,48 +610,20 @@ export const createBalancesService = ({
   /**
    * Transforms LTC balances into `ChainBalances`
    */
-  const ltcBalance$: ChainBalance$ = Rx.combineLatest([
-    LTC.addressUI$,
-    getChainBalance$({
-      chain: LTCChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: LTCChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const ltcBalance$: ChainBalance$ = createChainBalance$({
+    chain: LTCChain,
+    addressUI$: LTC.addressUI$,
+    walletBalanceType: 'all'
+  })
 
   /**
    * Transforms Dash balances into `ChainBalances`
    */
-  const dashBalance$: ChainBalance$ = Rx.combineLatest([
-    DASH.addressUI$,
-    getChainBalance$({
-      chain: DASHChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: DASHChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const dashBalance$: ChainBalance$ = createChainBalance$({
+    chain: DASHChain,
+    addressUI$: DASH.addressUI$,
+    walletBalanceType: 'all'
+  })
   /**
    * DASH Ledger balances
    */
@@ -687,27 +645,11 @@ export const createBalancesService = ({
   /**
    * Transforms BCH balances into `ChainBalances`
    */
-  const bchChainBalance$: ChainBalance$ = Rx.combineLatest([
-    BCH.addressUI$,
-    getChainBalance$({
-      chain: BCHChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      walletBalanceType: 'all',
-      hdMode: 'default'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: BCHChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const bchChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: BCHChain,
+    addressUI$: BCH.addressUI$,
+    walletBalanceType: 'all'
+  })
 
   /**
    * BCH Ledger balances
@@ -738,100 +680,37 @@ export const createBalancesService = ({
   /**
    * Transforms BTC balances into `ChainBalance`
    */
-  const btcChainBalance$: ChainBalance$ = Rx.combineLatest([
-    BTC.addressUI$,
-    getChainBalance$({
-      chain: BTCChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: BTCChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const btcChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: BTCChain,
+    addressUI$: BTC.addressUI$,
+    walletBalanceType: 'all'
+  })
+
   /**
-   * Transforms BTC balances into `ChainBalance`
+   * Transforms BTC confirmed balances into `ChainBalance`
    */
-  const btcChainBalanceConfirmed$: ChainBalance$ = Rx.combineLatest([
-    BTC.addressUI$,
-    getChainBalance$({
-      chain: BTCChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'confirmed'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: BTCChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'confirmed'
-    }))
-  )
+  const btcChainBalanceConfirmed$: ChainBalance$ = createChainBalance$({
+    chain: BTCChain,
+    addressUI$: BTC.addressUI$,
+    walletBalanceType: 'confirmed'
+  })
 
   /**
    * Transforms DOGE balances into `ChainBalance`
    */
-  const dogeChainBalance$: ChainBalance$ = Rx.combineLatest([
-    DOGE.addressUI$,
-    getChainBalance$({
-      chain: DOGEChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: DOGEChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const dogeChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: DOGEChain,
+    addressUI$: DOGE.addressUI$,
+    walletBalanceType: 'all'
+  })
   /**
    * Transforms KUJI balances into `ChainBalance`
    */
-  const kujiChainBalance$: ChainBalance$ = Rx.combineLatest([
-    KUJI.addressUI$,
-    getChainBalance$({
-      chain: KUJIChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: KUJIChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const kujiChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: KUJIChain,
+    addressUI$: KUJI.addressUI$,
+    walletBalanceType: 'all'
+  })
   /**
    * KUJI Ledger balances
    */
@@ -844,27 +723,11 @@ export const createBalancesService = ({
   /**
    * Transforms ADA balances into `ChainBalance`
    */
-  const adaChainBalance$: ChainBalance$ = Rx.combineLatest([
-    ADA.addressUI$,
-    getChainBalance$({
-      chain: ADAChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: ADAChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const adaChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: ADAChain,
+    addressUI$: ADA.addressUI$,
+    walletBalanceType: 'all'
+  })
 
   /**
    * ADA Ledger balances
@@ -884,172 +747,68 @@ export const createBalancesService = ({
     getBalanceByAddress$: DOGE.getBalanceByAddress$
   })
 
-  const ethBalances$ = getChainBalance$({
-    chain: ETHChain,
-    walletType: WalletType.Keystore,
-    walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-    walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-    hdMode: 'default',
-    walletBalanceType: 'all'
-  })
   /**
    * Transforms ETH data (address + `WalletBalance`) into `ChainBalance`
    */
-  const ethChainBalance$: ChainBalance$ = Rx.combineLatest([ETH.addressUI$, ethBalances$]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: ETHChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
-
-  const arbBalances$ = getChainBalance$({
-    chain: ARBChain,
-    walletType: WalletType.Keystore,
-    walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-    walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-    hdMode: 'default',
+  const ethChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: ETHChain,
+    addressUI$: ETH.addressUI$,
     walletBalanceType: 'all'
   })
 
   /**
    * Transforms ARB data (address + `WalletBalance`) into `ChainBalance`
    */
-  const arbChainBalance$: ChainBalance$ = Rx.combineLatest([ARB.addressUI$, arbBalances$]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: ARBChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
-
-  const avaxBalances$ = getChainBalance$({
-    chain: AVAXChain,
-    walletType: WalletType.Keystore,
-    walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-    walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-    hdMode: 'default',
+  const arbChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: ARBChain,
+    addressUI$: ARB.addressUI$,
     walletBalanceType: 'all'
   })
 
   /**
    * Transforms AVAX data (address + `WalletBalance`) into `ChainBalance`
    */
-  const avaxChainBalance$: ChainBalance$ = Rx.combineLatest([AVAX.addressUI$, avaxBalances$]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: AVAXChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
-  const baseBalances$ = getChainBalance$({
-    chain: BASEChain,
-    walletType: WalletType.Keystore,
-    walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-    walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-    hdMode: 'default',
+  const avaxChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: AVAXChain,
+    addressUI$: AVAX.addressUI$,
     walletBalanceType: 'all'
   })
+
   /**
    * Transforms BASE data (address + `WalletBalance`) into `ChainBalance`
    */
-  const baseChainBalance$: ChainBalance$ = Rx.combineLatest([BASE.addressUI$, baseBalances$]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: BASEChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
-
-  const bscBalances$ = getChainBalance$({
-    chain: BSCChain,
-    walletType: WalletType.Keystore,
-    walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-    walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-    hdMode: 'default',
+  const baseChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: BASEChain,
+    addressUI$: BASE.addressUI$,
     walletBalanceType: 'all'
   })
 
   /**
    * Transforms BSC data (address + `WalletBalance`) into `ChainBalance`
    */
-  const bscChainBalance$: ChainBalance$ = Rx.combineLatest([BSC.addressUI$, bscBalances$]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: BSCChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const bscChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: BSCChain,
+    addressUI$: BSC.addressUI$,
+    walletBalanceType: 'all'
+  })
 
   /**
    * Transforms COSMOS balances into `ChainBalance`
    */
-  const cosmosChainBalance$: ChainBalance$ = Rx.combineLatest([
-    COSMOS.addressUI$,
-    getChainBalance$({
-      chain: GAIAChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: GAIAChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const cosmosChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: GAIAChain,
+    addressUI$: COSMOS.addressUI$,
+    walletBalanceType: 'all'
+  })
 
   /**
    * Transforms Radix balances into `ChainBalance`
    */
-  const xrdChainBalance$: ChainBalance$ = Rx.combineLatest([
-    XRD.addressUI$,
-    getChainBalance$({
-      chain: RadixChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: RadixChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const xrdChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: RadixChain,
+    addressUI$: XRD.addressUI$,
+    walletBalanceType: 'all'
+  })
 
   /**
    * Cosmos Ledger balances
@@ -1081,27 +840,11 @@ export const createBalancesService = ({
   /**
    * Transforms TRON balances into `ChainBalance`
    */
-  const tronChainBalance$: ChainBalance$ = Rx.combineLatest([
-    TRON.addressUI$,
-    getChainBalance$({
-      chain: TRONChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: TRONChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const tronChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: TRONChain,
+    addressUI$: TRON.addressUI$,
+    walletBalanceType: 'all'
+  })
 
   /**
    * TRON Ledger balances
@@ -1186,27 +929,11 @@ export const createBalancesService = ({
   /**
    * Transforms ZEC balances into `ChainBalance`
    */
-  const zecChainBalance$: ChainBalance$ = Rx.combineLatest([
-    ZEC.addressUI$,
-    getChainBalance$({
-      chain: ZECChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: ZECChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const zecChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: ZECChain,
+    addressUI$: ZEC.addressUI$,
+    walletBalanceType: 'all'
+  })
 
   /**
    * ZEC Ledger balances
@@ -1220,27 +947,11 @@ export const createBalancesService = ({
   /**
    * Transforms XRP balances into `ChainBalance`
    */
-  const xrpChainBalance$: ChainBalance$ = Rx.combineLatest([
-    XRP.addressUI$,
-    getChainBalance$({
-      chain: XRPChain,
-      walletType: WalletType.Keystore,
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // walletIndex=0 (as long as we don't support HD wallets for keystore)
-      hdMode: 'default',
-      walletBalanceType: 'all'
-    })
-  ]).pipe(
-    RxOp.map<[O.Option<WalletAddress>, WalletBalancesRD], ChainBalance>(([oWalletAddress, balances]) => ({
-      walletType: WalletType.Keystore,
-      chain: XRPChain,
-      walletAddress: addressFromOptionalWalletAddress(oWalletAddress),
-      walletAccount: 0, // walletAccount=0 (as long as we don't support HD wallets for keystore)
-      walletIndex: 0, // Always 0 as long as we don't support HD wallets for keystore
-      balances,
-      balancesType: 'all'
-    }))
-  )
+  const xrpChainBalance$: ChainBalance$ = createChainBalance$({
+    chain: XRPChain,
+    addressUI$: XRP.addressUI$,
+    walletBalanceType: 'all'
+  })
 
   /**
    * XRP Ledger balances

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -46,6 +46,26 @@ export const isStandaloneLedgerMode = (state: AppWalletState): state is Standalo
 
 export const isKeystoreMode = (state: AppWalletState): state is KeystoreState => !isStandaloneLedgerMode(state)
 
+/**
+ * Derives WalletType from AppWalletState.
+ * Extend this function when adding new wallet types (e.g., Vultisig).
+ */
+export const getWalletTypeFromState = (state: AppWalletState): WalletType => {
+  if (isStandaloneLedgerMode(state)) {
+    return WalletType.Ledger
+  }
+  // Future: if (isVultisigMode(state)) return WalletType.Vultisig
+  return WalletType.Keystore
+}
+
+/**
+ * Determines if the keystore reload trigger should be used for balance reloading.
+ */
+export const isKeystoreReloadTrigger = (walletType: WalletType): boolean => {
+  return walletType === WalletType.Keystore
+  // Future: if (walletType === WalletType.Vultisig) ...
+}
+
 export type KeystoreLocked = { id: KeystoreId; name: string }
 export type KeystoreUnlocked = KeystoreLocked & { phrase: Phrase }
 export type KeystoreContent = KeystoreLocked | KeystoreUnlocked

--- a/src/renderer/services/zcash/balances.ts
+++ b/src/renderer/services/zcash/balances.ts
@@ -1,6 +1,7 @@
 import { HDMode, WalletBalanceType, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
 import { client$ } from './common'
 
 /**
@@ -12,7 +13,7 @@ const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolea
 const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
 const resetReloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(false)
   } else {
     setReloadLedgerBalances(false)
@@ -20,7 +21,7 @@ const resetReloadBalances = (walletType: WalletType) => {
 }
 
 const reloadBalances = (walletType: WalletType) => {
-  if (walletType === WalletType.Keystore) {
+  if (isKeystoreReloadTrigger(walletType)) {
     setReloadBalances(true)
   } else {
     setReloadLedgerBalances(true)
@@ -38,17 +39,21 @@ const balances$ = ({
   walletAccount: number
   walletIndex: number
   hdMode: HDMode
-}): C.WalletBalancesLD =>
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
   // For ZEC, we'll always use 'all' balance type since it might not support confirmed/unconfirmed distinction
-  C.balances$({
+  return C.balances$({
     client$,
-    trigger$: reloadBalances$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType: 'all' // Force 'all' for ZEC
   })
+}
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = (walletBalanceType: WalletBalanceType) =>


### PR DESCRIPTION
  Summary
  - Centralizes wallet type determination in `wallet/types.ts`                                                                                                                                 
  - Adds `getWalletTypeFromState()` and `isKeystoreReloadTrigger()` helpers                                                                                                                    
  - Updates all 15 chain balance services to use the centralized pattern                                                                                                                       
  - Future: Adding another wallet type requires only modifying `wallet/types.ts`                                                                                                                          
                                                                                

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized balance reload logic across multiple blockchain services to better support different wallet configurations. Enhanced internal state management for balance synchronization across keystore and ledger wallet types, improving consistency in balance data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->