### PR TITLE
Feat/update ledger evm rpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /coverage
 /build
 /release
+/docs
 
 .DS_Store
 

--- a/src/main/api/ledger/arb/transaction.ts
+++ b/src/main/api/ledger/arb/transaction.ts
@@ -44,16 +44,20 @@ export const send = async ({
   evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
+    // Derive chainId from the network parameter
+    // Arbitrum One mainnet: 42161, Arbitrum Sepolia testnet: 421614
+    const isTestnet = network === Network.Testnet
+    const chainId = isTestnet ? 421614 : 42161
+    const networkName = isTestnet ? 'arbitrum-sepolia' : 'arbitrum'
+
     // Use custom RPC URL if provided, otherwise use defaults
     const provider = evmRpcUrl
-      ? new JsonRpcProvider(evmRpcUrl, { name: 'arbitrum', chainId: 42161 })
-      : defaultArbParams.providers[Network.Mainnet]
+      ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+      : defaultArbParams.providers[network]
 
     const clientledger = new ARB.ClientLedger({
       ...defaultArbParams,
-      providers: evmRpcUrl
-        ? { ...defaultArbParams.providers, [Network.Mainnet]: provider }
-        : defaultArbParams.providers,
+      providers: evmRpcUrl ? { ...defaultArbParams.providers, [network]: provider } : defaultArbParams.providers,
       signer: new ARB.LedgerSigner({
         transport,
         provider,
@@ -121,16 +125,20 @@ export const deposit = async ({
 
     const isETHAddress = address === EVMZeroAddress
 
+    // Derive chainId from the network parameter
+    // Arbitrum One mainnet: 42161, Arbitrum Sepolia testnet: 421614
+    const isTestnet = network === Network.Testnet
+    const chainId = isTestnet ? 421614 : 42161
+    const networkName = isTestnet ? 'arbitrum-sepolia' : 'arbitrum'
+
     // Use custom RPC URL if provided, otherwise use defaults
     const rpcProvider = evmRpcUrl
-      ? new JsonRpcProvider(evmRpcUrl, { name: 'arbitrum', chainId: 42161 })
-      : defaultArbParams.providers[Network.Mainnet]
+      ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+      : defaultArbParams.providers[network]
 
     const clientledger = new ARB.ClientLedger({
       ...defaultArbParams,
-      providers: evmRpcUrl
-        ? { ...defaultArbParams.providers, [Network.Mainnet]: rpcProvider }
-        : defaultArbParams.providers,
+      providers: evmRpcUrl ? { ...defaultArbParams.providers, [network]: rpcProvider } : defaultArbParams.providers,
       signer: new ARB.LedgerSigner({
         transport,
         provider: rpcProvider,

--- a/src/main/api/ledger/arb/transaction.ts
+++ b/src/main/api/ledger/arb/transaction.ts
@@ -3,7 +3,7 @@ import { FeeOption, Network, TxHash } from '@xchainjs/xchain-client'
 import * as ARB from '@xchainjs/xchain-evm'
 import { Address, AnyAsset, assetToString, baseAmount, BaseAmount, TokenAsset } from '@xchainjs/xchain-util'
 import { BigNumber } from 'bignumber.js'
-import { Contract } from 'ethers'
+import { Contract, JsonRpcProvider } from 'ethers'
 import { either as E } from 'fp-ts'
 
 import { isAethAsset } from '../../../../renderer/helpers/assetHelper'
@@ -16,7 +16,7 @@ import { EvmHDMode } from '../../../../shared/evm/types'
 import { isError } from '../../../../shared/utils/guard'
 
 /**
- * Sends ETH tx using Ledger
+ * Sends ARB tx using Ledger
  */
 export const send = async ({
   asset,
@@ -28,7 +28,8 @@ export const send = async ({
   feeOption,
   walletAccount,
   walletIndex,
-  evmHDMode
+  evmHDMode,
+  evmRpcUrl
 }: {
   asset: AnyAsset
   transport: Transport
@@ -40,13 +41,22 @@ export const send = async ({
   walletAccount: number
   walletIndex: number
   evmHDMode: EvmHDMode
+  evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
+    // Use custom RPC URL if provided, otherwise use defaults
+    const provider = evmRpcUrl
+      ? new JsonRpcProvider(evmRpcUrl, { name: 'arbitrum', chainId: 42161 })
+      : defaultArbParams.providers[Network.Mainnet]
+
     const clientledger = new ARB.ClientLedger({
       ...defaultArbParams,
+      providers: evmRpcUrl
+        ? { ...defaultArbParams.providers, [Network.Mainnet]: provider }
+        : defaultArbParams.providers,
       signer: new ARB.LedgerSigner({
         transport,
-        provider: defaultArbParams.providers[Network.Mainnet],
+        provider,
         derivationPath: getDerivationPath(walletAccount, evmHDMode)
       }),
       network: network
@@ -70,7 +80,7 @@ export const send = async ({
 }
 
 /**
- * Sends ETH deposit txs using Ledger
+ * Sends ARB deposit txs using Ledger
  */
 export const deposit = async ({
   asset,
@@ -83,7 +93,8 @@ export const deposit = async ({
   walletAccount,
   walletIndex,
   feeOption,
-  evmHDMode
+  evmHDMode,
+  evmRpcUrl
 }: {
   asset: AnyAsset
   router: Address
@@ -96,6 +107,7 @@ export const deposit = async ({
   walletIndex: number
   feeOption: FeeOption
   evmHDMode: EvmHDMode
+  evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
     const address = !isAethAsset(asset) ? ARB.getTokenAddress(asset as TokenAsset) : EVMZeroAddress
@@ -109,11 +121,19 @@ export const deposit = async ({
 
     const isETHAddress = address === EVMZeroAddress
 
+    // Use custom RPC URL if provided, otherwise use defaults
+    const rpcProvider = evmRpcUrl
+      ? new JsonRpcProvider(evmRpcUrl, { name: 'arbitrum', chainId: 42161 })
+      : defaultArbParams.providers[Network.Mainnet]
+
     const clientledger = new ARB.ClientLedger({
       ...defaultArbParams,
+      providers: evmRpcUrl
+        ? { ...defaultArbParams.providers, [Network.Mainnet]: rpcProvider }
+        : defaultArbParams.providers,
       signer: new ARB.LedgerSigner({
         transport,
-        provider: defaultArbParams.providers[Network.Mainnet],
+        provider: rpcProvider,
         derivationPath: getDerivationPath(walletAccount, evmHDMode)
       }),
       network: network

--- a/src/main/api/ledger/avax/transaction.ts
+++ b/src/main/api/ledger/avax/transaction.ts
@@ -53,16 +53,19 @@ export const send = async ({
   evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
+    // Derive chainId and network name from the network parameter
+    const isTestnet = network === Network.Testnet
+    const chainId = isTestnet ? 43113 : 43114
+    const networkName = isTestnet ? 'fuji' : 'avalanche'
+
     // Use custom RPC URL if provided, otherwise use defaults
     const provider = evmRpcUrl
-      ? new JsonRpcProvider(evmRpcUrl, { name: 'avalanche', chainId: 43114 })
-      : defaultAvaxParams.providers[Network.Mainnet]
+      ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+      : defaultAvaxParams.providers[network]
 
     const ledgerClient = new ClientLedger({
       ...defaultAvaxParams,
-      providers: evmRpcUrl
-        ? { ...defaultAvaxParams.providers, [Network.Mainnet]: provider }
-        : defaultAvaxParams.providers,
+      providers: evmRpcUrl ? { ...defaultAvaxParams.providers, [network]: provider } : defaultAvaxParams.providers,
       signer: new LedgerSigner({
         transport,
         provider,
@@ -136,16 +139,19 @@ export const deposit = async ({
       })
     }
 
+    // Derive chainId and network name from the network parameter
+    const isTestnet = network === Network.Testnet
+    const chainId = isTestnet ? 43113 : 43114
+    const networkName = isTestnet ? 'fuji' : 'avalanche'
+
     // Use custom RPC URL if provided, otherwise use defaults
     const rpcProvider = evmRpcUrl
-      ? new JsonRpcProvider(evmRpcUrl, { name: 'avalanche', chainId: 43114 })
-      : defaultAvaxParams.providers[Network.Mainnet]
+      ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+      : defaultAvaxParams.providers[network]
 
     const ledgerClient = new ClientLedger({
       ...defaultAvaxParams,
-      providers: evmRpcUrl
-        ? { ...defaultAvaxParams.providers, [Network.Mainnet]: rpcProvider }
-        : defaultAvaxParams.providers,
+      providers: evmRpcUrl ? { ...defaultAvaxParams.providers, [network]: rpcProvider } : defaultAvaxParams.providers,
       signer: new LedgerSigner({
         transport,
         provider: rpcProvider,

--- a/src/main/api/ledger/avax/transaction.ts
+++ b/src/main/api/ledger/avax/transaction.ts
@@ -12,7 +12,7 @@ import {
   TokenAsset
 } from '@xchainjs/xchain-util'
 import { BigNumber } from 'bignumber.js'
-import { Contract, getAddress, ZeroAddress } from 'ethers'
+import { Contract, getAddress, JsonRpcProvider, ZeroAddress } from 'ethers'
 import { either as E } from 'fp-ts'
 
 import { isAvaxAsset, isEVMTokenAsset } from '../../../../renderer/helpers/assetHelper'
@@ -25,7 +25,7 @@ import { EvmHDMode } from '../../../../shared/evm/types'
 import { isError } from '../../../../shared/utils/guard'
 
 /**
- * Sends ETH tx using Ledger
+ * Sends AVAX tx using Ledger
  */
 export const send = async ({
   asset,
@@ -37,7 +37,8 @@ export const send = async ({
   feeOption,
   walletAccount,
   walletIndex,
-  evmHDMode
+  evmHDMode,
+  evmRpcUrl
 }: {
   asset: AnyAsset
   transport: Transport
@@ -49,13 +50,22 @@ export const send = async ({
   walletAccount: number
   walletIndex: number
   evmHDMode: EvmHDMode
+  evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
+    // Use custom RPC URL if provided, otherwise use defaults
+    const provider = evmRpcUrl
+      ? new JsonRpcProvider(evmRpcUrl, { name: 'avalanche', chainId: 43114 })
+      : defaultAvaxParams.providers[Network.Mainnet]
+
     const ledgerClient = new ClientLedger({
       ...defaultAvaxParams,
+      providers: evmRpcUrl
+        ? { ...defaultAvaxParams.providers, [Network.Mainnet]: provider }
+        : defaultAvaxParams.providers,
       signer: new LedgerSigner({
         transport,
-        provider: defaultAvaxParams.providers[Network.Mainnet],
+        provider,
         derivationPath: getDerivationPath(walletAccount, evmHDMode)
       }),
       rootDerivationPaths: getDerivationPaths(walletAccount, evmHDMode),
@@ -87,7 +97,7 @@ export const send = async ({
 }
 
 /**
- * Sends Avax deposit txs using Ledger
+ * Sends AVAX deposit txs using Ledger
  */
 export const deposit = async ({
   asset,
@@ -100,7 +110,8 @@ export const deposit = async ({
   walletAccount,
   walletIndex,
   feeOption,
-  evmHDMode
+  evmHDMode,
+  evmRpcUrl
 }: {
   asset: AnyAsset
   router: Address
@@ -113,6 +124,7 @@ export const deposit = async ({
   walletIndex: number
   feeOption: FeeOption
   evmHDMode: EvmHDMode
+  evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
     const address = !isAvaxAsset(asset) ? getTokenAddress(asset as TokenAsset) : EVMZeroAddress
@@ -124,11 +136,19 @@ export const deposit = async ({
       })
     }
 
+    // Use custom RPC URL if provided, otherwise use defaults
+    const rpcProvider = evmRpcUrl
+      ? new JsonRpcProvider(evmRpcUrl, { name: 'avalanche', chainId: 43114 })
+      : defaultAvaxParams.providers[Network.Mainnet]
+
     const ledgerClient = new ClientLedger({
       ...defaultAvaxParams,
+      providers: evmRpcUrl
+        ? { ...defaultAvaxParams.providers, [Network.Mainnet]: rpcProvider }
+        : defaultAvaxParams.providers,
       signer: new LedgerSigner({
         transport,
-        provider: defaultAvaxParams.providers[Network.Mainnet],
+        provider: rpcProvider,
         derivationPath: getDerivationPath(walletAccount, evmHDMode)
       }),
       rootDerivationPaths: getDerivationPaths(walletAccount, evmHDMode),

--- a/src/main/api/ledger/base/transaction.ts
+++ b/src/main/api/ledger/base/transaction.ts
@@ -53,16 +53,20 @@ export const send = async ({
   evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
+    // Derive chainId from the network parameter
+    // Base mainnet: 8453, Base Sepolia testnet: 84532
+    const isTestnet = network === Network.Testnet
+    const chainId = isTestnet ? 84532 : 8453
+    const networkName = isTestnet ? 'base-sepolia' : 'base'
+
     // Use custom RPC URL if provided, otherwise use defaults
     const provider = evmRpcUrl
-      ? new JsonRpcProvider(evmRpcUrl, { name: 'base', chainId: 8453 })
-      : defaultBaseParams.providers[Network.Mainnet]
+      ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+      : defaultBaseParams.providers[network]
 
     const ledgerClient = new ClientLedger({
       ...defaultBaseParams,
-      providers: evmRpcUrl
-        ? { ...defaultBaseParams.providers, [Network.Mainnet]: provider }
-        : defaultBaseParams.providers,
+      providers: evmRpcUrl ? { ...defaultBaseParams.providers, [network]: provider } : defaultBaseParams.providers,
       signer: new LedgerSigner({
         transport,
         provider,
@@ -136,16 +140,20 @@ export const deposit = async ({
       })
     }
 
+    // Derive chainId from the network parameter
+    // Base mainnet: 8453, Base Sepolia testnet: 84532
+    const isTestnet = network === Network.Testnet
+    const chainId = isTestnet ? 84532 : 8453
+    const networkName = isTestnet ? 'base-sepolia' : 'base'
+
     // Use custom RPC URL if provided, otherwise use defaults
     const rpcProvider = evmRpcUrl
-      ? new JsonRpcProvider(evmRpcUrl, { name: 'base', chainId: 8453 })
-      : defaultBaseParams.providers[Network.Mainnet]
+      ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+      : defaultBaseParams.providers[network]
 
     const ledgerClient = new ClientLedger({
       ...defaultBaseParams,
-      providers: evmRpcUrl
-        ? { ...defaultBaseParams.providers, [Network.Mainnet]: rpcProvider }
-        : defaultBaseParams.providers,
+      providers: evmRpcUrl ? { ...defaultBaseParams.providers, [network]: rpcProvider } : defaultBaseParams.providers,
       signer: new LedgerSigner({
         transport,
         provider: rpcProvider,

--- a/src/main/api/ledger/base/transaction.ts
+++ b/src/main/api/ledger/base/transaction.ts
@@ -12,7 +12,7 @@ import {
   TokenAsset
 } from '@xchainjs/xchain-util'
 import { BigNumber } from 'bignumber.js'
-import { Contract, getAddress, ZeroAddress } from 'ethers'
+import { Contract, getAddress, JsonRpcProvider, ZeroAddress } from 'ethers'
 import { either as E } from 'fp-ts'
 
 import { isBaseAsset, isEVMTokenAsset } from '../../../../renderer/helpers/assetHelper'
@@ -25,7 +25,7 @@ import { EvmHDMode } from '../../../../shared/evm/types'
 import { isError } from '../../../../shared/utils/guard'
 
 /**
- * Sends ETH tx using Ledger
+ * Sends BASE tx using Ledger
  */
 export const send = async ({
   asset,
@@ -37,7 +37,8 @@ export const send = async ({
   feeOption,
   walletAccount,
   walletIndex,
-  evmHDMode
+  evmHDMode,
+  evmRpcUrl
 }: {
   asset: AnyAsset
   transport: Transport
@@ -49,13 +50,22 @@ export const send = async ({
   walletAccount: number
   walletIndex: number
   evmHDMode: EvmHDMode
+  evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
+    // Use custom RPC URL if provided, otherwise use defaults
+    const provider = evmRpcUrl
+      ? new JsonRpcProvider(evmRpcUrl, { name: 'base', chainId: 8453 })
+      : defaultBaseParams.providers[Network.Mainnet]
+
     const ledgerClient = new ClientLedger({
       ...defaultBaseParams,
+      providers: evmRpcUrl
+        ? { ...defaultBaseParams.providers, [Network.Mainnet]: provider }
+        : defaultBaseParams.providers,
       signer: new LedgerSigner({
         transport,
-        provider: defaultBaseParams.providers[Network.Mainnet],
+        provider,
         derivationPath: getDerivationPath(walletAccount, evmHDMode)
       }),
       rootDerivationPaths: getDerivationPaths(walletAccount, evmHDMode),
@@ -87,7 +97,7 @@ export const send = async ({
 }
 
 /**
- * Sends Base deposit txs using Ledger
+ * Sends BASE deposit txs using Ledger
  */
 export const deposit = async ({
   asset,
@@ -100,7 +110,8 @@ export const deposit = async ({
   walletAccount,
   walletIndex,
   feeOption,
-  evmHDMode
+  evmHDMode,
+  evmRpcUrl
 }: {
   asset: AnyAsset
   router: Address
@@ -113,6 +124,7 @@ export const deposit = async ({
   walletIndex: number
   feeOption: FeeOption
   evmHDMode: EvmHDMode
+  evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
     const address = !isBaseAsset(asset) ? getTokenAddress(asset as TokenAsset) : EVMZeroAddress
@@ -124,11 +136,19 @@ export const deposit = async ({
       })
     }
 
+    // Use custom RPC URL if provided, otherwise use defaults
+    const rpcProvider = evmRpcUrl
+      ? new JsonRpcProvider(evmRpcUrl, { name: 'base', chainId: 8453 })
+      : defaultBaseParams.providers[Network.Mainnet]
+
     const ledgerClient = new ClientLedger({
       ...defaultBaseParams,
+      providers: evmRpcUrl
+        ? { ...defaultBaseParams.providers, [Network.Mainnet]: rpcProvider }
+        : defaultBaseParams.providers,
       signer: new LedgerSigner({
         transport,
-        provider: defaultBaseParams.providers[Network.Mainnet],
+        provider: rpcProvider,
         derivationPath: getDerivationPath(walletAccount, evmHDMode)
       }),
       rootDerivationPaths: getDerivationPaths(walletAccount, evmHDMode),

--- a/src/main/api/ledger/bsc/transaction.ts
+++ b/src/main/api/ledger/bsc/transaction.ts
@@ -44,16 +44,19 @@ export const send = async ({
   evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
+    // Derive chainId from the network parameter
+    const isTestnet = network === Network.Testnet
+    const chainId = isTestnet ? 97 : 56
+    const networkName = isTestnet ? 'bnb-testnet' : 'bnb'
+
     // Use custom RPC URL if provided, otherwise use defaults
     const provider = evmRpcUrl
-      ? new JsonRpcProvider(evmRpcUrl, { name: 'bnb', chainId: 56 })
-      : defaultBscParams.providers[Network.Mainnet]
+      ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+      : defaultBscParams.providers[network]
 
     const clientLedger = new BSC.ClientLedger({
       ...defaultBscParams,
-      providers: evmRpcUrl
-        ? { ...defaultBscParams.providers, [Network.Mainnet]: provider }
-        : defaultBscParams.providers,
+      providers: evmRpcUrl ? { ...defaultBscParams.providers, [network]: provider } : defaultBscParams.providers,
       signer: new BSC.LedgerSigner({
         transport,
         provider,
@@ -130,16 +133,19 @@ export const deposit = async ({
 
     const isETHAddress = address === EVMZeroAddress
 
+    // Derive chainId from the network parameter
+    const isTestnet = network === Network.Testnet
+    const chainId = isTestnet ? 97 : 56
+    const networkName = isTestnet ? 'bnb-testnet' : 'bnb'
+
     // Use custom RPC URL if provided, otherwise use defaults
     const rpcProvider = evmRpcUrl
-      ? new JsonRpcProvider(evmRpcUrl, { name: 'bnb', chainId: 56 })
-      : defaultBscParams.providers[Network.Mainnet]
+      ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+      : defaultBscParams.providers[network]
 
     const clientledger = new BSC.ClientLedger({
       ...defaultBscParams,
-      providers: evmRpcUrl
-        ? { ...defaultBscParams.providers, [Network.Mainnet]: rpcProvider }
-        : defaultBscParams.providers,
+      providers: evmRpcUrl ? { ...defaultBscParams.providers, [network]: rpcProvider } : defaultBscParams.providers,
       signer: new BSC.LedgerSigner({
         transport,
         provider: rpcProvider,

--- a/src/main/api/ledger/bsc/transaction.ts
+++ b/src/main/api/ledger/bsc/transaction.ts
@@ -2,7 +2,8 @@ import type Transport from '@ledgerhq/hw-transport'
 import { FeeOption, Network, TxHash } from '@xchainjs/xchain-client'
 import * as BSC from '@xchainjs/xchain-evm'
 import { Address, AnyAsset, Asset, assetToString, baseAmount, BaseAmount, TokenAsset } from '@xchainjs/xchain-util'
-import { Contract } from 'ethers'
+import BigNumber from 'bignumber.js'
+import { Contract, JsonRpcProvider } from 'ethers'
 import { either as E } from 'fp-ts'
 
 import { isBscAsset } from '../../../../renderer/helpers/assetHelper'
@@ -27,7 +28,8 @@ export const send = async ({
   feeOption,
   walletAccount,
   walletIndex,
-  evmHDMode
+  evmHDMode,
+  evmRpcUrl
 }: {
   asset: AnyAsset
   transport: Transport
@@ -39,13 +41,22 @@ export const send = async ({
   walletAccount: number
   walletIndex: number
   evmHDMode: EvmHDMode
+  evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
+    // Use custom RPC URL if provided, otherwise use defaults
+    const provider = evmRpcUrl
+      ? new JsonRpcProvider(evmRpcUrl, { name: 'bnb', chainId: 56 })
+      : defaultBscParams.providers[Network.Mainnet]
+
     const clientLedger = new BSC.ClientLedger({
       ...defaultBscParams,
+      providers: evmRpcUrl
+        ? { ...defaultBscParams.providers, [Network.Mainnet]: provider }
+        : defaultBscParams.providers,
       signer: new BSC.LedgerSigner({
         transport,
-        provider: defaultBscParams.providers[Network.Mainnet],
+        provider,
         derivationPath: getDerivationPath(walletAccount, evmHDMode)
       }),
       rootDerivationPaths: getDerivationPaths(walletAccount, evmHDMode),
@@ -91,7 +102,8 @@ export const deposit = async ({
   walletAccount,
   walletIndex,
   feeOption,
-  evmHDMode
+  evmHDMode,
+  evmRpcUrl
 }: {
   asset: AnyAsset
   router: Address
@@ -104,6 +116,7 @@ export const deposit = async ({
   walletIndex: number
   feeOption: FeeOption
   evmHDMode: EvmHDMode
+  evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
     const address = !isBscAsset(asset) ? BSC.getTokenAddress(asset as TokenAsset) : EVMZeroAddress
@@ -117,11 +130,19 @@ export const deposit = async ({
 
     const isETHAddress = address === EVMZeroAddress
 
+    // Use custom RPC URL if provided, otherwise use defaults
+    const rpcProvider = evmRpcUrl
+      ? new JsonRpcProvider(evmRpcUrl, { name: 'bnb', chainId: 56 })
+      : defaultBscParams.providers[Network.Mainnet]
+
     const clientledger = new BSC.ClientLedger({
       ...defaultBscParams,
+      providers: evmRpcUrl
+        ? { ...defaultBscParams.providers, [Network.Mainnet]: rpcProvider }
+        : defaultBscParams.providers,
       signer: new BSC.LedgerSigner({
         transport,
-        provider: defaultBscParams.providers[Network.Mainnet],
+        provider: rpcProvider,
         derivationPath: getDerivationPath(walletAccount, evmHDMode)
       }),
       rootDerivationPaths: getDerivationPaths(walletAccount, evmHDMode),

--- a/src/main/api/ledger/ethereum/transaction.ts
+++ b/src/main/api/ledger/ethereum/transaction.ts
@@ -35,7 +35,8 @@ export const send = async ({
   walletAccount,
   walletIndex,
   evmHDMode,
-  apiKey
+  apiKey,
+  evmRpcUrl
 }: {
   asset: AnyAsset
   transport: Transport
@@ -48,21 +49,27 @@ export const send = async ({
   walletIndex: number
   evmHDMode: EvmHDMode
   apiKey: string
+  evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
     const ethProviders = createEthProviders(apiKey)
 
+    // Use custom RPC URL if provided, otherwise use defaults
+    const mainnetProvider = evmRpcUrl
+      ? new JsonRpcProvider(evmRpcUrl, 'homestead')
+      : new JsonRpcProvider('https://eth.llamarpc.com', 'homestead')
+
     const ledgerClient = new ETH.ClientLedger({
       ...defaultEthParams,
       providers: {
-        mainnet: new JsonRpcProvider('https://eth.llamarpc.com', 'homestead'),
+        mainnet: mainnetProvider,
         testnet: ETH_TESTNET_ETHERS_PROVIDER,
         stagenet: ETH_MAINNET_ETHERS_PROVIDER
       },
       dataProviders: [ethProviders],
       signer: new ETH.LedgerSigner({
         transport,
-        provider: new JsonRpcProvider('https://eth.llamarpc.com', 'homestead'),
+        provider: mainnetProvider,
         derivationPath: getDerivationPath(walletAccount, evmHDMode)
       }),
       rootDerivationPaths: getDerivationPaths(walletAccount, evmHDMode),
@@ -109,7 +116,8 @@ export const deposit = async ({
   walletIndex,
   feeOption,
   evmHDMode,
-  apiKey
+  apiKey,
+  evmRpcUrl
 }: {
   asset: AnyAsset
   router: Address
@@ -123,6 +131,7 @@ export const deposit = async ({
   feeOption: FeeOption
   evmHDMode: EvmHDMode
   apiKey: string
+  evmRpcUrl?: string
 }): Promise<E.Either<LedgerError, TxHash>> => {
   try {
     const address = !isEthAsset(asset) ? ETH.getTokenAddress(asset as TokenAsset) : EVMZeroAddress
@@ -137,17 +146,22 @@ export const deposit = async ({
 
     const isETHAddress = address === EVMZeroAddress
 
+    // Use custom RPC URL if provided, otherwise use EtherscanProvider
+    const mainnetProvider = evmRpcUrl
+      ? new JsonRpcProvider(evmRpcUrl, 'homestead')
+      : new EtherscanProvider('homestead', apiKey)
+
     const ledgerClient = new ETH.ClientLedger({
       ...defaultEthParams,
       providers: {
-        mainnet: new EtherscanProvider('homestead', apiKey),
+        mainnet: mainnetProvider,
         testnet: ETH_TESTNET_ETHERS_PROVIDER,
         stagenet: ETH_MAINNET_ETHERS_PROVIDER
       },
       dataProviders: [ethProviders],
       signer: new ETH.LedgerSigner({
         transport,
-        provider: new EtherscanProvider('homestead', apiKey),
+        provider: mainnetProvider,
         derivationPath: getDerivationPath(walletAccount, evmHDMode)
       }),
       rootDerivationPaths: getDerivationPaths(walletAccount, evmHDMode),

--- a/src/main/api/ledger/evm/approve.ts
+++ b/src/main/api/ledger/evm/approve.ts
@@ -2,7 +2,7 @@ import { UPPER_FEE_BOUND as BASE_UPPER_FEE_BOUND } from '@xchainjs/xchain-base'
 import { FeeOption, Network, TxHash } from '@xchainjs/xchain-client'
 import { defaultEthParams, UPPER_FEE_BOUND } from '@xchainjs/xchain-ethereum'
 import { ClientLedger, LedgerSigner } from '@xchainjs/xchain-evm'
-import { EtherscanProvider } from 'ethers'
+import { EtherscanProvider, JsonRpcProvider } from 'ethers'
 
 import { IPCLedgerApproveERC20TokenParams } from '../../../../shared/api/io'
 import { defaultArbParams } from '../../../../shared/arb/const'
@@ -24,23 +24,31 @@ export const approveLedgerERC20Token = async ({
   walletAccount,
   walletIndex,
   hdMode,
-  apiKey
+  apiKey,
+  evmRpcUrl
 }: IPCLedgerApproveERC20TokenParams): Promise<TxHash> => {
   let clientParams
   const transport = await TransportNodeHidSingleton.default.create()
+  const isTestnet = network === Network.Testnet
+
   switch (chain) {
-    case 'ETH':
+    case 'ETH': {
+      // Use custom RPC URL if provided, otherwise use EtherscanProvider
+      const mainnetProvider = evmRpcUrl
+        ? new JsonRpcProvider(evmRpcUrl, 'homestead')
+        : new EtherscanProvider('homestead', apiKey)
+
       clientParams = {
         ...defaultEthParams,
         providers: {
-          mainnet: new EtherscanProvider('homestead', apiKey),
+          mainnet: mainnetProvider,
           testnet: ETH_TESTNET_ETHERS_PROVIDER,
           stagenet: ETH_MAINNET_ETHERS_PROVIDER
         },
         dataProviders: [createEthProviders(apiKey)],
         signer: new LedgerSigner({
           transport,
-          provider: new EtherscanProvider('homestead', apiKey),
+          provider: mainnetProvider,
           derivationPath: getDerivationPath(walletAccount, hdMode)
         }),
         rootDerivationPaths: getDerivationPaths(walletAccount, hdMode),
@@ -51,12 +59,22 @@ export const approveLedgerERC20Token = async ({
         }
       }
       break
-    case 'ARB':
+    }
+    case 'ARB': {
+      // Arbitrum One mainnet: 42161, Arbitrum Sepolia testnet: 421614
+      const chainId = isTestnet ? 421614 : 42161
+      const networkName = isTestnet ? 'arbitrum-sepolia' : 'arbitrum'
+
+      const provider = evmRpcUrl
+        ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+        : defaultArbParams.providers[network]
+
       clientParams = {
         ...defaultArbParams,
+        providers: evmRpcUrl ? { ...defaultArbParams.providers, [network]: provider } : defaultArbParams.providers,
         signer: new LedgerSigner({
           transport,
-          provider: defaultArbParams.providers[Network.Mainnet],
+          provider,
           derivationPath: getDerivationPath(walletAccount, hdMode)
         }),
         rootDerivationPaths: getDerivationPaths(walletAccount, hdMode),
@@ -67,12 +85,22 @@ export const approveLedgerERC20Token = async ({
         }
       }
       break
-    case 'AVAX':
+    }
+    case 'AVAX': {
+      // AVAX mainnet: 43114, Fuji testnet: 43113
+      const chainId = isTestnet ? 43113 : 43114
+      const networkName = isTestnet ? 'fuji' : 'avalanche'
+
+      const provider = evmRpcUrl
+        ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+        : defaultAvaxParams.providers[network]
+
       clientParams = {
         ...defaultAvaxParams,
+        providers: evmRpcUrl ? { ...defaultAvaxParams.providers, [network]: provider } : defaultAvaxParams.providers,
         signer: new LedgerSigner({
           transport,
-          provider: defaultAvaxParams.providers[Network.Mainnet],
+          provider,
           derivationPath: getDerivationPath(walletAccount, hdMode)
         }),
         rootDerivationPaths: getDerivationPaths(walletAccount, hdMode),
@@ -83,12 +111,22 @@ export const approveLedgerERC20Token = async ({
         }
       }
       break
-    case 'BSC':
+    }
+    case 'BSC': {
+      // BSC mainnet: 56, BSC testnet: 97
+      const chainId = isTestnet ? 97 : 56
+      const networkName = isTestnet ? 'bnb-testnet' : 'bnb'
+
+      const provider = evmRpcUrl
+        ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+        : defaultBscParams.providers[network]
+
       clientParams = {
         ...defaultBscParams,
+        providers: evmRpcUrl ? { ...defaultBscParams.providers, [network]: provider } : defaultBscParams.providers,
         signer: new LedgerSigner({
           transport,
-          provider: defaultBscParams.providers[Network.Mainnet],
+          provider,
           derivationPath: getDerivationPath(walletAccount, hdMode)
         }),
         rootDerivationPaths: getDerivationPaths(walletAccount, hdMode),
@@ -99,12 +137,22 @@ export const approveLedgerERC20Token = async ({
         }
       }
       break
-    case 'BASE':
+    }
+    case 'BASE': {
+      // Base mainnet: 8453, Base Sepolia testnet: 84532
+      const chainId = isTestnet ? 84532 : 8453
+      const networkName = isTestnet ? 'base-sepolia' : 'base'
+
+      const provider = evmRpcUrl
+        ? new JsonRpcProvider(evmRpcUrl, { name: networkName, chainId })
+        : defaultBaseParams.providers[network]
+
       clientParams = {
         ...defaultBaseParams,
+        providers: evmRpcUrl ? { ...defaultBaseParams.providers, [network]: provider } : defaultBaseParams.providers,
         signer: new LedgerSigner({
           transport,
-          provider: defaultBaseParams.providers[Network.Mainnet],
+          provider,
           derivationPath: getDerivationPath(walletAccount, hdMode)
         }),
         rootDerivationPaths: getDerivationPaths(walletAccount, hdMode),
@@ -115,6 +163,7 @@ export const approveLedgerERC20Token = async ({
         }
       }
       break
+    }
     default:
       throw new Error(`Unsupported chain: ${chain}`)
   }

--- a/src/main/api/ledger/transaction.ts
+++ b/src/main/api/ledger/transaction.ts
@@ -156,7 +156,13 @@ const chainSendFunctions: Record<
         msg: `Eth needs an api key ${chainToString(ETHChain)}`
       })
     }
-    return ETH.send({ ...params, feeOption: params.feeOption, evmHDMode: params.hdMode, apiKey: params.apiKey })
+    return ETH.send({
+      ...params,
+      feeOption: params.feeOption,
+      evmHDMode: params.hdMode,
+      apiKey: params.apiKey,
+      evmRpcUrl: params.evmRpcUrl
+    })
   },
   [AVAXChain]: async (params) => {
     if (!params.asset) {
@@ -177,7 +183,7 @@ const chainSendFunctions: Record<
         msg: `Invalid EvmHDMode set - needed to send Ledger transaction on ${chainToString(AVAXChain)}`
       })
     }
-    return AVAX.send({ ...params, feeOption: params.feeOption, evmHDMode: params.hdMode })
+    return AVAX.send({ ...params, feeOption: params.feeOption, evmHDMode: params.hdMode, evmRpcUrl: params.evmRpcUrl })
   },
   [BASEChain]: async (params) => {
     if (!params.asset) {
@@ -198,7 +204,7 @@ const chainSendFunctions: Record<
         msg: `Invalid EvmHDMode set - needed to send Ledger transaction on ${chainToString(BASEChain)}`
       })
     }
-    return BASE.send({ ...params, feeOption: params.feeOption, evmHDMode: params.hdMode })
+    return BASE.send({ ...params, feeOption: params.feeOption, evmHDMode: params.hdMode, evmRpcUrl: params.evmRpcUrl })
   },
   [BSCChain]: async (params) => {
     if (!params.asset) {
@@ -219,7 +225,7 @@ const chainSendFunctions: Record<
         msg: `Invalid EvmHDMode set - needed to send Ledger transaction on ${chainToString(BSCChain)}`
       })
     }
-    return BSC.send({ ...params, feeOption: params.feeOption, evmHDMode: params.hdMode })
+    return BSC.send({ ...params, feeOption: params.feeOption, evmHDMode: params.hdMode, evmRpcUrl: params.evmRpcUrl })
   },
   [ARBChain]: async (params) => {
     if (!params.asset) {
@@ -240,7 +246,7 @@ const chainSendFunctions: Record<
         msg: `Invalid EvmHDMode set - needed to send Ledger transaction on ${chainToString(ARBChain)}`
       })
     }
-    return ARB.send({ ...params, feeOption: params.feeOption, evmHDMode: params.hdMode })
+    return ARB.send({ ...params, feeOption: params.feeOption, evmHDMode: params.hdMode, evmRpcUrl: params.evmRpcUrl })
   },
   [GAIAChain]: async (params) => {
     if (!params.asset) {
@@ -314,7 +320,8 @@ export const sendTx = async ({
   nodeUrl,
   hdMode,
   apiKey,
-  destinationTag
+  destinationTag,
+  evmRpcUrl
 }: IPCLedgerSendTxParams): Promise<E.Either<LedgerError, TxHash>> => {
   try {
     const transport = await TransportNodeHidSingleton.default.create()
@@ -352,7 +359,8 @@ export const sendTx = async ({
       hdMode,
       feeAsset: undefined,
       apiKey,
-      destinationTag
+      destinationTag,
+      evmRpcUrl
     })
     await transport.close()
     return res
@@ -398,7 +406,8 @@ const chainDepositFunctions: Record<
     walletIndex,
     feeOption,
     hdMode,
-    apiKey
+    apiKey,
+    evmRpcUrl
   }) => {
     if (!router) {
       return E.left({
@@ -448,7 +457,8 @@ const chainDepositFunctions: Record<
       recipient,
       feeOption,
       evmHDMode: hdMode,
-      apiKey
+      apiKey,
+      evmRpcUrl
     })
   },
   [AVAXChain]: async (params) => {
@@ -494,7 +504,8 @@ const chainDepositFunctions: Record<
       walletIndex: params.walletIndex,
       recipient: params.recipient,
       feeOption: params.feeOption,
-      evmHDMode: params.hdMode
+      evmHDMode: params.hdMode,
+      evmRpcUrl: params.evmRpcUrl
     })
   },
   [BSCChain]: async (params) => {
@@ -540,7 +551,8 @@ const chainDepositFunctions: Record<
       walletIndex: params.walletIndex,
       recipient: params.recipient,
       feeOption: params.feeOption,
-      evmHDMode: params.hdMode
+      evmHDMode: params.hdMode,
+      evmRpcUrl: params.evmRpcUrl
     })
   },
   [BASEChain]: async (params) => {
@@ -586,7 +598,8 @@ const chainDepositFunctions: Record<
       walletIndex: params.walletIndex,
       recipient: params.recipient,
       feeOption: params.feeOption,
-      evmHDMode: params.hdMode
+      evmHDMode: params.hdMode,
+      evmRpcUrl: params.evmRpcUrl
     })
   },
   [ARBChain]: async (params) => {
@@ -632,7 +645,8 @@ const chainDepositFunctions: Record<
       walletIndex: params.walletIndex,
       recipient: params.recipient,
       feeOption: params.feeOption,
-      evmHDMode: params.hdMode
+      evmHDMode: params.hdMode,
+      evmRpcUrl: params.evmRpcUrl
     })
   }
 }
@@ -650,7 +664,8 @@ export const deposit = async ({
   feeOption,
   nodeUrl,
   hdMode,
-  apiKey
+  apiKey,
+  evmRpcUrl
 }: IPCLedgerDepositTxParams): Promise<E.Either<LedgerError, TxHash>> => {
   try {
     const transport = await TransportNodeHidSingleton.default.create()
@@ -684,7 +699,8 @@ export const deposit = async ({
       feeOption,
       nodeUrl,
       hdMode,
-      apiKey
+      apiKey,
+      evmRpcUrl
     })
     await transport.close()
     return res

--- a/src/renderer/i18n/fr/common.ts
+++ b/src/renderer/i18n/fr/common.ts
@@ -222,7 +222,7 @@ const common: CommonMessages = {
   'common.importTokens': 'Importer des tokens',
   'common.searchToken': 'Rechercher un token',
   'common.warning.token.import':
-    'N\'importe qui peut créer des tokens, y compris de fausses versions de tokens existants. Veuillez faire attention aux arnaques et aux risques de sécurité.'
+    "N'importe qui peut créer des tokens, y compris de fausses versions de tokens existants. Veuillez faire attention aux arnaques et aux risques de sécurité."
 }
 
 export default common

--- a/src/renderer/i18n/fr/settings.ts
+++ b/src/renderer/i18n/fr/settings.ts
@@ -70,7 +70,8 @@ const settings: SettingMessages = {
   'settings.expert.evm.base.title': 'RPC Base',
   'settings.evm.rpc.error.url': 'URL RPC EVM invalide. Veuillez vérifier et réessayer',
   'settings.evm.rpc.valid': 'URL RPC EVM valide',
-  'settings.evm.rpc.unhealthy': "Le point d'accès RPC ne répond pas. Vérifiez votre connexion ou essayez une autre URL.",
+  'settings.evm.rpc.unhealthy':
+    "Le point d'accès RPC ne répond pas. Vérifiez votre connexion ou essayez une autre URL.",
   'settings.ledgerMode.lockWalletWarning': "Verrouillez d'abord le portefeuille pour entrer en mode Ledger",
   'settings.wallet.whitelist': 'Liste blanche',
   'settings.wallet.customToken': 'Token personnalisé'

--- a/src/renderer/services/arb/index.ts
+++ b/src/renderer/services/arb/index.ts
@@ -1,4 +1,5 @@
 import { network$ } from '../app/service'
+import { arbRpc$ } from '../storage/common'
 import {
   reloadBalances,
   balances$,
@@ -22,7 +23,7 @@ const {
   sendPoolTx$,
   approveERC20Token$,
   isApprovedERC20Token$
-} = createTransactionService(client$, network$)
+} = createTransactionService(client$, network$, arbRpc$)
 const { reloadFees, fees$, poolInTxFees$, approveFee$, reloadApproveFee } = createFeesService(enhancedClient$)
 
 export {

--- a/src/renderer/services/arb/transaction.ts
+++ b/src/renderer/services/arb/transaction.ts
@@ -16,7 +16,7 @@ import {
   IPCLedgerSendTxParams,
   ipcLedgerSendTxParamsIO
 } from '../../../shared/api/io'
-import { LedgerError } from '../../../shared/api/types'
+import { ApiUrls, LedgerError } from '../../../shared/api/types'
 import { getBlocktime } from '../../../shared/evm/provider'
 import { isError, isEvmHDMode, isLedgerWallet } from '../../../shared/utils/guard'
 import { addressInArbWhitelist, getEVMAssetAddress, isEVMTokenAsset } from '../../helpers/assetHelper'
@@ -39,7 +39,11 @@ import {
 } from '../evm/types'
 import { ApiError, ErrorId, TxHashLD } from '../wallet/types'
 
-export const createTransactionService = (client$: Client$, network$: Network$): TransactionService => {
+export const createTransactionService = (
+  client$: Client$,
+  network$: Network$,
+  evmRpc$: Rx.Observable<ApiUrls>
+): TransactionService => {
   const common = C.createTransactionService(client$)
 
   // Note: We don't use `client.deposit` to send "pool" txs to avoid repeating same requests we already do in ASGARDEX
@@ -118,7 +122,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
   }
 
-  const sendLedgerPoolTx = ({ network, params }: { network: Network; params: SendPoolTxParams }): TxHashLD => {
+  const sendLedgerPoolTx = ({
+    network,
+    params,
+    evmRpcUrl
+  }: {
+    network: Network
+    params: SendPoolTxParams
+    evmRpcUrl: string
+  }): TxHashLD => {
     const ipcParams: IPCLedgerDepositTxParams = {
       chain: ARBChain,
       network,
@@ -132,7 +144,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       feeOption: params.feeOption,
       nodeUrl: undefined,
       hdMode: params.hdMode,
-      apiKey: undefined
+      apiKey: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerDepositTxParamsIO.encode(ipcParams)
 
@@ -159,8 +172,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
   const sendPoolTx$ = (params: SendPoolTxParams): TxHashLD => {
     if (isLedgerWallet(params.walletType))
       return FP.pipe(
-        network$,
-        RxOp.switchMap((network) => sendLedgerPoolTx({ network, params }))
+        Rx.combineLatest([network$, evmRpc$]),
+        RxOp.switchMap(([network, rpcUrls]) => sendLedgerPoolTx({ network, params, evmRpcUrl: rpcUrls[network] }))
       )
 
     return FP.pipe(
@@ -212,8 +225,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     spenderAddress,
     walletAccount,
     walletIndex,
-    hdMode
-  }: ApproveParams): TxHashLD => {
+    hdMode,
+    evmRpcUrl
+  }: ApproveParams & { evmRpcUrl: string }): TxHashLD => {
     if (!isEvmHDMode(hdMode)) {
       return Rx.of(
         RD.failure({
@@ -231,7 +245,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       walletAccount,
       walletIndex,
       hdMode,
-      apiKey: undefined
+      apiKey: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerApproveERC20TokenParamsIO.encode(ipcParams)
 
@@ -276,7 +291,11 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
         })
       )
 
-    if (isLedgerWallet(walletType)) return runApproveLedgerERC20Token$(params)
+    if (isLedgerWallet(walletType))
+      return FP.pipe(
+        evmRpc$,
+        RxOp.switchMap((rpcUrls) => runApproveLedgerERC20Token$({ ...params, evmRpcUrl: rpcUrls[network] }))
+      )
 
     return client$.pipe(
       RxOp.switchMap((oClient) =>
@@ -327,7 +346,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       )
     )
 
-  const sendLedgerTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD => {
+  const sendLedgerTx = ({
+    network,
+    params,
+    evmRpcUrl
+  }: {
+    network: Network
+    params: SendTxParams
+    evmRpcUrl: string
+  }): TxHashLD => {
     const ipcParams: IPCLedgerSendTxParams = {
       chain: ARBChain,
       network,
@@ -345,7 +372,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: params.hdMode,
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(ipcParams)
 
@@ -371,9 +399,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
 
   const sendTx = (params: SendTxParams) =>
     FP.pipe(
-      network$,
-      RxOp.switchMap((network) => {
-        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
+      Rx.combineLatest([network$, evmRpc$]),
+      RxOp.switchMap(([network, rpcUrls]) => {
+        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params, evmRpcUrl: rpcUrls[network] })
 
         return common.sendTx(params)
       })

--- a/src/renderer/services/avax/index.ts
+++ b/src/renderer/services/avax/index.ts
@@ -1,4 +1,5 @@
 import { network$ } from '../app/service'
+import { avaxRpc$ } from '../storage/common'
 import {
   reloadBalances,
   balances$,
@@ -22,7 +23,7 @@ const {
   sendPoolTx$,
   approveERC20Token$,
   isApprovedERC20Token$
-} = createTransactionService(client$, network$)
+} = createTransactionService(client$, network$, avaxRpc$)
 const { reloadFees, fees$, poolInTxFees$, approveFee$, reloadApproveFee } = createFeesService(enhancedClient$)
 
 export {

--- a/src/renderer/services/avax/transaction.ts
+++ b/src/renderer/services/avax/transaction.ts
@@ -17,7 +17,7 @@ import {
   IPCLedgerSendTxParams,
   ipcLedgerSendTxParamsIO
 } from '../../../shared/api/io'
-import { LedgerError } from '../../../shared/api/types'
+import { ApiUrls, LedgerError } from '../../../shared/api/types'
 import { getBlocktime } from '../../../shared/evm/provider'
 import { isError, isEvmHDMode, isLedgerWallet } from '../../../shared/utils/guard'
 import { addressInAvaxWhitelist, getEVMAssetAddress, isEVMTokenAsset } from '../../helpers/assetHelper'
@@ -39,7 +39,11 @@ import {
 } from '../evm/types'
 import { ApiError, ErrorId, TxHashLD } from '../wallet/types'
 
-export const createTransactionService = (client$: Client$, network$: Network$): TransactionService => {
+export const createTransactionService = (
+  client$: Client$,
+  network$: Network$,
+  evmRpc$: Rx.Observable<ApiUrls>
+): TransactionService => {
   const common = C.createTransactionService(client$)
 
   // Note: We don't use `client.deposit` to send "pool" txs to avoid repeating same requests we already do in ASGARDEX
@@ -111,7 +115,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
   }
 
-  const sendLedgerPoolTx = ({ network, params }: { network: Network; params: SendPoolTxParams }): TxHashLD => {
+  const sendLedgerPoolTx = ({
+    network,
+    params,
+    evmRpcUrl
+  }: {
+    network: Network
+    params: SendPoolTxParams
+    evmRpcUrl: string
+  }): TxHashLD => {
     const ipcParams: IPCLedgerDepositTxParams = {
       chain: AVAXChain,
       network,
@@ -125,7 +137,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       feeOption: params.feeOption,
       nodeUrl: undefined,
       hdMode: params.hdMode,
-      apiKey: undefined
+      apiKey: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerDepositTxParamsIO.encode(ipcParams)
 
@@ -152,8 +165,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
   const sendPoolTx$ = (params: SendPoolTxParams): TxHashLD => {
     if (isLedgerWallet(params.walletType))
       return FP.pipe(
-        network$,
-        RxOp.switchMap((network) => sendLedgerPoolTx({ network, params }))
+        Rx.combineLatest([network$, evmRpc$]),
+        RxOp.switchMap(([network, rpcUrls]) => sendLedgerPoolTx({ network, params, evmRpcUrl: rpcUrls[network] }))
       )
 
     return FP.pipe(
@@ -205,8 +218,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     spenderAddress,
     walletAccount,
     walletIndex,
-    hdMode
-  }: ApproveParams): TxHashLD => {
+    hdMode,
+    evmRpcUrl
+  }: ApproveParams & { evmRpcUrl: string }): TxHashLD => {
     if (!isEvmHDMode(hdMode)) {
       return Rx.of(
         RD.failure({
@@ -224,7 +238,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       walletAccount,
       walletIndex,
       hdMode,
-      apiKey: undefined
+      apiKey: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerApproveERC20TokenParamsIO.encode(ipcParams)
 
@@ -269,7 +284,11 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
         })
       )
 
-    if (isLedgerWallet(walletType)) return runApproveLedgerERC20Token$(params)
+    if (isLedgerWallet(walletType))
+      return FP.pipe(
+        evmRpc$,
+        RxOp.switchMap((rpcUrls) => runApproveLedgerERC20Token$({ ...params, evmRpcUrl: rpcUrls[network] }))
+      )
 
     return client$.pipe(
       RxOp.switchMap((oClient) =>
@@ -320,7 +339,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       )
     )
 
-  const sendLedgerTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD => {
+  const sendLedgerTx = ({
+    network,
+    params,
+    evmRpcUrl
+  }: {
+    network: Network
+    params: SendTxParams
+    evmRpcUrl: string
+  }): TxHashLD => {
     const ipcParams: IPCLedgerSendTxParams = {
       chain: AVAXChain,
       network,
@@ -338,7 +365,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: params.hdMode,
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(ipcParams)
 
@@ -364,9 +392,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
 
   const sendTx = (params: SendTxParams) =>
     FP.pipe(
-      network$,
-      RxOp.switchMap((network) => {
-        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
+      Rx.combineLatest([network$, evmRpc$]),
+      RxOp.switchMap(([network, rpcUrls]) => {
+        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params, evmRpcUrl: rpcUrls[network] })
 
         return common.sendTx(params)
       })

--- a/src/renderer/services/base/index.ts
+++ b/src/renderer/services/base/index.ts
@@ -1,4 +1,5 @@
 import { network$ } from '../app/service'
+import { baseRpc$ } from '../storage/common'
 import {
   reloadBalances,
   balances$,
@@ -22,7 +23,7 @@ const {
   sendPoolTx$,
   approveERC20Token$,
   isApprovedERC20Token$
-} = createTransactionService(client$, network$)
+} = createTransactionService(client$, network$, baseRpc$)
 const { reloadFees, fees$, poolInTxFees$, approveFee$, reloadApproveFee } = createFeesService(enhancedClient$)
 
 export {

--- a/src/renderer/services/base/transaction.ts
+++ b/src/renderer/services/base/transaction.ts
@@ -17,7 +17,7 @@ import {
   IPCLedgerSendTxParams,
   ipcLedgerSendTxParamsIO
 } from '../../../shared/api/io'
-import { LedgerError } from '../../../shared/api/types'
+import { ApiUrls, LedgerError } from '../../../shared/api/types'
 import { getBlocktime } from '../../../shared/evm/provider'
 import { isError, isEvmHDMode, isLedgerWallet } from '../../../shared/utils/guard'
 import { addressInBaseWhitelist, getEVMAssetAddress, isEVMTokenAsset } from '../../helpers/assetHelper'
@@ -39,7 +39,11 @@ import {
 } from '../evm/types'
 import { ApiError, ErrorId, TxHashLD } from '../wallet/types'
 
-export const createTransactionService = (client$: Client$, network$: Network$): TransactionService => {
+export const createTransactionService = (
+  client$: Client$,
+  network$: Network$,
+  evmRpc$: Rx.Observable<ApiUrls>
+): TransactionService => {
   const common = C.createTransactionService(client$)
 
   // Note: We don't use `client.deposit` to send "pool" txs to avoid repeating same requests we already do in ASGARDEX
@@ -110,7 +114,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
   }
 
-  const sendLedgerPoolTx = ({ network, params }: { network: Network; params: SendPoolTxParams }): TxHashLD => {
+  const sendLedgerPoolTx = ({
+    network,
+    params,
+    evmRpcUrl
+  }: {
+    network: Network
+    params: SendPoolTxParams
+    evmRpcUrl: string
+  }): TxHashLD => {
     const ipcParams: IPCLedgerDepositTxParams = {
       chain: BASEChain,
       network,
@@ -124,7 +136,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       feeOption: params.feeOption,
       nodeUrl: undefined,
       hdMode: params.hdMode,
-      apiKey: undefined
+      apiKey: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerDepositTxParamsIO.encode(ipcParams)
 
@@ -151,8 +164,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
   const sendPoolTx$ = (params: SendPoolTxParams): TxHashLD => {
     if (isLedgerWallet(params.walletType))
       return FP.pipe(
-        network$,
-        RxOp.switchMap((network) => sendLedgerPoolTx({ network, params }))
+        Rx.combineLatest([network$, evmRpc$]),
+        RxOp.switchMap(([network, rpcUrls]) => sendLedgerPoolTx({ network, params, evmRpcUrl: rpcUrls[network] }))
       )
 
     return FP.pipe(
@@ -204,13 +217,14 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     spenderAddress,
     walletAccount,
     walletIndex,
-    hdMode
-  }: ApproveParams): TxHashLD => {
+    hdMode,
+    evmRpcUrl
+  }: ApproveParams & { evmRpcUrl: string }): TxHashLD => {
     if (!isEvmHDMode(hdMode)) {
       return Rx.of(
         RD.failure({
           errorId: ErrorId.APPROVE_LEDGER_TX,
-          msg: `Invalid AvaxHDMode ${hdMode} - needed for Ledger to send ERC20 token.`
+          msg: `Invalid BaseHDMode ${hdMode} - needed for Ledger to send ERC20 token.`
         })
       )
     }
@@ -223,7 +237,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       walletAccount,
       walletIndex,
       hdMode,
-      apiKey: undefined
+      apiKey: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerApproveERC20TokenParamsIO.encode(ipcParams)
 
@@ -268,7 +283,11 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
         })
       )
 
-    if (isLedgerWallet(walletType)) return runApproveLedgerERC20Token$(params)
+    if (isLedgerWallet(walletType))
+      return FP.pipe(
+        evmRpc$,
+        RxOp.switchMap((rpcUrls) => runApproveLedgerERC20Token$({ ...params, evmRpcUrl: rpcUrls[network] }))
+      )
 
     return client$.pipe(
       RxOp.switchMap((oClient) =>
@@ -319,7 +338,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       )
     )
 
-  const sendLedgerTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD => {
+  const sendLedgerTx = ({
+    network,
+    params,
+    evmRpcUrl
+  }: {
+    network: Network
+    params: SendTxParams
+    evmRpcUrl: string
+  }): TxHashLD => {
     const ipcParams: IPCLedgerSendTxParams = {
       chain: BASEChain,
       network,
@@ -337,7 +364,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: params.hdMode,
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(ipcParams)
 
@@ -363,9 +391,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
 
   const sendTx = (params: SendTxParams) =>
     FP.pipe(
-      network$,
-      RxOp.switchMap((network) => {
-        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
+      Rx.combineLatest([network$, evmRpc$]),
+      RxOp.switchMap(([network, rpcUrls]) => {
+        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params, evmRpcUrl: rpcUrls[network] })
 
         return common.sendTx(params)
       })

--- a/src/renderer/services/bitcoin/transaction.ts
+++ b/src/renderer/services/bitcoin/transaction.ts
@@ -38,7 +38,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode,
       apiKey: blockcypherApiKey,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
 
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)

--- a/src/renderer/services/bitcoincash/transaction.ts
+++ b/src/renderer/services/bitcoincash/transaction.ts
@@ -37,7 +37,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode,
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/bsc/index.ts
+++ b/src/renderer/services/bsc/index.ts
@@ -1,4 +1,5 @@
 import { network$ } from '../app/service'
+import { bscRpc$ } from '../storage/common'
 import {
   reloadBalances,
   balances$,
@@ -22,7 +23,7 @@ const {
   sendPoolTx$,
   approveERC20Token$,
   isApprovedERC20Token$
-} = createTransactionService(client$, network$)
+} = createTransactionService(client$, network$, bscRpc$)
 const { reloadFees, fees$, poolInTxFees$, approveFee$, reloadApproveFee } = createFeesService(enhancedClient$)
 
 export {

--- a/src/renderer/services/bsc/transaction.ts
+++ b/src/renderer/services/bsc/transaction.ts
@@ -17,7 +17,7 @@ import {
   IPCLedgerSendTxParams,
   ipcLedgerSendTxParamsIO
 } from '../../../shared/api/io'
-import { LedgerError } from '../../../shared/api/types'
+import { ApiUrls, LedgerError } from '../../../shared/api/types'
 import { getBlocktime } from '../../../shared/evm/provider'
 import { isError, isEvmHDMode, isLedgerWallet } from '../../../shared/utils/guard'
 import { addressInBscWhitelist, getEVMAssetAddress, isEVMTokenAsset } from '../../helpers/assetHelper'
@@ -39,7 +39,11 @@ import {
 } from '../evm/types'
 import { ApiError, ErrorId, TxHashLD } from '../wallet/types'
 
-export const createTransactionService = (client$: Client$, network$: Network$): TransactionService => {
+export const createTransactionService = (
+  client$: Client$,
+  network$: Network$,
+  evmRpc$: Rx.Observable<ApiUrls>
+): TransactionService => {
   const common = C.createTransactionService(client$)
 
   // Note: We don't use `client.deposit` to send "pool" txs to avoid repeating same requests we already do in ASGARDEX
@@ -109,7 +113,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
   }
 
-  const sendLedgerPoolTx = ({ network, params }: { network: Network; params: SendPoolTxParams }): TxHashLD => {
+  const sendLedgerPoolTx = ({
+    network,
+    params,
+    evmRpcUrl
+  }: {
+    network: Network
+    params: SendPoolTxParams
+    evmRpcUrl: string
+  }): TxHashLD => {
     const ipcParams: IPCLedgerDepositTxParams = {
       chain: BSCChain,
       network,
@@ -123,7 +135,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       feeOption: params.feeOption,
       nodeUrl: undefined,
       hdMode: params.hdMode,
-      apiKey: undefined
+      apiKey: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerDepositTxParamsIO.encode(ipcParams)
 
@@ -150,8 +163,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
   const sendPoolTx$ = (params: SendPoolTxParams): TxHashLD => {
     if (isLedgerWallet(params.walletType))
       return FP.pipe(
-        network$,
-        RxOp.switchMap((network) => sendLedgerPoolTx({ network, params }))
+        Rx.combineLatest([network$, evmRpc$]),
+        RxOp.switchMap(([network, rpcUrls]) => sendLedgerPoolTx({ network, params, evmRpcUrl: rpcUrls[network] }))
       )
 
     return FP.pipe(
@@ -203,8 +216,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     spenderAddress,
     walletAccount,
     walletIndex,
-    hdMode
-  }: ApproveParams): TxHashLD => {
+    hdMode,
+    evmRpcUrl
+  }: ApproveParams & { evmRpcUrl: string }): TxHashLD => {
     if (!isEvmHDMode(hdMode)) {
       return Rx.of(
         RD.failure({
@@ -222,7 +236,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       walletAccount,
       walletIndex,
       hdMode,
-      apiKey: undefined
+      apiKey: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerApproveERC20TokenParamsIO.encode(ipcParams)
 
@@ -267,7 +282,11 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
         })
       )
 
-    if (isLedgerWallet(walletType)) return runApproveLedgerERC20Token$(params)
+    if (isLedgerWallet(walletType))
+      return FP.pipe(
+        evmRpc$,
+        RxOp.switchMap((rpcUrls) => runApproveLedgerERC20Token$({ ...params, evmRpcUrl: rpcUrls[network] }))
+      )
 
     return client$.pipe(
       RxOp.switchMap((oClient) =>
@@ -318,7 +337,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       )
     )
 
-  const sendLedgerTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD => {
+  const sendLedgerTx = ({
+    network,
+    params,
+    evmRpcUrl
+  }: {
+    network: Network
+    params: SendTxParams
+    evmRpcUrl: string
+  }): TxHashLD => {
     const ipcParams: IPCLedgerSendTxParams = {
       chain: BSCChain,
       network,
@@ -336,7 +363,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: params.hdMode,
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(ipcParams)
 
@@ -362,9 +390,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
 
   const sendTx = (params: SendTxParams) =>
     FP.pipe(
-      network$,
-      RxOp.switchMap((network) => {
-        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
+      Rx.combineLatest([network$, evmRpc$]),
+      RxOp.switchMap(([network, rpcUrls]) => {
+        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params, evmRpcUrl: rpcUrls[network] })
 
         return common.sendTx(params)
       })

--- a/src/renderer/services/cardano/transaction.ts
+++ b/src/renderer/services/cardano/transaction.ts
@@ -35,7 +35,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: 'default',
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/cosmos/transaction.ts
+++ b/src/renderer/services/cosmos/transaction.ts
@@ -59,7 +59,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: 'default',
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/dash/transaction.ts
+++ b/src/renderer/services/dash/transaction.ts
@@ -57,7 +57,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode,
       apiKey: blockcypherApiKey,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
     return FP.pipe(

--- a/src/renderer/services/doge/transaction.ts
+++ b/src/renderer/services/doge/transaction.ts
@@ -38,7 +38,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode,
       apiKey: blockcypherApiKey,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/ethereum/index.ts
+++ b/src/renderer/services/ethereum/index.ts
@@ -1,4 +1,5 @@
 import { network$ } from '../app/service'
+import { ethRpc$ } from '../storage/common'
 import {
   reloadBalances,
   balances$,
@@ -22,7 +23,7 @@ const {
   sendPoolTx$,
   approveERC20Token$,
   isApprovedERC20Token$
-} = createTransactionService(client$, network$)
+} = createTransactionService(client$, network$, ethRpc$)
 const { reloadFees, fees$, poolInTxFees$, approveFee$, reloadApproveFee } = createFeesService(enhancedClient$)
 
 export {

--- a/src/renderer/services/ethereum/transaction.ts
+++ b/src/renderer/services/ethereum/transaction.ts
@@ -10,6 +10,7 @@ import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
 import { etherscanApiKey } from '../../../shared/api/etherscan'
+import { ApiUrls } from '../../../shared/api/types'
 import {
   IPCLedgerApproveERC20TokenParams,
   ipcLedgerApproveERC20TokenParamsIO,
@@ -40,7 +41,11 @@ import {
 } from '../evm/types'
 import { ApiError, ErrorId, TxHashLD } from '../wallet/types'
 
-export const createTransactionService = (client$: Client$, network$: Network$): TransactionService => {
+export const createTransactionService = (
+  client$: Client$,
+  network$: Network$,
+  evmRpc$: Rx.Observable<ApiUrls>
+): TransactionService => {
   const common = C.createTransactionService(client$)
 
   // Note: We don't use `client.deposit` to send "pool" txs to avoid repeating same requests we already do in ASGARDEX
@@ -112,7 +117,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
   }
 
-  const sendLedgerPoolTx = ({ network, params }: { network: Network; params: SendPoolTxParams }): TxHashLD => {
+  const sendLedgerPoolTx = ({
+    network,
+    params,
+    evmRpcUrl
+  }: {
+    network: Network
+    params: SendPoolTxParams
+    evmRpcUrl: string
+  }): TxHashLD => {
     const ipcParams: IPCLedgerDepositTxParams = {
       chain: ETHChain,
       network,
@@ -126,7 +139,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       feeOption: params.feeOption,
       nodeUrl: undefined,
       hdMode: params.hdMode,
-      apiKey: etherscanApiKey
+      apiKey: etherscanApiKey,
+      evmRpcUrl
     }
     const encoded = ipcLedgerDepositTxParamsIO.encode(ipcParams)
     return FP.pipe(
@@ -152,8 +166,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
   const sendPoolTx$ = (params: SendPoolTxParams): TxHashLD => {
     if (isLedgerWallet(params.walletType))
       return FP.pipe(
-        network$,
-        RxOp.switchMap((network) => sendLedgerPoolTx({ network, params }))
+        Rx.combineLatest([network$, evmRpc$]),
+        RxOp.switchMap(([network, rpcUrls]) => sendLedgerPoolTx({ network, params, evmRpcUrl: rpcUrls[network] }))
       )
 
     return FP.pipe(
@@ -205,8 +219,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     spenderAddress,
     walletAccount,
     walletIndex,
-    hdMode
-  }: ApproveParams): TxHashLD => {
+    hdMode,
+    evmRpcUrl
+  }: ApproveParams & { evmRpcUrl: string }): TxHashLD => {
     if (!isEvmHDMode(hdMode)) {
       return Rx.of(
         RD.failure({
@@ -224,7 +239,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       walletAccount,
       walletIndex,
       hdMode,
-      apiKey: etherscanApiKey
+      apiKey: etherscanApiKey,
+      evmRpcUrl
     }
     const encoded = ipcLedgerApproveERC20TokenParamsIO.encode(ipcParams)
     return FP.pipe(
@@ -268,7 +284,11 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
         })
       )
 
-    if (isLedgerWallet(walletType)) return runApproveLedgerERC20Token$(params)
+    if (isLedgerWallet(walletType))
+      return FP.pipe(
+        evmRpc$,
+        RxOp.switchMap((rpcUrls) => runApproveLedgerERC20Token$({ ...params, evmRpcUrl: rpcUrls[network] }))
+      )
 
     return client$.pipe(
       RxOp.switchMap((oClient) =>
@@ -319,7 +339,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       )
     )
 
-  const sendLedgerTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD => {
+  const sendLedgerTx = ({
+    network,
+    params,
+    evmRpcUrl
+  }: {
+    network: Network
+    params: SendTxParams
+    evmRpcUrl: string
+  }): TxHashLD => {
     const ipcParams: IPCLedgerSendTxParams = {
       chain: ETHChain,
       network,
@@ -337,7 +365,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: params.hdMode,
       apiKey: etherscanApiKey,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl
     }
 
     const encoded = ipcLedgerSendTxParamsIO.encode(ipcParams)
@@ -364,9 +393,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
 
   const sendTx = (params: SendTxParams) =>
     FP.pipe(
-      network$,
-      RxOp.switchMap((network) => {
-        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
+      Rx.combineLatest([network$, evmRpc$]),
+      RxOp.switchMap(([network, rpcUrls]) => {
+        if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params, evmRpcUrl: rpcUrls[network] })
 
         return common.sendTx(params)
       })

--- a/src/renderer/services/ethereum/transaction.ts
+++ b/src/renderer/services/ethereum/transaction.ts
@@ -10,7 +10,6 @@ import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
 import { etherscanApiKey } from '../../../shared/api/etherscan'
-import { ApiUrls } from '../../../shared/api/types'
 import {
   IPCLedgerApproveERC20TokenParams,
   ipcLedgerApproveERC20TokenParamsIO,
@@ -19,7 +18,7 @@ import {
   IPCLedgerSendTxParams,
   ipcLedgerSendTxParamsIO
 } from '../../../shared/api/io'
-import { LedgerError } from '../../../shared/api/types'
+import { ApiUrls, LedgerError } from '../../../shared/api/types'
 import { getBlocktime } from '../../../shared/evm/provider'
 import { isError, isEvmHDMode, isLedgerWallet } from '../../../shared/utils/guard'
 import { addressInERC20Whitelist, getEVMAssetAddress, isEVMTokenAsset } from '../../helpers/assetHelper'

--- a/src/renderer/services/kuji/transaction.ts
+++ b/src/renderer/services/kuji/transaction.ts
@@ -34,7 +34,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: 'default',
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/litecoin/transaction.ts
+++ b/src/renderer/services/litecoin/transaction.ts
@@ -38,7 +38,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode,
       apiKey: blockcypherApiKey,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/mayachain/transaction.ts
+++ b/src/renderer/services/mayachain/transaction.ts
@@ -54,7 +54,8 @@ export const createTransactionService = (
       feeOption: undefined,
       nodeUrl: clientUrl[network].node,
       hdMode: params.hdMode,
-      apiKey: undefined
+      apiKey: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerDepositTxParamsIO.encode(depositLedgerTxParams)
     return FP.pipe(
@@ -160,7 +161,8 @@ export const createTransactionService = (
       nodeUrl: clientUrl[network].node,
       hdMode: 'default',
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/radix/transaction.ts
+++ b/src/renderer/services/radix/transaction.ts
@@ -88,7 +88,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       feeOption: undefined,
       nodeUrl: undefined,
       hdMode: params.hdMode,
-      apiKey: undefined
+      apiKey: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerDepositTxParamsIO.encode(ipcParams)
 
@@ -151,7 +152,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: 'default',
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/ripple/transaction.ts
+++ b/src/renderer/services/ripple/transaction.ts
@@ -34,7 +34,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: 'default',
       apiKey: undefined,
-      destinationTag: params.destinationTag
+      destinationTag: params.destinationTag,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/solana/transaction.ts
+++ b/src/renderer/services/solana/transaction.ts
@@ -34,7 +34,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: 'default',
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/thorchain/transaction.ts
+++ b/src/renderer/services/thorchain/transaction.ts
@@ -53,7 +53,8 @@ export const createTransactionService = (
       feeOption: undefined,
       nodeUrl: clientUrl[network].node,
       hdMode: params.hdMode,
-      apiKey: undefined
+      apiKey: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerDepositTxParamsIO.encode(depositLedgerTxParams)
     return FP.pipe(
@@ -158,7 +159,8 @@ export const createTransactionService = (
       nodeUrl: clientUrl[network].node,
       hdMode: 'default',
       apiKey: undefined,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/tron/transaction.ts
+++ b/src/renderer/services/tron/transaction.ts
@@ -70,7 +70,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: params.hdMode,
       apiKey: undefined,
-      destinationTag: undefined // TRON doesn't need API key
+      destinationTag: undefined, // TRON doesn't need API key
+      evmRpcUrl: undefined
     }
 
     const encoded = ipcLedgerSendTxParamsIO.encode(ipcParams)

--- a/src/renderer/services/zcash/transaction.ts
+++ b/src/renderer/services/zcash/transaction.ts
@@ -37,7 +37,8 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       nodeUrl: undefined,
       hdMode: 'default',
       apiKey: blockcypherApiKey,
-      destinationTag: undefined
+      destinationTag: undefined,
+      evmRpcUrl: undefined
     }
 
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)

--- a/src/shared/api/io.test.ts
+++ b/src/shared/api/io.test.ts
@@ -103,7 +103,8 @@ describe('shared/io', () => {
         nodeUrl: 'node-url',
         hdMode: 'default',
         apiKey: 'apikey',
-        destinationTag: 1234
+        destinationTag: 1234,
+        evmRpcUrl: undefined
       })
       expect(encoded).toEqual({
         chain: 'BTC',
@@ -144,7 +145,8 @@ describe('shared/io', () => {
         nodeUrl: undefined,
         hdMode: 'default',
         apiKey: 'apikey',
-        destinationTag: 1234
+        destinationTag: 1234,
+        evmRpcUrl: undefined
       })
 
       expect(encoded).toEqual({

--- a/src/shared/api/io.ts
+++ b/src/shared/api/io.ts
@@ -123,7 +123,8 @@ export const ipcLedgerSendTxParamsIO = t.type({
   nodeUrl: t.union([t.string, t.undefined]),
   hdMode: hdModeIO,
   apiKey: t.union([t.string, t.undefined]),
-  destinationTag: t.union([t.number, t.undefined])
+  destinationTag: t.union([t.number, t.undefined]),
+  evmRpcUrl: t.union([t.string, t.undefined])
 })
 
 export type IPCLedgerSendTxParams = t.TypeOf<typeof ipcLedgerSendTxParamsIO>
@@ -141,7 +142,8 @@ export const ipcLedgerDepositTxParamsIO = t.type({
   feeOption: t.union([feeOptionIO, t.undefined]),
   nodeUrl: t.union([t.string, t.undefined]),
   hdMode: hdModeIO,
-  apiKey: t.union([t.string, t.undefined])
+  apiKey: t.union([t.string, t.undefined]),
+  evmRpcUrl: t.union([t.string, t.undefined])
 })
 
 export type IPCLedgerDepositTxParams = t.TypeOf<typeof ipcLedgerDepositTxParamsIO>
@@ -154,7 +156,8 @@ export const ipcLedgerApproveERC20TokenParamsIO = t.type({
   walletAccount: t.number,
   walletIndex: t.number,
   hdMode: evmHDModeIO,
-  apiKey: t.union([t.string, t.undefined])
+  apiKey: t.union([t.string, t.undefined]),
+  evmRpcUrl: t.union([t.string, t.undefined])
 })
 
 export type IPCLedgerApproveERC20TokenParams = t.TypeOf<typeof ipcLedgerApproveERC20TokenParamsIO>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ledger transactions on EVM-compatible chains now accept an optional custom RPC URL, letting users route Ledger send/deposit flows via a preferred RPC provider (Ethereum, Arbitrum, Avalanche, Base, BSC and others).
  * Transaction services now resolve per-network RPC URLs and propagate them to ledger flows so ledger operations use the selected endpoint when provided.
  * IPC ledger payloads include the optional RPC URL field for ledger operations.

* **Documentation**
  * Minor i18n and wording refinements for network labels and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->