### PR TITLE
Allow deposit action for Maya token

### DIFF
--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.tsx
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.tsx
@@ -477,7 +477,10 @@ export const AssetsTableCollapsable = (props: Props): JSX.Element => {
         )
       }
 
-      if ((isRuneNativeAsset(asset) || isCacaoAsset(asset) || isTCYAsset(asset)) && !isStandaloneLedger) {
+      if (
+        (isRuneNativeAsset(asset) || isTCYAsset(asset) || isCacaoAsset(asset) || isMayaAsset(asset)) &&
+        !isStandaloneLedger
+      ) {
         actions.push(createAction('wallet.action.deposit', () => assetHandler(walletAsset, 'deposit')))
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled deposit functionality for Maya assets in the wallet when not using standalone ledger mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->