### PR TITLE
refactor: extract THORName/MAYAName into standalone form components

### DIFF
--- a/src/renderer/components/wallet/txs/interact/InteractFormMaya.tsx
+++ b/src/renderer/components/wallet/txs/interact/InteractFormMaya.tsx
@@ -509,17 +509,7 @@ export const InteractFormMaya = (props: Props) => {
     }
     setMemo(createMemo)
     return createMemo
-  }, [
-    watch,
-    interactType,
-    whitelisting,
-    cacaoPoolAction,
-    cacaoPoolProvider.value,
-    _amountToSend,
-    network,
-    currentMemo,
-    memo
-  ])
+  }, [watch, interactType, whitelisting, cacaoPoolAction, cacaoPoolProvider.value, _amountToSend, network, currentMemo])
 
   const onChangeInput = useCallback(
     async (value: BigNumber) => {

--- a/src/renderer/components/wallet/txs/interact/InteractFormMaya.tsx
+++ b/src/renderer/components/wallet/txs/interact/InteractFormMaya.tsx
@@ -4,19 +4,13 @@ import * as RD from '@devexperts/remote-data-ts'
 import {
   ArrowDownTrayIcon,
   ArrowUpTrayIcon,
-  MagnifyingGlassIcon,
   MagnifyingGlassMinusIcon,
-  MagnifyingGlassPlusIcon,
-  UserIcon
+  MagnifyingGlassPlusIcon
 } from '@heroicons/react/24/outline'
-import { AssetAETH } from '@xchainjs/xchain-arbitrum'
-import { AssetBTC } from '@xchainjs/xchain-bitcoin'
 import { Network } from '@xchainjs/xchain-client'
-import { AssetETH } from '@xchainjs/xchain-ethereum'
 import { AssetCacao, CACAO_DECIMAL, MAYAChain } from '@xchainjs/xchain-mayachain'
-import { MayachainQuery, QuoteMAYANameParams, MAYANameDetails } from '@xchainjs/xchain-mayachain-query'
+import { MayachainQuery } from '@xchainjs/xchain-mayachain-query'
 import { PoolDetails } from '@xchainjs/xchain-mayamidgard'
-import { AssetRuneNative } from '@xchainjs/xchain-thorchain'
 import {
   BaseAmount,
   CryptoAmount,
@@ -73,17 +67,16 @@ import { TxModal } from '../../../modal/tx'
 import { SendAsset } from '../../../modal/tx/extra/SendAsset'
 import { AssetIcon } from '../../../uielements/assets/assetIcon'
 import { BaseButton, FlatButton, ViewTxButton } from '../../../uielements/button'
-import { CheckButton } from '../../../uielements/button/CheckButton'
 import { MaxBalanceButton } from '../../../uielements/button/MaxBalanceButton'
 import { SwitchButton } from '../../../uielements/button/SwitchButton'
-import { Fees, UIFees, UIFeesRD } from '../../../uielements/fees'
-import { InfoIcon } from '../../../uielements/info'
+import { Fees, UIFeesRD } from '../../../uielements/fees'
 import { Input, InputBigNumber } from '../../../uielements/input'
 import { Label } from '../../../uielements/label'
 import { Tooltip } from '../../../uielements/tooltip'
 import { validateTxAmountInput } from '../TxForm.util'
 import * as H from './Interact.helpers'
 import { InteractType } from './Interact.types'
+import { MAYANameForm } from './thorname/MAYANameForm'
 
 type FormValues = {
   memo: string
@@ -91,15 +84,8 @@ type FormValues = {
   providerAddress: string
   operatorFee: number
   amount: BigNumber
-  mayaname: string
-  chainAddress: string
-  chain: string
-  preferredAsset: string
-  expiry: string
   bondLpUnits: string
   assetPool: string
-  aliasChain: string
-  aliasAddress: string
 }
 type UserNodeInfo = {
   nodeAddress: string
@@ -272,7 +258,6 @@ export const InteractFormMaya = (props: Props) => {
       case InteractType.Whitelist:
         return ONE_CACAO_BASE_AMOUNT
       case InteractType.Custom:
-      case InteractType.MAYAName:
       case InteractType.THORName:
       case InteractType.RunePool:
         return _amountToSend
@@ -283,6 +268,8 @@ export const InteractFormMaya = (props: Props) => {
         const amnt = cacaoPoolAction === Action.add ? _amountToSend : ZERO_BASE_AMOUNT
         return amnt
       }
+      default:
+        return ZERO_BASE_AMOUNT
     }
   }, [_amountToSend, interactType, cacaoPoolAction])
 
@@ -308,34 +295,17 @@ export const InteractFormMaya = (props: Props) => {
     defaultValues: {
       mayaAddress: '',
       amount: bn(0),
-      chain: MAYAChain,
-      chainAddress: balance.walletAddress,
-      expiry: '1',
       memo: '',
       providerAddress: '',
       operatorFee: 0,
-      mayaname: '',
-      preferredAsset: '',
       bondLpUnits: '',
-      assetPool: '',
-      aliasChain: '',
-      aliasAddress: ''
+      assetPool: ''
     }
   })
   const [currentMemo, setCurrentMemo] = useState('')
   const [whitelisting, setWhitelisting] = useState<boolean>(true)
 
   const oFee: O.Option<BaseAmount> = useMemo(() => FP.pipe(feeRD, RD.toOption), [feeRD])
-
-  // state variable for mayanames
-  const [oMayaname, setMayaname] = useState<O.Option<MAYANameDetails>>(O.none)
-  const [mayanameAvailable, setMayanameAvailable] = useState<boolean>(false) // if Mayaname is available
-  const [mayanameUpdate, setMayanameUpdate] = useState<boolean>(false) // allow to update
-  const [mayanameRegister, setMayanameRegister] = useState<boolean>(false) // allow to update
-  const [mayanameQuoteValid, setMayanameQuoteValid] = useState<boolean>(false) // if the quote is valid then allow to buy
-  const [isOwner, setIsOwner] = useState<boolean>(false) // if the mayaname.owner is the wallet address then allow to update
-  // const [preferredAsset, setPreferredAsset] = useState<AnyAsset>()
-  const [aliasChain, setAliasChain] = useState<string>('')
 
   const isFeeError = useMemo(
     () =>
@@ -472,98 +442,6 @@ export const InteractFormMaya = (props: Props) => {
     [interactType, intl, maxAmount]
   )
 
-  const [isLookingUp, setIsLookingUp] = useState(false)
-  const [lookupMode, setLookupMode] = useState<'name' | 'owner'>('name')
-  const [ownerAddress, setOwnerAddress] = useState('')
-  const [ownerNames, setOwnerNames] = useState<MAYANameDetails[]>([])
-  const [isLookingUpOwner, setIsLookingUpOwner] = useState(false)
-  const [ownerSearchDone, setOwnerSearchDone] = useState(false)
-
-  const mayanameHandler = useCallback(async () => {
-    const mayaname = watch('mayaname')
-    setMemo('')
-    if (mayaname === '') return
-
-    setIsLookingUp(true)
-    try {
-      const mayanameDetails = await mayachainQuery.getMAYANameDetails(mayaname)
-      if (mayanameDetails) {
-        setMayaname(O.some(mayanameDetails))
-        setMayanameAvailable(mayanameDetails.owner === '' || balance.walletAddress === mayanameDetails.owner)
-        setMayanameUpdate(mayaname === mayanameDetails.name && mayanameDetails.owner === '')
-        setMayanameRegister(mayanameDetails.name === '')
-        setIsOwner(balance.walletAddress === mayanameDetails.owner)
-      }
-      if (mayanameDetails === undefined) {
-        setMayanameAvailable(true)
-        setMayanameRegister(true)
-      }
-    } catch (_error) {
-      setMayanameAvailable(false)
-    } finally {
-      setIsLookingUp(false)
-    }
-  }, [watch, mayachainQuery, balance.walletAddress])
-
-  const ownerLookupHandler = useCallback(async () => {
-    if (ownerAddress === '') return
-    setIsLookingUpOwner(true)
-    setOwnerNames([])
-    setOwnerSearchDone(false)
-    try {
-      const details = await mayachainQuery.getMAYANamesByOwner(ownerAddress)
-      if (details && details.length > 0) {
-        setOwnerNames(details)
-      }
-    } catch (_error) {
-      // no names found
-    } finally {
-      setIsLookingUpOwner(false)
-      setOwnerSearchDone(true)
-    }
-  }, [ownerAddress, mayachainQuery])
-
-  const estimateMayanameHandler = useCallback(() => {
-    const currentDate = new Date()
-
-    const mayaname = watch('mayaname')
-    const chain = mayanameRegister ? watch('chain') : watch('aliasChain')
-    const yearsToAdd = parseInt(watch('expiry'))
-    const expirity =
-      yearsToAdd === 1
-        ? undefined
-        : new Date(currentDate.getFullYear() + yearsToAdd, currentDate.getMonth(), currentDate.getDate())
-    const chainAddress = mayanameRegister ? watch('chainAddress') : watch('aliasAddress')
-    const owner = balance.walletAddress
-    if (mayaname !== undefined && chain !== undefined && chainAddress !== undefined) {
-      const fetchMayanameQuote = async () => {
-        try {
-          const params: QuoteMAYANameParams = {
-            name: mayaname,
-            chain,
-            chainAddress,
-            owner,
-            expiry: expirity,
-            isUpdate: mayanameUpdate || isOwner
-          }
-          const mayanameQuote = await mayachainQuery.estimateMAYAName(params)
-          if (mayanameQuote) {
-            setMemo(mayanameQuote.memo)
-            setAmountToSend(mayanameQuote.value.baseAmount)
-            setMayanameQuoteValid(true)
-          }
-        } catch (error) {
-          console.error('Error fetching fetchMAYANameQuote:', error)
-        }
-      }
-      fetchMayanameQuote()
-    }
-  }, [balance.walletAddress, watch, isOwner, mayachainQuery, mayanameRegister, mayanameUpdate])
-
-  const handleRadioChainChange = useCallback((radioChain: string) => {
-    setAliasChain(radioChain)
-  }, [])
-
   const addMaxAmountHandler = useCallback(
     (maxAmount: BaseAmount) => {
       setAmountToSend(maxAmount)
@@ -626,10 +504,6 @@ export const InteractFormMaya = (props: Props) => {
       }
       case InteractType.Custom: {
         createMemo = currentMemo
-        break
-      }
-      case InteractType.MAYAName: {
-        createMemo = memo
         break
       }
     }
@@ -702,18 +576,11 @@ export const InteractFormMaya = (props: Props) => {
     reset({
       mayaAddress: '',
       amount: bn(0),
-      chain: MAYAChain,
-      chainAddress: balance.walletAddress,
-      expiry: '1',
       memo: '',
       providerAddress: '',
       operatorFee: 0,
-      mayaname: '',
-      preferredAsset: '',
       bondLpUnits: '',
-      assetPool: '',
-      aliasChain: '',
-      aliasAddress: ''
+      assetPool: ''
     })
     setMemo('')
     // Reset amount appropriately based on interaction type
@@ -722,14 +589,7 @@ export const InteractFormMaya = (props: Props) => {
     } else {
       setAmountToSend(ZERO_BASE_AMOUNT)
     }
-    setMayaname(O.none)
-    setIsOwner(false)
-    setMayanameQuoteValid(false)
-    setMayanameUpdate(false)
-    setMayanameAvailable(false)
-    setOwnerNames([])
-    setOwnerSearchDone(false)
-  }, [reset, resetInteractState, balance.walletAddress, interactType])
+  }, [reset, resetInteractState, interactType])
 
   const renderConfirmationModal = useMemo(() => {
     const onSuccessHandler = () => {
@@ -857,14 +717,8 @@ export const InteractFormMaya = (props: Props) => {
             : intl.formatMessage({ id: 'deposit.withdraw.sym' })
         return label
       }
-      case InteractType.MAYAName:
-        if (isOwner) {
-          return intl.formatMessage({ id: 'common.isUpdateMayaname' })
-        } else {
-          return intl.formatMessage({ id: 'deposit.interact.actions.buyMayaname' })
-        }
     }
-  }, [interactType, intl, isOwner, whitelisting, cacaoPoolAction])
+  }, [interactType, intl, whitelisting, cacaoPoolAction])
 
   const uiFeesRD: UIFeesRD = useMemo(
     () =>
@@ -903,11 +757,6 @@ export const InteractFormMaya = (props: Props) => {
     setValue('amount', baseToAsset(_amountToSend).amount())
   }, [_amountToSend, setValue])
 
-  const mayaNamefees: UIFeesRD = useMemo(() => {
-    const fees: UIFees = [{ asset: AssetCacao, amount: _amountToSend }]
-    return RD.success(fees)
-  }, [_amountToSend])
-
   // Reset values whenever interactType has been changed (an user clicks on navigation tab)
   useEffect(() => {
     resetForm()
@@ -921,13 +770,6 @@ export const InteractFormMaya = (props: Props) => {
       setMemo('')
     }
   }, [cacaoPoolAction, resetForm, interactType])
-
-  // Call estimate handler when mayaname becomes available
-  useEffect(() => {
-    if (mayanameAvailable && interactType === InteractType.MAYAName) {
-      estimateMayanameHandler()
-    }
-  }, [mayanameAvailable, interactType, estimateMayanameHandler])
 
   // Updated renderPoolShares
   const renderPoolShares = useMemo(() => {
@@ -1293,434 +1135,27 @@ export const InteractFormMaya = (props: Props) => {
         )}
         {isFeeError && renderFeeError}
 
-        {/* Mayaname Button and Details*/}
+        {/* MAYAName — delegated to standalone component */}
         {interactType === InteractType.MAYAName && (
-          <div className="w-full sm:max-w-[630px]">
-            {/* Tab navigation */}
-            <div className="mb-4 flex border-b border-gray0 dark:border-gray0d">
-              <button
-                type="button"
-                className={`flex items-center gap-1.5 px-4 pb-2 font-main text-[14px] transition-colors ${
-                  lookupMode === 'name'
-                    ? 'border-b-2 border-turquoise text-turquoise'
-                    : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
-                }`}
-                onClick={() => setLookupMode('name')}>
-                <MagnifyingGlassIcon className="h-4 w-4" />
-                Lookup Name
-              </button>
-              <button
-                type="button"
-                className={`flex items-center gap-1.5 px-4 pb-2 font-main text-[14px] transition-colors ${
-                  lookupMode === 'owner'
-                    ? 'border-b-2 border-turquoise text-turquoise'
-                    : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
-                }`}
-                onClick={() => setLookupMode('owner')}>
-                <UserIcon className="h-4 w-4" />
-                Names by Owner
-              </button>
-            </div>
-
-            {lookupMode === 'name' && (
-              <>
-                <div className="flex items-center text-[12px]">
-                  <Label color="input" size="big" textTransform="uppercase">
-                    {intl.formatMessage({ id: 'common.mayaname' })}
-                  </Label>
-                  <InfoIcon
-                    className="ml-[3px] h-[15px] w-[15px] text-inherit"
-                    color="primary"
-                    tooltip={intl.formatMessage({ id: 'common.mayanameRegistrationSpecifics' })}
-                  />
-                </div>
-
-                <div className="flex items-start gap-2">
-                  <div className="flex-1">
-                    <Input
-                      {...register('mayaname', {
-                        required:
-                          interactType === InteractType.MAYAName && lookupMode === 'name'
-                            ? intl.formatMessage({ id: 'wallet.validations.shouldNotBeEmpty' })
-                            : false
-                      })}
-                      disabled={isLoading || isLookingUp}
-                      size="large"
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          e.preventDefault()
-                          mayanameHandler()
-                        }
-                      }}
-                    />
-                    {errors.mayaname && (
-                      <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.mayaname.message}</div>
-                    )}
-                  </div>
-                  <FlatButton
-                    className="h-[40px] min-w-[100px]"
-                    size="normal"
-                    color="primary"
-                    disabled={isLoading || isLookingUp || !watch('mayaname')}
-                    loading={isLookingUp}
-                    onClick={mayanameHandler}>
-                    Lookup
-                  </FlatButton>
-                </div>
-              </>
-            )}
-
-            {lookupMode === 'owner' && (
-              <>
-                <Label color="input" size="big" textTransform="uppercase">
-                  Owner Address
-                </Label>
-                <Input
-                  value={ownerAddress}
-                  onChange={(e) => setOwnerAddress(e.target.value)}
-                  disabled={isLoading || isLookingUpOwner}
-                  size="large"
-                  placeholder="maya1... or any chain address"
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault()
-                      ownerLookupHandler()
-                    }
-                  }}
-                />
-                <FlatButton
-                  className="mt-4 w-full"
-                  size="large"
-                  color="primary"
-                  disabled={isLoading || isLookingUpOwner || !ownerAddress}
-                  loading={isLookingUpOwner}
-                  onClick={ownerLookupHandler}>
-                  <UserIcon className="mr-2 h-5 w-5" />
-                  Find Names
-                </FlatButton>
-                {/* Owner lookup results */}
-                {ownerSearchDone && !isLookingUpOwner && ownerNames.length === 0 && (
-                  <div className="mt-4 text-center text-[14px] text-gray2 dark:text-gray2d">
-                    No names found for this address
-                  </div>
-                )}
-                {!isLookingUpOwner && ownerNames.length > 0 && (
-                  <div className="mt-4 space-y-3">
-                    {ownerNames.map((details) => {
-                      const currentBlock = FP.pipe(
-                        mayachainLastblockRD,
-                        RD.toOption,
-                        O.chain((blocks) => O.fromNullable(blocks.find((b) => b.mayachain))),
-                        O.map((b) => b.mayachain),
-                        O.toUndefined
-                      )
-                      const estimatedExpiry =
-                        currentBlock && details.expireBlockHeight
-                          ? (() => {
-                              const blocksLeft = details.expireBlockHeight - currentBlock
-                              const secondsLeft = blocksLeft * 6
-                              const daysLeft = Math.round(secondsLeft / 86400)
-                              const expiryDate = new Date(Date.now() + secondsLeft * 1000)
-                              return { date: expiryDate, daysLeft }
-                            })()
-                          : undefined
-
-                      return (
-                        <div key={details.name} className="rounded-lg border border-gray0 p-4 dark:border-gray0d">
-                          <div className="flex gap-6">
-                            <div className="flex-1">
-                              <div className="text-[11px] text-gray2 dark:text-gray2d">
-                                {intl.formatMessage({ id: 'common.mayaname' })}
-                              </div>
-                              <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
-                                {details.name}
-                              </div>
-                            </div>
-                            <div className="flex-1">
-                              <div className="text-[11px] text-gray2 dark:text-gray2d">Expiry</div>
-                              {estimatedExpiry ? (
-                                <>
-                                  <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
-                                    {estimatedExpiry.date.toLocaleDateString(undefined, {
-                                      day: 'numeric',
-                                      month: 'short',
-                                      year: 'numeric'
-                                    })}{' '}
-                                    <span className="text-[12px] text-gray2 dark:text-gray2d">
-                                      (~{estimatedExpiry.daysLeft} days)
-                                    </span>
-                                  </div>
-                                  <div className="text-[11px] text-gray2 dark:text-gray2d">
-                                    Block {details.expireBlockHeight?.toLocaleString()}
-                                  </div>
-                                </>
-                              ) : (
-                                <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
-                                  Block {details.expireBlockHeight?.toLocaleString()}
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                          <div className="mt-3">
-                            <div className="text-[11px] text-gray2 dark:text-gray2d">
-                              {intl.formatMessage({ id: 'common.owner' })}
-                            </div>
-                            <div className="font-mono text-[12px] break-all text-text0 dark:text-text0d">
-                              {details.owner}
-                            </div>
-                          </div>
-                          {details.aliases && details.aliases.length > 0 && (
-                            <div className="mt-3">
-                              <div className="mb-1 text-[11px] text-gray2 dark:text-gray2d">
-                                Chain Aliases ({details.aliases.length})
-                              </div>
-                              <div className="space-y-1">
-                                {details.aliases.map((alias, index) => (
-                                  <div
-                                    key={index}
-                                    className="flex items-baseline gap-3 rounded bg-bg1 px-3 py-2 dark:bg-bg1d">
-                                    <span className="font-mainSemiBold w-[50px] shrink-0 text-[12px] text-text0 dark:text-text0d">
-                                      {alias.chain}
-                                    </span>
-                                    <span className="font-mono text-[12px] break-all text-gray2 dark:text-gray2d">
-                                      {alias.address}
-                                    </span>
-                                  </div>
-                                ))}
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                      )
-                    })}
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        )}
-        {/** Form item for unregistered mayaname */}
-        {lookupMode === 'name' && mayanameAvailable && (
-          <div className="mt-4 w-full rounded-lg border border-gray0 p-5 sm:max-w-[630px] dark:border-gray0d">
-            {isOwner && (
-              <div className="mb-4">
-                <CheckButton
-                  checked={mayanameUpdate || isOwner}
-                  clickHandler={() => setMayanameUpdate(true)}
-                  disabled={isLoading}>
-                  {intl.formatMessage({ id: 'common.isUpdateMayaname' })}
-                </CheckButton>
-              </div>
-            )}
-            {!mayanameRegister ? (
-              <div className="space-y-5">
-                {/* Alias Chain */}
-                <div>
-                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                    {intl.formatMessage({ id: 'common.aliasChain' })}
-                  </div>
-                  <Controller
-                    name="aliasChain"
-                    control={control}
-                    rules={{
-                      required: interactType === InteractType.MAYAName ? 'Please provide an alias chain.' : false
-                    }}
-                    render={({ field }) => (
-                      <div className="flex flex-wrap gap-2">
-                        {[
-                          { value: AssetAETH.chain, label: 'ARB' },
-                          { value: AssetBTC.chain, label: 'BTC' },
-                          { value: AssetETH.chain, label: 'ETH' },
-                          { value: AssetRuneNative.chain, label: 'RUNE' }
-                        ].map((item) => (
-                          <button
-                            key={item.value}
-                            type="button"
-                            className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
-                              aliasChain === item.value
-                                ? 'border-turquoise bg-turquoise/10 text-turquoise'
-                                : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
-                            }`}
-                            onClick={() => {
-                              field.onChange(item.value)
-                              handleRadioChainChange(item.value)
-                              estimateMayanameHandler()
-                            }}>
-                            {item.label}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  />
-                  {errors.aliasChain && (
-                    <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.aliasChain.message}</div>
-                  )}
-                </div>
-
-                {/* Alias Address */}
-                <div>
-                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                    {intl.formatMessage({ id: 'common.aliasAddress' })}
-                  </div>
-                  <Input
-                    {...register('aliasAddress', {
-                      required: interactType === InteractType.MAYAName ? 'Please provide an alias address.' : false,
-                      onChange: () => estimateMayanameHandler()
-                    })}
-                    disabled={isLoading}
-                    size="large"
-                  />
-                  {errors.aliasAddress && (
-                    <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.aliasAddress.message}</div>
-                  )}
-                </div>
-
-                {/* Expiry */}
-                <div>
-                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                    {intl.formatMessage({ id: 'common.expiry' })}
-                  </div>
-                  <Controller
-                    name="expiry"
-                    control={control}
-                    render={({ field }) => (
-                      <div className="flex flex-wrap gap-2">
-                        {[
-                          { value: '1', label: '1 year' },
-                          { value: '2', label: '2 years' },
-                          { value: '3', label: '3 years' },
-                          { value: '5', label: '5 years' }
-                        ].map((item) => (
-                          <button
-                            key={item.value}
-                            type="button"
-                            className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
-                              field.value === item.value
-                                ? 'border-turquoise bg-turquoise/10 text-turquoise'
-                                : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
-                            }`}
-                            onClick={() => {
-                              field.onChange(item.value)
-                              estimateMayanameHandler()
-                            }}>
-                            {item.label}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  />
-                  {errors.expiry && (
-                    <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.expiry.message}</div>
-                  )}
-                </div>
-              </div>
-            ) : (
-              <div className="space-y-5">
-                {/* Initial registration — chain locked to MAYA */}
-                <div>
-                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                    {intl.formatMessage({ id: 'common.aliasChain' })}
-                  </div>
-                  <Controller
-                    name="chain"
-                    control={control}
-                    rules={{
-                      required: interactType === InteractType.MAYAName ? 'Please provide an alias chain.' : false
-                    }}
-                    render={({ field }) => (
-                      <div className="flex flex-wrap gap-2">
-                        <button
-                          type="button"
-                          className="rounded-full border border-turquoise bg-turquoise/10 px-4 py-1.5 font-main text-[13px] text-turquoise"
-                          onClick={() => {
-                            field.onChange(AssetCacao.chain)
-                            estimateMayanameHandler()
-                          }}>
-                          MAYA
-                        </button>
-                      </div>
-                    )}
-                  />
-                  {errors.chain && (
-                    <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.chain.message}</div>
-                  )}
-                </div>
-
-                {/* Alias Address */}
-                <div>
-                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                    {intl.formatMessage({ id: 'common.aliasAddress' })}
-                  </div>
-                  <Input
-                    {...register('chainAddress', {
-                      required: interactType === InteractType.MAYAName ? 'Please provide an alias address.' : false,
-                      onChange: () => estimateMayanameHandler()
-                    })}
-                    disabled={isLoading}
-                    size="large"
-                  />
-                  {errors.chainAddress && (
-                    <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.chainAddress.message}</div>
-                  )}
-                </div>
-
-                {/* Expiry */}
-                <div>
-                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                    {intl.formatMessage({ id: 'common.expiry' })}
-                  </div>
-                  <Controller
-                    name="expiry"
-                    control={control}
-                    rules={{ required: interactType === InteractType.MAYAName }}
-                    render={({ field }) => (
-                      <div className="flex flex-wrap gap-2">
-                        {[
-                          { value: '1', label: '1 year' },
-                          { value: '2', label: '2 years' },
-                          { value: '3', label: '3 years' },
-                          { value: '5', label: '5 years' }
-                        ].map((item) => (
-                          <button
-                            key={item.value}
-                            type="button"
-                            className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
-                              field.value === item.value
-                                ? 'border-turquoise bg-turquoise/10 text-turquoise'
-                                : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
-                            }`}
-                            onClick={() => {
-                              field.onChange(item.value)
-                              estimateMayanameHandler()
-                            }}>
-                            {item.label}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  />
-                  {errors.expiry && (
-                    <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.expiry.message}</div>
-                  )}
-                </div>
-              </div>
-            )}
-            <Fees className="mt-5 pb-5" fees={mayaNamefees} disabled={isLoading} />
-          </div>
+          <MAYANameForm
+            walletType={walletType}
+            walletAccount={walletAccount}
+            walletIndex={walletIndex}
+            hdMode={hdMode}
+            balance={balance}
+            interactMaya$={interactMaya$}
+            openExplorerTxUrl={openExplorerTxUrl}
+            getExplorerTxUrl={getExplorerTxUrl}
+            validatePassword$={validatePassword$}
+            mayachainQuery={mayachainQuery}
+            network={network}
+            fee={feeRD}
+            reloadFeesHandler={reloadFeesHandler}
+            mayachainLastblockRD={mayachainLastblockRD}
+          />
         )}
       </div>
       <div className="flex items-center justify-center">
-        {lookupMode === 'name' && mayanameQuoteValid && (
-          <FlatButton
-            className="mt-10px min-w-[200px]"
-            loading={isLoading}
-            disabled={isLoading}
-            type="submit"
-            size="large">
-            {submitLabel}
-          </FlatButton>
-        )}
-
         {interactType === InteractType.CacaoPool && (
           <FlatButton
             className="mt-20px min-w-[200px]"
@@ -1750,160 +1185,72 @@ export const InteractFormMaya = (props: Props) => {
           </FlatButton>
         )}
       </div>
-      <div className="pt-10px font-main text-[14px] text-gray2 dark:text-gray2d">
-        {/* memo */}
-        <div className="my-20px w-full font-main text-[12px] uppercase dark:border-gray1d">
-          <BaseButton
-            className="group font-mainSemiBold flex w-full !justify-between !p-0 text-[16px] text-text2 hover:text-turquoise dark:text-text2d dark:hover:text-turquoise"
-            onClick={() => setShowDetails((current) => !current)}>
-            {intl.formatMessage({ id: 'common.details' })}
-            {showDetails ? (
-              <MagnifyingGlassMinusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
-            ) : (
-              <MagnifyingGlassPlusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
-            )}
-          </BaseButton>
-          {showDetails && (
-            <>
-              {FP.pipe(
-                oMayaname,
-                O.map(({ owner, name, expireBlockHeight, aliases }) => {
-                  if (owner || name || expireBlockHeight || aliases) {
-                    // Estimate expiry date from block height
-                    const currentBlock = FP.pipe(
-                      mayachainLastblockRD,
-                      RD.toOption,
-                      O.chain((blocks) => O.fromNullable(blocks.find((b) => b.mayachain))),
-                      O.map((b) => b.mayachain),
-                      O.toUndefined
-                    )
-                    const estimatedExpiry =
-                      currentBlock && expireBlockHeight
-                        ? (() => {
-                            const blocksLeft = expireBlockHeight - currentBlock
-                            const secondsLeft = blocksLeft * 6
-                            const daysLeft = Math.round(secondsLeft / 86400)
-                            const expiryDate = new Date(Date.now() + secondsLeft * 1000)
-                            return { date: expiryDate, daysLeft }
-                          })()
-                        : undefined
-
-                    return (
-                      <div key={name} className="mt-2 rounded-lg border border-gray0 p-4 dark:border-gray0d">
-                        {/* Name + Expiry row */}
-                        <div className="flex gap-6">
-                          <div className="flex-1">
-                            <div className="text-[11px] text-gray2 dark:text-gray2d">
-                              {intl.formatMessage({ id: 'common.mayaname' })}
-                            </div>
-                            <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">{name}</div>
-                          </div>
-                          <div className="flex-1">
-                            <div className="text-[11px] text-gray2 dark:text-gray2d">Expiry</div>
-                            {estimatedExpiry ? (
-                              <>
-                                <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
-                                  {estimatedExpiry.date.toLocaleDateString(undefined, {
-                                    day: 'numeric',
-                                    month: 'short',
-                                    year: 'numeric'
-                                  })}{' '}
-                                  <span className="text-[12px] text-gray2 dark:text-gray2d">
-                                    (~{estimatedExpiry.daysLeft} days)
-                                  </span>
-                                </div>
-                                <div className="text-[11px] text-gray2 dark:text-gray2d">
-                                  Block {expireBlockHeight?.toLocaleString()}
-                                </div>
-                              </>
-                            ) : (
-                              <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
-                                Block {expireBlockHeight?.toLocaleString()}
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                        {/* Owner */}
-                        <div className="mt-3">
-                          <div className="text-[11px] text-gray2 dark:text-gray2d">
-                            {intl.formatMessage({ id: 'common.owner' })}
-                          </div>
-                          <div className="font-mono text-[12px] break-all text-text0 dark:text-text0d">{owner}</div>
-                        </div>
-                        {/* Chain Aliases */}
-                        {aliases && aliases.length > 0 && (
-                          <div className="mt-3">
-                            <div className="mb-1 text-[11px] text-gray2 dark:text-gray2d">
-                              Chain Aliases ({aliases.length})
-                            </div>
-                            <div className="space-y-1">
-                              {aliases.map((alias, index) => (
-                                <div
-                                  key={index}
-                                  className="flex items-baseline gap-3 rounded bg-bg1 px-3 py-2 dark:bg-bg1d">
-                                  <span className="font-mainSemiBold w-[50px] shrink-0 text-[12px] text-text0 dark:text-text0d">
-                                    {alias.chain}
-                                  </span>
-                                  <span className="font-mono text-[12px] break-all text-gray2 dark:text-gray2d">
-                                    {alias.address}
-                                  </span>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    )
-                  }
-                  return null
-                }),
-                O.toNullable
+      {/* MAYAName has its own details section — skip parent's */}
+      {interactType !== InteractType.MAYAName && (
+        <div className="pt-10px font-main text-[14px] text-gray2 dark:text-gray2d">
+          {/* memo */}
+          <div className="my-20px w-full font-main text-[12px] uppercase dark:border-gray1d">
+            <BaseButton
+              className="group font-mainSemiBold flex w-full !justify-between !p-0 text-[16px] text-text2 hover:text-turquoise dark:text-text2d dark:hover:text-turquoise"
+              onClick={() => setShowDetails((current) => !current)}>
+              {intl.formatMessage({ id: 'common.details' })}
+              {showDetails ? (
+                <MagnifyingGlassMinusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
+              ) : (
+                <MagnifyingGlassPlusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
               )}
-              {interactType === InteractType.CacaoPool && (
-                <>
-                  <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
-                    {intl.formatMessage({ id: 'protocolPool.detail.daysLeft' })}
-                    <div className="truncate pl-10px font-main text-[12px]">
-                      {RD.fold(
-                        () => <p>{emptyString}</p>,
-                        () => <p>{emptyString}</p>,
-                        (error: Error) => (
-                          <p>
-                            {intl.formatMessage({ id: 'common.error' })}: {error.message}
-                          </p>
-                        ),
-                        (data: { daysLeft: number; blocksLeft: number }) => (
-                          <div>
+            </BaseButton>
+            {showDetails && (
+              <>
+                {interactType === InteractType.CacaoPool && (
+                  <>
+                    <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
+                      {intl.formatMessage({ id: 'protocolPool.detail.daysLeft' })}
+                      <div className="truncate pl-10px font-main text-[12px]">
+                        {RD.fold(
+                          () => <p>{emptyString}</p>,
+                          () => <p>{emptyString}</p>,
+                          (error: Error) => (
                             <p>
-                              {intl.formatMessage({ id: 'common.time.days' }, { days: `${data.daysLeft.toFixed(1)}` })}
+                              {intl.formatMessage({ id: 'common.error' })}: {error.message}
                             </p>
-                          </div>
-                        )
-                      )(cacaoPoolData)}
+                          ),
+                          (data: { daysLeft: number; blocksLeft: number }) => (
+                            <div>
+                              <p>
+                                {intl.formatMessage(
+                                  { id: 'common.time.days' },
+                                  { days: `${data.daysLeft.toFixed(1)}` }
+                                )}
+                              </p>
+                            </div>
+                          )
+                        )(cacaoPoolData)}
+                      </div>
                     </div>
+                  </>
+                )}
+                <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
+                  {intl.formatMessage({ id: 'common.amount' })}
+                  <div className="truncate pl-10px font-main text-[12px]">
+                    {formatAssetAmountCurrency({
+                      amount: baseToAsset(_amountToSend), // Find the value of swap slippage
+                      asset: AssetCacao,
+                      decimal: isUSDAsset(AssetCacao) ? 2 : 6,
+                      trimZeros: !isUSDAsset(AssetCacao)
+                    })}
                   </div>
-                </>
-              )}
-              <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
-                {intl.formatMessage({ id: 'common.amount' })}
-                <div className="truncate pl-10px font-main text-[12px]">
-                  {formatAssetAmountCurrency({
-                    amount: baseToAsset(_amountToSend), // Find the value of swap slippage
-                    asset: AssetCacao,
-                    decimal: isUSDAsset(AssetCacao) ? 2 : 6,
-                    trimZeros: !isUSDAsset(AssetCacao)
-                  })}
                 </div>
-              </div>
 
-              <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
-                {intl.formatMessage({ id: 'common.memo' })}
-                <div className="overflow pl-10px font-main text-[12px] break-normal">{memoLabel}</div>
-              </div>
-            </>
-          )}
+                <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
+                  {intl.formatMessage({ id: 'common.memo' })}
+                  <div className="overflow pl-10px font-main text-[12px] break-normal">{memoLabel}</div>
+                </div>
+              </>
+            )}
+          </div>
         </div>
-      </div>
+      )}
       {showConfirmationModal && renderConfirmationModal}
       {renderTxModal}
     </form>

--- a/src/renderer/components/wallet/txs/interact/InteractFormThor.tsx
+++ b/src/renderer/components/wallet/txs/interact/InteractFormThor.tsx
@@ -66,7 +66,7 @@ import { SendAsset } from '../../../modal/tx/extra/SendAsset'
 import { BaseButton, FlatButton, ViewTxButton } from '../../../uielements/button'
 import { MaxBalanceButton } from '../../../uielements/button/MaxBalanceButton'
 import { SwitchButton } from '../../../uielements/button/SwitchButton'
-import { Fees, UIFees, UIFeesRD } from '../../../uielements/fees'
+import { Fees, UIFeesRD } from '../../../uielements/fees'
 import { Input, InputBigNumber } from '../../../uielements/input'
 import { Label } from '../../../uielements/label'
 import { Tooltip } from '../../../uielements/tooltip'
@@ -517,17 +517,7 @@ export const InteractFormThor = ({
     }
     setMemo(createMemo)
     return createMemo
-  }, [
-    _amountToSend,
-    currentMemo,
-    watch,
-    interactType,
-    memo,
-    network,
-    runePoolAction,
-    runePoolProvider.value,
-    whitelisting
-  ])
+  }, [_amountToSend, currentMemo, watch, interactType, network, runePoolAction, runePoolProvider.value, whitelisting])
 
   const onChangeInput = useCallback(
     (value: BigNumber) => {

--- a/src/renderer/components/wallet/txs/interact/InteractFormThor.tsx
+++ b/src/renderer/components/wallet/txs/interact/InteractFormThor.tsx
@@ -4,18 +4,14 @@ import * as RD from '@devexperts/remote-data-ts'
 import {
   ArrowDownTrayIcon,
   ArrowUpTrayIcon,
-  MagnifyingGlassIcon,
   MagnifyingGlassMinusIcon,
-  MagnifyingGlassPlusIcon,
-  UserIcon
+  MagnifyingGlassPlusIcon
 } from '@heroicons/react/24/outline'
 import { Network } from '@xchainjs/xchain-client'
 import { PoolDetails } from '@xchainjs/xchain-midgard'
 import { THORChain } from '@xchainjs/xchain-thorchain'
-import { QuoteTHORNameParams, ThorchainQuery, ThornameDetails } from '@xchainjs/xchain-thorchain-query'
+import { ThorchainQuery } from '@xchainjs/xchain-thorchain-query'
 import {
-  AnyAsset,
-  Asset,
   assetAmount,
   assetToBase,
   baseAmount,
@@ -31,10 +27,10 @@ import { useForm, Controller } from 'react-hook-form'
 import { useIntl } from 'react-intl'
 
 import { ONE_RUNE_BASE_AMOUNT } from '../../../../../shared/mock/amount'
-import { AssetAVAX, AssetBTC, AssetDOGE, AssetETH, AssetRuneNative } from '../../../../../shared/utils/asset'
+import { AssetRuneNative } from '../../../../../shared/utils/asset'
 import { isKeystoreWallet, isLedgerWallet } from '../../../../../shared/utils/guard'
 import { HDMode, WalletType } from '../../../../../shared/wallet/types'
-import { AssetUSDT, ZERO_BASE_AMOUNT } from '../../../../const'
+import { ZERO_BASE_AMOUNT } from '../../../../const'
 import { THORCHAIN_DECIMAL, isUSDAsset } from '../../../../helpers/assetHelper'
 import { validateAddress } from '../../../../helpers/form/validation'
 import {
@@ -68,17 +64,16 @@ import { LedgerConfirmationModal, WalletPasswordConfirmationModal } from '../../
 import { TxModal } from '../../../modal/tx'
 import { SendAsset } from '../../../modal/tx/extra/SendAsset'
 import { BaseButton, FlatButton, ViewTxButton } from '../../../uielements/button'
-import { CheckButton } from '../../../uielements/button/CheckButton'
 import { MaxBalanceButton } from '../../../uielements/button/MaxBalanceButton'
 import { SwitchButton } from '../../../uielements/button/SwitchButton'
 import { Fees, UIFees, UIFeesRD } from '../../../uielements/fees'
-import { InfoIcon } from '../../../uielements/info'
 import { Input, InputBigNumber } from '../../../uielements/input'
 import { Label } from '../../../uielements/label'
 import { Tooltip } from '../../../uielements/tooltip'
 import { validateTxAmountInput } from '../TxForm.util'
 import * as H from './Interact.helpers'
 import { InteractType } from './Interact.types'
+import { THORNameForm } from './thorname/THORNameForm'
 
 type FormValues = {
   memo: string
@@ -86,13 +81,6 @@ type FormValues = {
   providerAddress: string
   operatorFee: number
   amount: BigNumber
-  thorname: string
-  chainAddress: string
-  chain: string
-  preferredAsset: string
-  expiry: string
-  aliasChain: string
-  aliasAddress: string
 }
 type UserNodeInfo = {
   nodeAddress: string
@@ -121,12 +109,6 @@ type Props = {
   nodes: NodeInfosRD
   runePoolProvider: RunePoolProviderRD
   thorchainLastblock: ThorchainLastblockRD
-}
-
-const preferredAssetMap: Record<string, AnyAsset> = {
-  [AssetBTC.symbol]: AssetBTC,
-  [AssetETH.symbol]: AssetETH,
-  [AssetUSDT.symbol]: AssetUSDT
 }
 
 export const InteractFormThor = ({
@@ -269,8 +251,6 @@ export const InteractFormThor = ({
     switch (interactType) {
       case InteractType.Bond:
       case InteractType.Custom:
-      case InteractType.THORName:
-      case InteractType.MAYAName:
         return _amountToSend
       case InteractType.Whitelist:
         return ONE_RUNE_BASE_AMOUNT
@@ -284,6 +264,8 @@ export const InteractFormThor = ({
       case InteractType.CacaoPool: {
         return ZERO_BASE_AMOUNT
       }
+      default:
+        return ZERO_BASE_AMOUNT
     }
   }, [_amountToSend, interactType, runePoolAction])
 
@@ -311,28 +293,11 @@ export const InteractFormThor = ({
       thorAddress: '',
       providerAddress: '',
       operatorFee: 0,
-      amount: bn(0),
-      thorname: '',
-      chainAddress: balance.walletAddress,
-      chain: THORChain,
-      preferredAsset: '',
-      expiry: '1',
-      aliasChain: '',
-      aliasAddress: ''
+      amount: bn(0)
     }
   })
 
   const oFee: O.Option<BaseAmount> = useMemo(() => FP.pipe(feeRD, RD.toOption), [feeRD])
-
-  // state variable for thornames
-  const [oThorname, setThorname] = useState<O.Option<ThornameDetails>>(O.none)
-  const [thornameAvailable, setThornameAvailable] = useState<boolean>(false) // if thorname is available
-  const [thornameUpdate, setThornameUpdate] = useState<boolean>(false) // allow to update
-  const [thornameRegister, setThornameRegister] = useState<boolean>(false) // allow to update
-  const [thornameQuoteValid, setThornameQuoteValid] = useState<boolean>(false) // if the quote is valid then allow to buy
-  const [isOwner, setIsOwner] = useState<boolean>(false) // if the thorname.owner is the wallet address then allow to update
-  const [preferredAsset, setPreferredAsset] = useState<string>()
-  const [aliasChain, setAliasChain] = useState<string>('')
 
   const [currentMemo, setCurrentMemo] = useState('')
 
@@ -481,104 +446,6 @@ export const InteractFormThor = ({
     [interactType, intl, maxAmount]
   )
 
-  const [isLookingUp, setIsLookingUp] = useState(false)
-  const [lookupMode, setLookupMode] = useState<'name' | 'owner'>('name')
-  const [ownerAddress, setOwnerAddress] = useState('')
-  const [ownerNames, setOwnerNames] = useState<ThornameDetails[]>([])
-  const [isLookingUpOwner, setIsLookingUpOwner] = useState(false)
-  const [ownerSearchDone, setOwnerSearchDone] = useState(false)
-
-  const thornameHandler = useCallback(async () => {
-    const thorname = watch('thorname')
-    setThornameQuoteValid(false)
-    setMemo('')
-    if (thorname === '') return
-
-    setIsLookingUp(true)
-    try {
-      const thornameDetails = await thorchainQuery.getThornameDetails(thorname)
-      if (thornameDetails) {
-        setThorname(O.some(thornameDetails))
-        setThornameAvailable(thornameDetails.owner === '' || balance.walletAddress === thornameDetails.owner)
-        setThornameUpdate(thorname === thornameDetails.name && thornameDetails.owner === '')
-        setThornameRegister(thornameDetails.name === '')
-        setIsOwner(balance.walletAddress === thornameDetails.owner)
-      }
-    } catch (_error) {
-      setThornameAvailable(true)
-    } finally {
-      setIsLookingUp(false)
-    }
-  }, [balance.walletAddress, watch, thorchainQuery])
-
-  const ownerLookupHandler = useCallback(async () => {
-    if (ownerAddress === '') return
-    setIsLookingUpOwner(true)
-    setOwnerNames([])
-    setOwnerSearchDone(false)
-    try {
-      const names =
-        await thorchainQuery.thorchainCache.midgardQuery.midgardCache.midgard.getTHORNameReverseLookup(ownerAddress)
-      if (names && names.length > 0) {
-        const details = await Promise.all(names.map((n) => thorchainQuery.getThornameDetails(n)))
-        setOwnerNames(details.filter((d) => d && !d.error?.length))
-      }
-    } catch (_error) {
-      // no names found
-    } finally {
-      setIsLookingUpOwner(false)
-      setOwnerSearchDone(true)
-    }
-  }, [ownerAddress, thorchainQuery])
-
-  const estimateThornameHandler = useCallback(() => {
-    const currentDate = new Date()
-
-    const name = watch('thorname')
-    const chain = thornameRegister ? watch('chain') : watch('aliasChain')
-    const yearsToAdd = parseInt(watch('expiry') || '1')
-    const expiry =
-      yearsToAdd === 1
-        ? undefined
-        : new Date(currentDate.getFullYear() + yearsToAdd, currentDate.getMonth(), currentDate.getDate())
-    const chainAddress = thornameRegister ? watch('chainAddress') : watch('aliasAddress')
-    const owner = balance.walletAddress
-    if (name !== undefined && chain !== undefined && chainAddress !== undefined) {
-      const fetchThornameQuote = async () => {
-        try {
-          const params: QuoteTHORNameParams = {
-            name,
-            chain,
-            chainAddress,
-            owner,
-            preferredAsset: preferredAsset ? (preferredAssetMap[preferredAsset] as Asset) : undefined,
-            expiry,
-            isUpdate: thornameUpdate || isOwner
-          }
-
-          const thornameQuote = await thorchainQuery.estimateThorname(params)
-
-          if (thornameQuote) {
-            setMemo(thornameQuote.memo)
-            setAmountToSend(thornameQuote.value.baseAmount)
-            setThornameQuoteValid(true)
-          }
-        } catch (error) {
-          console.error('Error fetching fetchThornameQuote:', error)
-        }
-      }
-      fetchThornameQuote()
-    }
-  }, [balance.walletAddress, watch, isOwner, preferredAsset, thorchainQuery, thornameRegister, thornameUpdate])
-
-  const handleRadioAssetChange = useCallback((asset: string) => {
-    setPreferredAsset(asset)
-  }, [])
-
-  const handleRadioChainChange = useCallback((chain: string) => {
-    setAliasChain(chain)
-  }, [])
-
   const addMaxAmountHandler = useCallback(
     (maxAmount: BaseAmount) => {
       setAmountToSend(maxAmount)
@@ -647,10 +514,6 @@ export const InteractFormThor = ({
         createMemo = currentMemo
         break
       }
-      case InteractType.THORName: {
-        createMemo = memo
-        break
-      }
     }
     setMemo(createMemo)
     return createMemo
@@ -705,26 +568,12 @@ export const InteractFormThor = ({
       thorAddress: watch('thorAddress'), // Keep thorAddress value
       providerAddress: '',
       operatorFee: 0,
-      amount: bn(0),
-      thorname: '',
-      chainAddress: balance.walletAddress,
-      chain: THORChain,
-      preferredAsset: '',
-      expiry: '1',
-      aliasChain: '',
-      aliasAddress: ''
+      amount: bn(0)
     })
     setHasProviderAddress(false)
     setMemo('')
     setAmountToSend(ZERO_BASE_AMOUNT)
-    setThorname(O.none)
-    setIsOwner(false)
-    setThornameQuoteValid(false)
-    setThornameUpdate(false)
-    setThornameAvailable(false)
-    setOwnerNames([])
-    setOwnerSearchDone(false)
-  }, [reset, resetInteractState, watch, balance.walletAddress])
+  }, [reset, resetInteractState, watch])
 
   const renderConfirmationModal = useMemo(() => {
     const onSuccessHandler = () => {
@@ -860,10 +709,6 @@ export const InteractFormThor = ({
         })} ${intl.formatMessage({
           id: 'common.amount'
         })}`
-      case InteractType.THORName:
-        return intl.formatMessage({
-          id: 'common.amount'
-        })
     }
   }, [interactType, intl])
 
@@ -892,14 +737,8 @@ export const InteractFormThor = ({
       }
       case InteractType.Custom:
         return intl.formatMessage({ id: 'wallet.action.send' })
-      case InteractType.THORName:
-        if (isOwner) {
-          return intl.formatMessage({ id: 'common.isUpdateThorname' })
-        } else {
-          return intl.formatMessage({ id: 'deposit.interact.actions.buyThorname' })
-        }
     }
-  }, [interactType, hasProviderAddress, intl, whitelisting, isOwner, runePoolAction])
+  }, [interactType, hasProviderAddress, intl, whitelisting, runePoolAction])
 
   const uiFeesRD: UIFeesRD = useMemo(
     () =>
@@ -928,11 +767,6 @@ export const InteractFormThor = ({
     // Whenever `amountToSend` has been updated, we put it back into input field
     setValue('amount', baseToAsset(_amountToSend).amount())
   }, [_amountToSend, setValue])
-
-  const thorNamefees: UIFeesRD = useMemo(() => {
-    const fees: UIFees = [{ asset: AssetRuneNative, amount: _amountToSend }]
-    return RD.success(fees)
-  }, [_amountToSend])
 
   // Reset values whenever interactType has been changed (an user clicks on navigation tab)
   useEffect(() => {
@@ -1244,479 +1078,27 @@ export const InteractFormThor = ({
             )}
           </>
         )}
-        {/* Thorname Button and Details*/}
-        <>
-          {interactType === InteractType.THORName && (
-            <div className="w-full sm:max-w-[630px]">
-              {/* Tab navigation */}
-              <div className="mb-4 flex border-b border-gray0 dark:border-gray0d">
-                <button
-                  type="button"
-                  className={`flex items-center gap-1.5 px-4 pb-2 font-main text-[14px] transition-colors ${
-                    lookupMode === 'name'
-                      ? 'border-b-2 border-turquoise text-turquoise'
-                      : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
-                  }`}
-                  onClick={() => setLookupMode('name')}>
-                  <MagnifyingGlassIcon className="h-4 w-4" />
-                  Lookup Name
-                </button>
-                <button
-                  type="button"
-                  className={`flex items-center gap-1.5 px-4 pb-2 font-main text-[14px] transition-colors ${
-                    lookupMode === 'owner'
-                      ? 'border-b-2 border-turquoise text-turquoise'
-                      : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
-                  }`}
-                  onClick={() => setLookupMode('owner')}>
-                  <UserIcon className="h-4 w-4" />
-                  Names by Owner
-                </button>
-              </div>
-
-              {lookupMode === 'name' && (
-                <>
-                  <div className="flex items-center text-[12px]">
-                    <Label color="input" size="big" textTransform="uppercase">
-                      {intl.formatMessage({ id: 'common.thorname' })}
-                    </Label>
-                    <InfoIcon
-                      className="ml-[3px] h-[15px] w-[15px] text-inherit"
-                      tooltip={intl.formatMessage({ id: 'common.thornameRegistrationSpecifics' })}
-                      color="primary"
-                    />
-                  </div>
-
-                  <div className="flex items-start gap-2">
-                    <div className="flex-1">
-                      <Input
-                        {...register('thorname', {
-                          required:
-                            interactType === InteractType.THORName && lookupMode === 'name'
-                              ? intl.formatMessage({ id: 'wallet.validations.shouldNotBeEmpty' })
-                              : false
-                        })}
-                        disabled={isLoading || isLookingUp}
-                        size="large"
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter') {
-                            e.preventDefault()
-                            thornameHandler()
-                          }
-                        }}
-                      />
-                      {errors.thorname && (
-                        <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.thorname.message}</div>
-                      )}
-                    </div>
-                    <FlatButton
-                      className="h-[40px] min-w-[100px]"
-                      size="normal"
-                      color="primary"
-                      disabled={isLoading || isLookingUp || !watch('thorname')}
-                      loading={isLookingUp}
-                      onClick={thornameHandler}>
-                      Lookup
-                    </FlatButton>
-                  </div>
-                </>
-              )}
-
-              {lookupMode === 'owner' && (
-                <>
-                  <Label color="input" size="big" textTransform="uppercase">
-                    Owner Address
-                  </Label>
-                  <Input
-                    value={ownerAddress}
-                    onChange={(e) => setOwnerAddress(e.target.value)}
-                    disabled={isLoading || isLookingUpOwner}
-                    size="large"
-                    placeholder="thor1... or any chain address"
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault()
-                        ownerLookupHandler()
-                      }
-                    }}
-                  />
-                  <FlatButton
-                    className="mt-4 w-full"
-                    size="large"
-                    color="primary"
-                    disabled={isLoading || isLookingUpOwner || !ownerAddress}
-                    loading={isLookingUpOwner}
-                    onClick={ownerLookupHandler}>
-                    <UserIcon className="mr-2 h-5 w-5" />
-                    Find Names
-                  </FlatButton>
-                  {/* Owner lookup results */}
-                  {ownerSearchDone && !isLookingUpOwner && ownerNames.length === 0 && (
-                    <div className="mt-4 text-center text-[14px] text-gray2 dark:text-gray2d">
-                      No names found for this address
-                    </div>
-                  )}
-                  {!isLookingUpOwner && ownerNames.length > 0 && (
-                    <div className="mt-4 space-y-3">
-                      {ownerNames.map((details) => {
-                        const currentBlock = FP.pipe(
-                          thorchainLastblockRd,
-                          RD.toOption,
-                          O.chain((blocks) => O.fromNullable(blocks.find((b) => b.thorchain))),
-                          O.map((b) => b.thorchain),
-                          O.toUndefined
-                        )
-                        const estimatedExpiry =
-                          currentBlock && details.expireBlockHeight
-                            ? (() => {
-                                const blocksLeft = details.expireBlockHeight - currentBlock
-                                const secondsLeft = blocksLeft * 6
-                                const daysLeft = Math.round(secondsLeft / 86400)
-                                const expiryDate = new Date(Date.now() + secondsLeft * 1000)
-                                return { date: expiryDate, daysLeft }
-                              })()
-                            : undefined
-
-                        return (
-                          <div key={details.name} className="rounded-lg border border-gray0 p-4 dark:border-gray0d">
-                            <div className="flex gap-6">
-                              <div className="flex-1">
-                                <div className="text-[11px] text-gray2 dark:text-gray2d">
-                                  {intl.formatMessage({ id: 'common.thorname' })}
-                                </div>
-                                <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
-                                  {details.name}
-                                </div>
-                              </div>
-                              <div className="flex-1">
-                                <div className="text-[11px] text-gray2 dark:text-gray2d">Expiry</div>
-                                {estimatedExpiry ? (
-                                  <>
-                                    <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
-                                      {estimatedExpiry.date.toLocaleDateString(undefined, {
-                                        day: 'numeric',
-                                        month: 'short',
-                                        year: 'numeric'
-                                      })}{' '}
-                                      <span className="text-[12px] text-gray2 dark:text-gray2d">
-                                        (~{estimatedExpiry.daysLeft} days)
-                                      </span>
-                                    </div>
-                                    <div className="text-[11px] text-gray2 dark:text-gray2d">
-                                      Block {details.expireBlockHeight?.toLocaleString()}
-                                    </div>
-                                  </>
-                                ) : (
-                                  <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
-                                    Block {details.expireBlockHeight?.toLocaleString()}
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                            <div className="mt-3">
-                              <div className="text-[11px] text-gray2 dark:text-gray2d">
-                                {intl.formatMessage({ id: 'common.owner' })}
-                              </div>
-                              <div className="font-mono text-[12px] break-all text-text0 dark:text-text0d">
-                                {details.owner}
-                              </div>
-                            </div>
-                            {details.preferredAsset && (
-                              <div className="mt-3">
-                                <div className="text-[11px] text-gray2 dark:text-gray2d">
-                                  {intl.formatMessage({ id: 'common.preferredAsset' })}
-                                </div>
-                                <div className="font-mono text-[12px] break-all text-text0 dark:text-text0d">
-                                  {details.preferredAsset}
-                                </div>
-                              </div>
-                            )}
-                            {details.aliases && details.aliases.length > 0 && (
-                              <div className="mt-3">
-                                <div className="mb-1 text-[11px] text-gray2 dark:text-gray2d">
-                                  Chain Aliases ({details.aliases.length})
-                                </div>
-                                <div className="space-y-1">
-                                  {details.aliases.map((alias, index) => (
-                                    <div
-                                      key={index}
-                                      className="flex items-baseline gap-3 rounded bg-bg1 px-3 py-2 dark:bg-bg1d">
-                                      <span className="font-mainSemiBold w-[50px] shrink-0 text-[12px] text-text0 dark:text-text0d">
-                                        {alias.chain}
-                                      </span>
-                                      <span className="font-mono text-[12px] break-all text-gray2 dark:text-gray2d">
-                                        {alias.address}
-                                      </span>
-                                    </div>
-                                  ))}
-                                </div>
-                              </div>
-                            )}
-                          </div>
-                        )
-                      })}
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
-          )}
-          {/** Form item for unregistered thorname */}
-          {lookupMode === 'name' && thornameAvailable && (
-            <div className="mt-4 w-full rounded-lg border border-gray0 p-5 sm:max-w-[630px] dark:border-gray0d">
-              {isOwner && (
-                <div className="mb-4">
-                  <CheckButton
-                    checked={thornameUpdate || isOwner}
-                    clickHandler={() => setThornameUpdate(true)}
-                    disabled={isLoading}>
-                    {intl.formatMessage({ id: 'common.isUpdateThorname' })}
-                  </CheckButton>
-                </div>
-              )}
-              {!thornameRegister ? (
-                <div className="space-y-5">
-                  {/* Preferred Asset */}
-                  <div>
-                    <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                      {intl.formatMessage({ id: 'common.preferredAsset' })}
-                    </div>
-                    <Controller
-                      name="preferredAsset"
-                      control={control}
-                      render={({ field }) => (
-                        <div className="flex flex-wrap gap-2">
-                          {[
-                            { value: AssetBTC.symbol, label: 'BTC' },
-                            { value: AssetETH.symbol, label: 'ETH' },
-                            { value: AssetUSDT.symbol, label: 'USDT' }
-                          ].map((item) => (
-                            <button
-                              key={item.value}
-                              type="button"
-                              className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
-                                preferredAsset === item.value
-                                  ? 'border-turquoise bg-turquoise/10 text-turquoise'
-                                  : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
-                              }`}
-                              onClick={() => {
-                                field.onChange(item.value)
-                                handleRadioAssetChange(item.value)
-                              }}>
-                              {item.label}
-                            </button>
-                          ))}
-                        </div>
-                      )}
-                    />
-                    {errors.preferredAsset && (
-                      <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.preferredAsset.message}</div>
-                    )}
-                  </div>
-
-                  {/* Alias Chain */}
-                  <div>
-                    <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                      {intl.formatMessage({ id: 'common.aliasChain' })}
-                    </div>
-                    <Controller
-                      name="aliasChain"
-                      control={control}
-                      rules={{ required: 'Please provide an alias chain.' }}
-                      render={({ field }) => (
-                        <div className="flex flex-wrap gap-2">
-                          {[
-                            { value: AssetAVAX.chain, label: 'AVAX' },
-                            { value: AssetBTC.chain, label: 'BTC' },
-                            { value: AssetETH.chain, label: 'ETH' },
-                            { value: AssetDOGE.chain, label: 'DOGE' }
-                          ].map((item) => (
-                            <button
-                              key={item.value}
-                              type="button"
-                              className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
-                                aliasChain === item.value
-                                  ? 'border-turquoise bg-turquoise/10 text-turquoise'
-                                  : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
-                              }`}
-                              onClick={() => {
-                                field.onChange(item.value)
-                                handleRadioChainChange(item.value)
-                              }}>
-                              {item.label}
-                            </button>
-                          ))}
-                        </div>
-                      )}
-                    />
-                    {errors.aliasChain && (
-                      <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.aliasChain.message}</div>
-                    )}
-                  </div>
-
-                  {/* Alias Address */}
-                  <div>
-                    <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                      {intl.formatMessage({ id: 'common.aliasAddress' })}
-                    </div>
-                    <Input
-                      {...register('aliasAddress', {
-                        required: 'Please provide an alias address.',
-                        onChange: () => estimateThornameHandler()
-                      })}
-                      disabled={isLoading}
-                      size="large"
-                    />
-                    {errors.aliasAddress && (
-                      <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.aliasAddress.message}</div>
-                    )}
-                  </div>
-
-                  {/* Expiry */}
-                  <div>
-                    <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                      {intl.formatMessage({ id: 'common.expiry' })}
-                    </div>
-                    <Controller
-                      name="expiry"
-                      control={control}
-                      render={({ field }) => (
-                        <div className="flex flex-wrap gap-2">
-                          {[
-                            { value: '1', label: '1 year' },
-                            { value: '2', label: '2 years' },
-                            { value: '3', label: '3 years' },
-                            { value: '5', label: '5 years' }
-                          ].map((item) => (
-                            <button
-                              key={item.value}
-                              type="button"
-                              className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
-                                field.value === item.value
-                                  ? 'border-turquoise bg-turquoise/10 text-turquoise'
-                                  : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
-                              }`}
-                              onClick={() => {
-                                field.onChange(item.value)
-                                estimateThornameHandler()
-                              }}>
-                              {item.label}
-                            </button>
-                          ))}
-                        </div>
-                      )}
-                    />
-                    {errors.expiry && (
-                      <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.expiry.message}</div>
-                    )}
-                  </div>
-                </div>
-              ) : (
-                <div className="space-y-5">
-                  {/* Initial registration — chain locked to THOR */}
-                  <div>
-                    <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                      {intl.formatMessage({ id: 'common.aliasChain' })}
-                    </div>
-                    <Controller
-                      name="chain"
-                      control={control}
-                      rules={{ required: 'Please provide an alias chain.' }}
-                      render={({ field }) => (
-                        <div className="flex flex-wrap gap-2">
-                          <button
-                            type="button"
-                            className="rounded-full border border-turquoise bg-turquoise/10 px-4 py-1.5 font-main text-[13px] text-turquoise"
-                            onClick={() => {
-                              field.onChange(AssetRuneNative.chain)
-                              estimateThornameHandler()
-                            }}>
-                            THOR
-                          </button>
-                        </div>
-                      )}
-                    />
-                    {errors.chain && (
-                      <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.chain.message}</div>
-                    )}
-                  </div>
-
-                  {/* Alias Address */}
-                  <div>
-                    <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                      {intl.formatMessage({ id: 'common.aliasAddress' })}
-                    </div>
-                    <Input
-                      {...register('chainAddress', {
-                        required: 'Please provide an alias address.',
-                        onChange: () => estimateThornameHandler()
-                      })}
-                      disabled={isLoading}
-                      size="large"
-                    />
-                    {errors.chainAddress && (
-                      <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.chainAddress.message}</div>
-                    )}
-                  </div>
-
-                  {/* Expiry */}
-                  <div>
-                    <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
-                      {intl.formatMessage({ id: 'common.expiry' })}
-                    </div>
-                    <Controller
-                      name="expiry"
-                      control={control}
-                      rules={{ required: true }}
-                      render={({ field }) => (
-                        <div className="flex flex-wrap gap-2">
-                          {[
-                            { value: '1', label: '1 year' },
-                            { value: '2', label: '2 years' },
-                            { value: '3', label: '3 years' },
-                            { value: '5', label: '5 years' }
-                          ].map((item) => (
-                            <button
-                              key={item.value}
-                              type="button"
-                              className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
-                                field.value === item.value
-                                  ? 'border-turquoise bg-turquoise/10 text-turquoise'
-                                  : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
-                              }`}
-                              onClick={() => {
-                                field.onChange(item.value)
-                                estimateThornameHandler()
-                              }}>
-                              {item.label}
-                            </button>
-                          ))}
-                        </div>
-                      )}
-                    />
-                    {errors.expiry && (
-                      <div className="mt-1 text-sm text-error0 dark:text-error0d">{errors.expiry.message}</div>
-                    )}
-                  </div>
-                </div>
-              )}
-              <Fees className="mt-5" fees={thorNamefees} disabled={isLoading} />
-            </div>
-          )}
-        </>
+        {/* THORName — delegated to standalone component */}
+        {interactType === InteractType.THORName && (
+          <THORNameForm
+            walletType={walletType}
+            walletAccount={walletAccount}
+            walletIndex={walletIndex}
+            hdMode={hdMode}
+            balance={balance}
+            interact$={interact$}
+            openExplorerTxUrl={openExplorerTxUrl}
+            getExplorerTxUrl={getExplorerTxUrl}
+            validatePassword$={validatePassword$}
+            thorchainQuery={thorchainQuery}
+            network={network}
+            fee={feeRD}
+            reloadFeesHandler={reloadFeesHandler}
+            thorchainLastblock={thorchainLastblockRd}
+          />
+        )}
       </div>
       <div className="flex items-center justify-center">
-        {lookupMode === 'name' && thornameQuoteValid && (
-          <FlatButton
-            className="mt-10px min-w-[200px]"
-            loading={isLoading}
-            disabled={isLoading || !isValid}
-            type="submit"
-            size="large">
-            {submitLabel}
-          </FlatButton>
-        )}
-
         {interactType === InteractType.RunePool && (
           <FlatButton
             className="mt-20px min-w-[200px]"
@@ -1747,173 +1129,74 @@ export const InteractFormThor = ({
           </FlatButton>
         )}
       </div>
-      <div className="pt-10px font-main text-[14px] text-gray2 dark:text-gray2d">
-        {/* memo */}
-        <div className="my-20px w-full font-main text-[12px] uppercase dark:border-gray1d">
-          <BaseButton
-            className="group font-mainSemiBold flex w-full !justify-between !p-0 text-[16px] text-text2 hover:text-turquoise dark:text-text2d dark:hover:text-turquoise"
-            onClick={() => setShowDetails((current) => !current)}>
-            {intl.formatMessage({ id: 'common.details' })}
-            {showDetails ? (
-              <MagnifyingGlassMinusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
-            ) : (
-              <MagnifyingGlassPlusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
-            )}
-          </BaseButton>
-          {showDetails && (
-            <>
-              {FP.pipe(
-                oThorname,
-                O.map(({ owner, name, aliases, preferredAsset, expireBlockHeight }) => {
-                  if (owner || name || aliases || preferredAsset || expireBlockHeight) {
-                    // Estimate expiry date from block height
-                    const currentBlock = FP.pipe(
-                      thorchainLastblockRd,
-                      RD.toOption,
-                      O.chain((blocks) => O.fromNullable(blocks.find((b) => b.thorchain))),
-                      O.map((b) => b.thorchain),
-                      O.toUndefined
-                    )
-                    const estimatedExpiry =
-                      currentBlock && expireBlockHeight
-                        ? (() => {
-                            const blocksLeft = expireBlockHeight - currentBlock
-                            const secondsLeft = blocksLeft * 6
-                            const daysLeft = Math.round(secondsLeft / 86400)
-                            const expiryDate = new Date(Date.now() + secondsLeft * 1000)
-                            return { date: expiryDate, daysLeft }
-                          })()
-                        : undefined
-
-                    return (
-                      <div key={name} className="mt-2 rounded-lg border border-gray0 p-4 dark:border-gray0d">
-                        {/* Name + Expiry row */}
-                        <div className="flex gap-6">
-                          <div className="flex-1">
-                            <div className="text-[11px] text-gray2 dark:text-gray2d">
-                              {intl.formatMessage({ id: 'common.thorname' })}
-                            </div>
-                            <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">{name}</div>
-                          </div>
-                          <div className="flex-1">
-                            <div className="text-[11px] text-gray2 dark:text-gray2d">Expiry</div>
-                            {estimatedExpiry ? (
-                              <>
-                                <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
-                                  {estimatedExpiry.date.toLocaleDateString(undefined, {
-                                    day: 'numeric',
-                                    month: 'short',
-                                    year: 'numeric'
-                                  })}{' '}
-                                  <span className="text-[12px] text-gray2 dark:text-gray2d">
-                                    (~{estimatedExpiry.daysLeft} days)
-                                  </span>
-                                </div>
-                                <div className="text-[11px] text-gray2 dark:text-gray2d">
-                                  Block {expireBlockHeight?.toLocaleString()}
-                                </div>
-                              </>
-                            ) : (
-                              <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
-                                Block {expireBlockHeight?.toLocaleString()}
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                        {/* Owner */}
-                        <div className="mt-3">
-                          <div className="text-[11px] text-gray2 dark:text-gray2d">
-                            {intl.formatMessage({ id: 'common.owner' })}
-                          </div>
-                          <div className="font-mono text-[12px] break-all text-text0 dark:text-text0d">{owner}</div>
-                        </div>
-                        {/* Preferred Asset */}
-                        {preferredAsset && (
-                          <div className="mt-3">
-                            <div className="text-[11px] text-gray2 dark:text-gray2d">
-                              {intl.formatMessage({ id: 'common.preferredAsset' })}
-                            </div>
-                            <div className="font-mono text-[12px] break-all text-text0 dark:text-text0d">
-                              {preferredAsset}
-                            </div>
-                          </div>
-                        )}
-                        {/* Chain Aliases */}
-                        {aliases && aliases.length > 0 && (
-                          <div className="mt-3">
-                            <div className="mb-1 text-[11px] text-gray2 dark:text-gray2d">
-                              Chain Aliases ({aliases.length})
-                            </div>
-                            <div className="space-y-1">
-                              {aliases.map((alias, index) => (
-                                <div
-                                  key={index}
-                                  className="flex items-baseline gap-3 rounded bg-bg1 px-3 py-2 dark:bg-bg1d">
-                                  <span className="font-mainSemiBold w-[50px] shrink-0 text-[12px] text-text0 dark:text-text0d">
-                                    {alias.chain}
-                                  </span>
-                                  <span className="font-mono text-[12px] break-all text-gray2 dark:text-gray2d">
-                                    {alias.address}
-                                  </span>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    )
-                  }
-                  return null
-                }),
-                O.toNullable
+      {/* THORName has its own details section — skip parent's */}
+      {interactType !== InteractType.THORName && (
+        <div className="pt-10px font-main text-[14px] text-gray2 dark:text-gray2d">
+          {/* memo */}
+          <div className="my-20px w-full font-main text-[12px] uppercase dark:border-gray1d">
+            <BaseButton
+              className="group font-mainSemiBold flex w-full !justify-between !p-0 text-[16px] text-text2 hover:text-turquoise dark:text-text2d dark:hover:text-turquoise"
+              onClick={() => setShowDetails((current) => !current)}>
+              {intl.formatMessage({ id: 'common.details' })}
+              {showDetails ? (
+                <MagnifyingGlassMinusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
+              ) : (
+                <MagnifyingGlassPlusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
               )}
-              {interactType === InteractType.RunePool && (
-                <>
-                  <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
-                    {intl.formatMessage({ id: 'protocolPool.detail.daysLeft' })}
-                    <div className="truncate pl-10px font-main text-[12px]">
-                      {RD.fold(
-                        () => <p>{emptyString}</p>,
-                        () => <p>{emptyString}</p>,
-                        (error: Error) => (
-                          <p>
-                            {intl.formatMessage({ id: 'common.error' })}: {error.message}
-                          </p>
-                        ),
-                        (data: { daysLeft: number; blocksLeft: number }) => (
-                          <div>
+            </BaseButton>
+            {showDetails && (
+              <>
+                {interactType === InteractType.RunePool && (
+                  <>
+                    <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
+                      {intl.formatMessage({ id: 'protocolPool.detail.daysLeft' })}
+                      <div className="truncate pl-10px font-main text-[12px]">
+                        {RD.fold(
+                          () => <p>{emptyString}</p>,
+                          () => <p>{emptyString}</p>,
+                          (error: Error) => (
                             <p>
-                              {intl.formatMessage({ id: 'common.time.days' }, { days: `${data.daysLeft.toFixed(1)}` })}
+                              {intl.formatMessage({ id: 'common.error' })}: {error.message}
                             </p>
-                          </div>
-                        )
-                      )(runePoolData)}
+                          ),
+                          (data: { daysLeft: number; blocksLeft: number }) => (
+                            <div>
+                              <p>
+                                {intl.formatMessage(
+                                  { id: 'common.time.days' },
+                                  { days: `${data.daysLeft.toFixed(1)}` }
+                                )}
+                              </p>
+                            </div>
+                          )
+                        )(runePoolData)}
+                      </div>
                     </div>
+                  </>
+                )}
+
+                <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
+                  {amountLabel}
+                  <div className="truncate pl-10px font-main text-[12px]">
+                    {formatAssetAmountCurrency({
+                      amount:
+                        interactType === InteractType.Unbond ? baseToAsset(_amountToSend) : baseToAsset(amountToSend),
+                      asset: AssetRuneNative,
+                      decimal: isUSDAsset(AssetRuneNative) ? 2 : 6,
+                      trimZeros: !isUSDAsset(AssetRuneNative)
+                    })}
                   </div>
-                </>
-              )}
-
-              <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
-                {amountLabel}
-                <div className="truncate pl-10px font-main text-[12px]">
-                  {formatAssetAmountCurrency({
-                    amount:
-                      interactType === InteractType.Unbond ? baseToAsset(_amountToSend) : baseToAsset(amountToSend),
-                    asset: AssetRuneNative,
-                    decimal: isUSDAsset(AssetRuneNative) ? 2 : 6,
-                    trimZeros: !isUSDAsset(AssetRuneNative)
-                  })}
                 </div>
-              </div>
 
-              <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
-                {intl.formatMessage({ id: 'common.memo' })}
-                <div className="overflow pl-10px font-main text-[12px] break-normal">{memoLabel}</div>
-              </div>
-            </>
-          )}
+                <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
+                  {intl.formatMessage({ id: 'common.memo' })}
+                  <div className="overflow pl-10px font-main text-[12px] break-normal">{memoLabel}</div>
+                </div>
+              </>
+            )}
+          </div>
         </div>
-      </div>
+      )}
       {showConfirmationModal && renderConfirmationModal}
       {renderTxModal}
     </form>

--- a/src/renderer/components/wallet/txs/interact/thorname/MAYANameForm.tsx
+++ b/src/renderer/components/wallet/txs/interact/thorname/MAYANameForm.tsx
@@ -1,0 +1,784 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import * as RD from '@devexperts/remote-data-ts'
+import {
+  MagnifyingGlassIcon,
+  MagnifyingGlassMinusIcon,
+  MagnifyingGlassPlusIcon,
+  UserIcon
+} from '@heroicons/react/24/outline'
+import { AssetAETH } from '@xchainjs/xchain-arbitrum'
+import { AssetBTC } from '@xchainjs/xchain-bitcoin'
+import { Network } from '@xchainjs/xchain-client'
+import { AssetETH } from '@xchainjs/xchain-ethereum'
+import { AssetCacao, MAYAChain } from '@xchainjs/xchain-mayachain'
+import { MayachainQuery, QuoteMAYANameParams, MAYANameDetails } from '@xchainjs/xchain-mayachain-query'
+import { AssetRuneNative } from '@xchainjs/xchain-thorchain'
+import { baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
+import { function as FP, option as O } from 'fp-ts'
+import { useIntl } from 'react-intl'
+
+import { isKeystoreWallet, isLedgerWallet } from '../../../../../../shared/utils/guard'
+import { HDMode, WalletType } from '../../../../../../shared/wallet/types'
+import { ZERO_BASE_AMOUNT } from '../../../../../const'
+import { useSubscriptionState } from '../../../../../hooks/useSubscriptionState'
+import { FeeRD } from '../../../../../services/chain/types'
+import { GetExplorerTxUrl, OpenExplorerTxUrl } from '../../../../../services/clients'
+import { INITIAL_INTERACT_STATE } from '../../../../../services/mayachain/const'
+import { InteractState, InteractStateHandler, LastblockItems } from '../../../../../services/mayachain/types'
+import { ValidatePasswordHandler, WalletBalance } from '../../../../../services/wallet/types'
+import { LedgerConfirmationModal, WalletPasswordConfirmationModal } from '../../../../modal/confirmation'
+import { TxModal } from '../../../../modal/tx'
+import { SendAsset } from '../../../../modal/tx/extra/SendAsset'
+import { BaseButton, FlatButton, ViewTxButton } from '../../../../uielements/button'
+import { CheckButton } from '../../../../uielements/button/CheckButton'
+import { Fees, UIFees, UIFeesRD } from '../../../../uielements/fees'
+import { InfoIcon } from '../../../../uielements/info'
+import { Input } from '../../../../uielements/input'
+import { Label } from '../../../../uielements/label'
+import { Tooltip } from '../../../../uielements/tooltip'
+import * as H from '../Interact.helpers'
+import { NameDetailsCard } from './NameDetailsCard'
+import { QuoteState, estimateExpiry } from './types'
+
+type Props = {
+  walletType: WalletType
+  walletAccount: number
+  walletIndex: number
+  hdMode: HDMode
+  balance: WalletBalance
+  interactMaya$: InteractStateHandler
+  openExplorerTxUrl: OpenExplorerTxUrl
+  getExplorerTxUrl: GetExplorerTxUrl
+  validatePassword$: ValidatePasswordHandler
+  mayachainQuery: MayachainQuery
+  network: Network
+  fee: FeeRD
+  reloadFeesHandler: FP.Lazy<void>
+  mayachainLastblockRD: RD.RemoteData<Error, LastblockItems>
+}
+
+type Tab = 'lookup' | 'owner' | 'register'
+
+export const MAYANameForm = ({
+  walletType,
+  walletAccount,
+  walletIndex,
+  hdMode,
+  balance,
+  interactMaya$,
+  openExplorerTxUrl,
+  getExplorerTxUrl,
+  validatePassword$,
+  mayachainQuery,
+  network,
+  fee: feeRD,
+  reloadFeesHandler,
+  mayachainLastblockRD
+}: Props) => {
+  const intl = useIntl()
+  const { asset, walletAddress } = balance
+
+  // Tab state
+  const [activeTab, setActiveTab] = useState<Tab>('lookup')
+
+  // Lookup tab state
+  const [lookupName, setLookupName] = useState('')
+  const [lookupResult, setLookupResult] = useState<O.Option<MAYANameDetails>>(O.none)
+  const [isLookingUp, setIsLookingUp] = useState(false)
+
+  // Owner tab state
+  const [ownerAddress, setOwnerAddress] = useState('')
+  const [ownerNames, setOwnerNames] = useState<MAYANameDetails[]>([])
+  const [isLookingUpOwner, setIsLookingUpOwner] = useState(false)
+  const [ownerSearchDone, setOwnerSearchDone] = useState(false)
+
+  // Register tab state
+  const [regName, setRegName] = useState('')
+  const [regChainAddress, setRegChainAddress] = useState(walletAddress)
+  const [regAliasChain, setRegAliasChain] = useState('')
+  const [regAliasAddress, setRegAliasAddress] = useState('')
+  const [regExpiry, setRegExpiry] = useState('1')
+  const [nameAvailable, setNameAvailable] = useState(false)
+  const [isNewRegistration, setIsNewRegistration] = useState(false)
+  const [isOwner, setIsOwner] = useState(false)
+
+  // Quote state (two-phase flow)
+  const [quoteState, setQuoteState] = useState<QuoteState>({ status: 'idle' })
+
+  // Tx state
+  const {
+    state: interactState,
+    reset: resetInteractState,
+    subscribe: subscribeInteractState
+  } = useSubscriptionState<InteractState>(INITIAL_INTERACT_STATE)
+  const isLoading = useMemo(() => RD.isPending(interactState.txRD), [interactState.txRD])
+  const [sendTxStartTime, setSendTxStartTime] = useState(0)
+  const [showConfirmationModal, setShowConfirmationModal] = useState(false)
+  const [showDetails, setShowDetails] = useState(true)
+
+  // Lookup handler
+  const handleLookup = useCallback(async () => {
+    if (!lookupName) return
+    setIsLookingUp(true)
+    try {
+      const details = await mayachainQuery.getMAYANameDetails(lookupName)
+      if (details) {
+        setLookupResult(O.some(details))
+      }
+    } catch (_error) {
+      setLookupResult(O.none)
+    } finally {
+      setIsLookingUp(false)
+    }
+  }, [lookupName, mayachainQuery])
+
+  // Owner lookup handler
+  const handleOwnerLookup = useCallback(async () => {
+    if (!ownerAddress) return
+    setIsLookingUpOwner(true)
+    setOwnerNames([])
+    setOwnerSearchDone(false)
+    try {
+      const details = await mayachainQuery.getMAYANamesByOwner(ownerAddress)
+      if (details && details.length > 0) {
+        setOwnerNames(details)
+      }
+    } catch (_error) {
+      // no names found
+    } finally {
+      setIsLookingUpOwner(false)
+      setOwnerSearchDone(true)
+    }
+  }, [ownerAddress, mayachainQuery])
+
+  // Check name availability (register tab)
+  const handleCheckName = useCallback(async () => {
+    if (!regName) return
+    setQuoteState({ status: 'idle' })
+    setIsLookingUp(true)
+    try {
+      const details = await mayachainQuery.getMAYANameDetails(regName)
+      if (details) {
+        const available = details.owner === '' || walletAddress === details.owner
+        setNameAvailable(available)
+        setIsNewRegistration(details.name === '')
+        setIsOwner(walletAddress === details.owner)
+      }
+      if (details === undefined) {
+        setNameAvailable(true)
+        setIsNewRegistration(true)
+        setIsOwner(false)
+      }
+    } catch (_error) {
+      setNameAvailable(true)
+      setIsNewRegistration(true)
+      setIsOwner(false)
+    } finally {
+      setIsLookingUp(false)
+    }
+  }, [regName, mayachainQuery, walletAddress])
+
+  // Get quote (Phase 1)
+  const handleGetQuote = useCallback(async () => {
+    const currentDate = new Date()
+    const chain = isNewRegistration ? MAYAChain : regAliasChain
+    const chainAddress = isNewRegistration ? regChainAddress : regAliasAddress
+    const yearsToAdd = parseInt(regExpiry || '1')
+    const expiry =
+      yearsToAdd === 1
+        ? undefined
+        : new Date(currentDate.getFullYear() + yearsToAdd, currentDate.getMonth(), currentDate.getDate())
+
+    if (!regName || !chain || !chainAddress) return
+
+    setQuoteState({ status: 'loading' })
+    try {
+      const params: QuoteMAYANameParams = {
+        name: regName,
+        chain,
+        chainAddress,
+        owner: walletAddress,
+        expiry,
+        isUpdate: isOwner
+      }
+      const quote = await mayachainQuery.estimateMAYAName(params)
+      if (quote) {
+        setQuoteState({
+          status: 'success',
+          memo: quote.memo,
+          amount: quote.value.baseAmount
+        })
+      } else {
+        setQuoteState({ status: 'error', message: 'No quote returned' })
+      }
+    } catch (error) {
+      setQuoteState({ status: 'error', message: error instanceof Error ? error.message : 'Quote failed' })
+    }
+  }, [
+    regName,
+    regAliasChain,
+    regAliasAddress,
+    regChainAddress,
+    regExpiry,
+    walletAddress,
+    isNewRegistration,
+    isOwner,
+    mayachainQuery
+  ])
+
+  // Submit tx (Phase 2)
+  const submitTx = useCallback(() => {
+    if (quoteState.status !== 'success') return
+    setSendTxStartTime(Date.now())
+    subscribeInteractState(
+      interactMaya$({
+        walletType,
+        walletAccount,
+        walletIndex,
+        hdMode,
+        amount: quoteState.amount,
+        memo: quoteState.memo,
+        asset
+      })
+    )
+  }, [subscribeInteractState, interactMaya$, walletType, walletAccount, walletIndex, hdMode, quoteState, asset])
+
+  const resetForm = useCallback(() => {
+    resetInteractState()
+    setQuoteState({ status: 'idle' })
+    setNameAvailable(false)
+    setIsNewRegistration(false)
+    setIsOwner(false)
+    setRegName('')
+    setRegChainAddress(walletAddress)
+    setRegAliasChain('')
+    setRegAliasAddress('')
+    setRegExpiry('1')
+    setOwnerNames([])
+    setOwnerSearchDone(false)
+    setLookupResult(O.none)
+  }, [resetInteractState, walletAddress])
+
+  // Reset when switching tabs
+  useEffect(() => {
+    setQuoteState({ status: 'idle' })
+    setNameAvailable(false)
+  }, [activeTab])
+
+  // Current block for expiry estimation
+  const currentBlock = useMemo(
+    () =>
+      FP.pipe(
+        mayachainLastblockRD,
+        RD.toOption,
+        O.chain((blocks) => O.fromNullable(blocks.find((b) => b.mayachain))),
+        O.map((b) => b.mayachain),
+        O.toUndefined
+      ),
+    [mayachainLastblockRD]
+  )
+
+  // Fee display for quote amount
+  const quoteFees: UIFeesRD = useMemo(() => {
+    if (quoteState.status === 'success') {
+      const fees: UIFees = [{ asset: AssetCacao, amount: quoteState.amount }]
+      return RD.success(fees)
+    }
+    return FP.pipe(
+      feeRD,
+      RD.map((fee) => [{ asset: AssetCacao, amount: fee }])
+    )
+  }, [quoteState, feeRD])
+
+  // Confirmation modal
+  const renderConfirmationModal = useMemo(() => {
+    const onSuccessHandler = () => {
+      setShowConfirmationModal(false)
+      submitTx()
+    }
+    const onCloseHandler = () => {
+      setShowConfirmationModal(false)
+    }
+
+    if (isKeystoreWallet(walletType)) {
+      return (
+        <WalletPasswordConfirmationModal
+          onSuccess={onSuccessHandler}
+          onClose={onCloseHandler}
+          validatePassword$={validatePassword$}
+        />
+      )
+    }
+    if (isLedgerWallet(walletType)) {
+      return (
+        <LedgerConfirmationModal
+          network={network}
+          onSuccess={onSuccessHandler}
+          onClose={onCloseHandler}
+          visible={showConfirmationModal}
+          chain={MAYAChain}
+          description2={intl.formatMessage({ id: 'ledger.sign' })}
+          addresses={O.none}
+        />
+      )
+    }
+    return <></>
+  }, [walletType, submitTx, validatePassword$, network, showConfirmationModal, intl])
+
+  // Tx result modal
+  const renderTxModal = useMemo(() => {
+    const { txRD } = interactState
+    if (RD.isInitial(txRD)) return <></>
+
+    const timerValue = FP.pipe(
+      txRD,
+      RD.fold(
+        () => 0,
+        FP.flow(
+          O.map(({ loaded }) => loaded),
+          O.getOrElse(() => 0)
+        ),
+        () => 0,
+        () => 100
+      )
+    )
+    const oTxHash = RD.toOption(txRD)
+    const txRDasBoolean = FP.pipe(
+      txRD,
+      RD.map((txHash) => !!txHash)
+    )
+
+    return (
+      <TxModal
+        title={intl.formatMessage({ id: 'common.tx.sending' })}
+        onClose={resetForm}
+        onFinish={resetForm}
+        startTime={sendTxStartTime}
+        txRD={txRDasBoolean}
+        extraResult={
+          <ViewTxButton
+            txHash={oTxHash}
+            onClick={openExplorerTxUrl}
+            txUrl={FP.pipe(oTxHash, O.chain(getExplorerTxUrl))}
+            network={network}
+          />
+        }
+        timerValue={timerValue}
+        extra={
+          <SendAsset
+            asset={{ asset, amount: quoteState.status === 'success' ? quoteState.amount : ZERO_BASE_AMOUNT }}
+            network={network}
+            description={H.getInteractiveDescription({ state: interactState, intl })}
+          />
+        }
+      />
+    )
+  }, [interactState, intl, resetForm, sendTxStartTime, openExplorerTxUrl, getExplorerTxUrl, asset, quoteState, network])
+
+  return (
+    <div className="w-full sm:max-w-[630px]">
+      {/* Tab navigation */}
+      <div className="mb-4 flex border-b border-gray0 dark:border-gray0d">
+        <button
+          type="button"
+          className={`flex items-center gap-1.5 px-4 pb-2 font-main text-[14px] transition-colors ${
+            activeTab === 'lookup'
+              ? 'border-b-2 border-turquoise text-turquoise'
+              : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
+          }`}
+          onClick={() => setActiveTab('lookup')}>
+          <MagnifyingGlassIcon className="h-4 w-4" />
+          Lookup Name
+        </button>
+        <button
+          type="button"
+          className={`flex items-center gap-1.5 px-4 pb-2 font-main text-[14px] transition-colors ${
+            activeTab === 'owner'
+              ? 'border-b-2 border-turquoise text-turquoise'
+              : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
+          }`}
+          onClick={() => setActiveTab('owner')}>
+          <UserIcon className="h-4 w-4" />
+          Names by Owner
+        </button>
+        <button
+          type="button"
+          className={`flex items-center gap-1.5 px-4 pb-2 font-main text-[14px] transition-colors ${
+            activeTab === 'register'
+              ? 'border-b-2 border-turquoise text-turquoise'
+              : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
+          }`}
+          onClick={() => setActiveTab('register')}>
+          Register / Update
+        </button>
+      </div>
+
+      {/* ═══ LOOKUP TAB ═══ */}
+      {activeTab === 'lookup' && (
+        <>
+          <div className="flex items-center text-[12px]">
+            <Label color="input" size="big" textTransform="uppercase">
+              {intl.formatMessage({ id: 'common.mayaname' })}
+            </Label>
+            <InfoIcon
+              className="ml-[3px] h-[15px] w-[15px] text-inherit"
+              color="primary"
+              tooltip={intl.formatMessage({ id: 'common.mayanameRegistrationSpecifics' })}
+            />
+          </div>
+          <div className="flex items-start gap-2">
+            <div className="flex-1">
+              <Input
+                value={lookupName}
+                onChange={(e) => setLookupName(e.target.value)}
+                disabled={isLookingUp}
+                size="large"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleLookup()
+                  }
+                }}
+              />
+            </div>
+            <FlatButton
+              className="h-[40px] min-w-[100px]"
+              size="normal"
+              color="primary"
+              disabled={isLookingUp || !lookupName}
+              loading={isLookingUp}
+              onClick={handleLookup}>
+              Lookup
+            </FlatButton>
+          </div>
+
+          {/* Lookup result */}
+          {FP.pipe(
+            lookupResult,
+            O.map((details) => (
+              <div key={details.name} className="mt-4">
+                <NameDetailsCard
+                  name={details.name}
+                  owner={details.owner}
+                  expireBlockHeight={details.expireBlockHeight}
+                  estimatedExpiry={estimateExpiry(currentBlock, details.expireBlockHeight)}
+                  aliases={details.aliases}
+                  nameLabel={intl.formatMessage({ id: 'common.mayaname' })}
+                />
+              </div>
+            )),
+            O.toNullable
+          )}
+        </>
+      )}
+
+      {/* ═══ OWNER TAB ═══ */}
+      {activeTab === 'owner' && (
+        <>
+          <Label color="input" size="big" textTransform="uppercase">
+            Owner Address
+          </Label>
+          <Input
+            value={ownerAddress}
+            onChange={(e) => setOwnerAddress(e.target.value)}
+            disabled={isLookingUpOwner}
+            size="large"
+            placeholder="maya1... or any chain address"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                handleOwnerLookup()
+              }
+            }}
+          />
+          <FlatButton
+            className="mt-4 w-full"
+            size="large"
+            color="primary"
+            disabled={isLookingUpOwner || !ownerAddress}
+            loading={isLookingUpOwner}
+            onClick={handleOwnerLookup}>
+            <UserIcon className="mr-2 h-5 w-5" />
+            Find Names
+          </FlatButton>
+
+          {ownerSearchDone && !isLookingUpOwner && ownerNames.length === 0 && (
+            <div className="mt-4 text-center text-[14px] text-gray2 dark:text-gray2d">
+              No names found for this address
+            </div>
+          )}
+          {!isLookingUpOwner && ownerNames.length > 0 && (
+            <div className="mt-4 space-y-3">
+              {ownerNames.map((details) => (
+                <NameDetailsCard
+                  key={details.name}
+                  name={details.name}
+                  owner={details.owner}
+                  expireBlockHeight={details.expireBlockHeight}
+                  estimatedExpiry={estimateExpiry(currentBlock, details.expireBlockHeight)}
+                  aliases={details.aliases}
+                  nameLabel={intl.formatMessage({ id: 'common.mayaname' })}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* ═══ REGISTER / UPDATE TAB ═══ */}
+      {activeTab === 'register' && (
+        <>
+          {/* Name input + check */}
+          <div className="flex items-center text-[12px]">
+            <Label color="input" size="big" textTransform="uppercase">
+              {intl.formatMessage({ id: 'common.mayaname' })}
+            </Label>
+            <InfoIcon
+              className="ml-[3px] h-[15px] w-[15px] text-inherit"
+              color="primary"
+              tooltip={intl.formatMessage({ id: 'common.mayanameRegistrationSpecifics' })}
+            />
+          </div>
+          <div className="flex items-start gap-2">
+            <div className="flex-1">
+              <Input
+                value={regName}
+                onChange={(e) => {
+                  setRegName(e.target.value)
+                  setNameAvailable(false)
+                  setQuoteState({ status: 'idle' })
+                }}
+                disabled={isLoading || isLookingUp}
+                size="large"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleCheckName()
+                  }
+                }}
+              />
+            </div>
+            <FlatButton
+              className="h-[40px] min-w-[100px]"
+              size="normal"
+              color="primary"
+              disabled={isLoading || isLookingUp || !regName}
+              loading={isLookingUp}
+              onClick={handleCheckName}>
+              {intl.formatMessage({ id: 'deposit.interact.actions.checkThorname' })}
+            </FlatButton>
+          </div>
+
+          {/* Name available — show form */}
+          {nameAvailable && (
+            <div className="mt-4 rounded-lg border border-gray0 p-5 dark:border-gray0d">
+              {isOwner && (
+                <div className="mb-4">
+                  <CheckButton checked={true} clickHandler={() => {}} disabled={isLoading}>
+                    {intl.formatMessage({ id: 'common.isUpdateMayaname' })}
+                  </CheckButton>
+                </div>
+              )}
+
+              <div className="space-y-5">
+                {/* Alias Chain */}
+                <div>
+                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
+                    {intl.formatMessage({ id: 'common.aliasChain' })}
+                  </div>
+                  {isNewRegistration ? (
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className="rounded-full border border-turquoise bg-turquoise/10 px-4 py-1.5 font-main text-[13px] text-turquoise">
+                        MAYA
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      {[
+                        { value: AssetAETH.chain, label: 'ARB' },
+                        { value: AssetBTC.chain, label: 'BTC' },
+                        { value: AssetETH.chain, label: 'ETH' },
+                        { value: AssetRuneNative.chain, label: 'RUNE' }
+                      ].map((item) => (
+                        <button
+                          key={item.value}
+                          type="button"
+                          className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
+                            regAliasChain === item.value
+                              ? 'border-turquoise bg-turquoise/10 text-turquoise'
+                              : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
+                          }`}
+                          onClick={() => setRegAliasChain(item.value)}>
+                          {item.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Alias Address */}
+                <div>
+                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
+                    {intl.formatMessage({ id: 'common.aliasAddress' })}
+                  </div>
+                  {isNewRegistration ? (
+                    <Input
+                      value={regChainAddress}
+                      onChange={(e) => setRegChainAddress(e.target.value)}
+                      disabled={isLoading}
+                      size="large"
+                    />
+                  ) : (
+                    <Input
+                      value={regAliasAddress}
+                      onChange={(e) => setRegAliasAddress(e.target.value)}
+                      disabled={isLoading}
+                      size="large"
+                    />
+                  )}
+                </div>
+
+                {/* Expiry */}
+                <div>
+                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
+                    {intl.formatMessage({ id: 'common.expiry' })}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {[
+                      { value: '1', label: '1 year' },
+                      { value: '2', label: '2 years' },
+                      { value: '3', label: '3 years' },
+                      { value: '5', label: '5 years' }
+                    ].map((item) => (
+                      <button
+                        key={item.value}
+                        type="button"
+                        className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
+                          regExpiry === item.value
+                            ? 'border-turquoise bg-turquoise/10 text-turquoise'
+                            : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
+                        }`}
+                        onClick={() => setRegExpiry(item.value)}>
+                        {item.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Get Quote button */}
+                <FlatButton
+                  className="mt-2 w-full"
+                  size="large"
+                  color="primary"
+                  disabled={
+                    isLoading ||
+                    quoteState.status === 'loading' ||
+                    (!isNewRegistration && (!regAliasChain || !regAliasAddress)) ||
+                    (isNewRegistration && !regChainAddress)
+                  }
+                  loading={quoteState.status === 'loading'}
+                  onClick={handleGetQuote}>
+                  {intl.formatMessage({ id: 'deposit.interact.actions.getQuote' })}
+                </FlatButton>
+              </div>
+
+              {/* Quote error */}
+              {quoteState.status === 'error' && (
+                <div className="mt-4 rounded-lg border border-error0 bg-error0/10 p-3 dark:border-error0d dark:bg-error0d/10">
+                  <div className="text-[13px] text-error0 dark:text-error0d">{quoteState.message}</div>
+                </div>
+              )}
+
+              {/* Quote result */}
+              {quoteState.status === 'success' && (
+                <div className="mt-4 rounded-lg border border-turquoise/30 bg-turquoise/5 p-4">
+                  <div className="flex gap-6">
+                    <div className="flex-1">
+                      <div className="text-[11px] text-gray2 dark:text-gray2d">
+                        {intl.formatMessage({ id: 'common.amount' })}
+                      </div>
+                      <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
+                        {formatAssetAmountCurrency({
+                          amount: baseToAsset(quoteState.amount),
+                          asset: AssetCacao,
+                          trimZeros: true
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mt-2">
+                    <div className="text-[11px] text-gray2 dark:text-gray2d">
+                      {intl.formatMessage({ id: 'common.memo' })}
+                    </div>
+                    <div className="font-mono text-[11px] break-all text-text0 dark:text-text0d">
+                      <Tooltip title={quoteState.memo}>{quoteState.memo}</Tooltip>
+                    </div>
+                  </div>
+
+                  {/* Execute button (Phase 2) */}
+                  <FlatButton
+                    className="mt-4 w-full"
+                    size="large"
+                    loading={isLoading}
+                    disabled={isLoading}
+                    onClick={() => setShowConfirmationModal(true)}>
+                    {isOwner
+                      ? intl.formatMessage({ id: 'common.isUpdateMayaname' })
+                      : intl.formatMessage({ id: 'deposit.interact.actions.buyMayaname' })}
+                  </FlatButton>
+                </div>
+              )}
+
+              {/* Fees */}
+              <Fees className="mt-4" fees={quoteFees} reloadFees={reloadFeesHandler} disabled={isLoading} />
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Details section — only render when there's a quote */}
+      {quoteState.status === 'success' && (
+        <div className="pt-10px font-main text-[14px] text-gray2 dark:text-gray2d">
+          <div className="my-20px w-full font-main text-[12px] uppercase dark:border-gray1d">
+            <BaseButton
+              className="group font-mainSemiBold flex w-full !justify-between !p-0 text-[16px] text-text2 hover:text-turquoise dark:text-text2d dark:hover:text-turquoise"
+              onClick={() => setShowDetails((current) => !current)}>
+              {intl.formatMessage({ id: 'common.details' })}
+              {showDetails ? (
+                <MagnifyingGlassMinusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
+              ) : (
+                <MagnifyingGlassPlusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
+              )}
+            </BaseButton>
+            {showDetails && (
+              <>
+                <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
+                  {intl.formatMessage({ id: 'common.amount' })}
+                  <div className="truncate pl-10px font-main text-[12px]">
+                    {formatAssetAmountCurrency({
+                      amount: baseToAsset(quoteState.amount),
+                      asset: AssetCacao,
+                      trimZeros: true
+                    })}
+                  </div>
+                </div>
+                <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
+                  {intl.formatMessage({ id: 'common.memo' })}
+                  <div className="overflow pl-10px font-main text-[12px] break-normal">
+                    <Tooltip title={quoteState.memo}>{quoteState.memo}</Tooltip>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {showConfirmationModal && renderConfirmationModal}
+      {renderTxModal}
+    </div>
+  )
+}

--- a/src/renderer/components/wallet/txs/interact/thorname/MAYANameForm.tsx
+++ b/src/renderer/components/wallet/txs/interact/thorname/MAYANameForm.tsx
@@ -389,7 +389,7 @@ export const MAYANameForm = ({
           }`}
           onClick={() => setActiveTab('lookup')}>
           <MagnifyingGlassIcon className="h-4 w-4" />
-          Lookup Name
+          {intl.formatMessage({ id: 'common.lookupName' })}
         </button>
         <button
           type="button"
@@ -400,7 +400,7 @@ export const MAYANameForm = ({
           }`}
           onClick={() => setActiveTab('owner')}>
           <UserIcon className="h-4 w-4" />
-          Names by Owner
+          {intl.formatMessage({ id: 'common.namesByOwner' })}
         </button>
         <button
           type="button"
@@ -410,7 +410,7 @@ export const MAYANameForm = ({
               : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
           }`}
           onClick={() => setActiveTab('register')}>
-          Register / Update
+          {intl.formatMessage({ id: 'common.registerUpdate' })}
         </button>
       </div>
 
@@ -449,7 +449,7 @@ export const MAYANameForm = ({
               disabled={isLookingUp || !lookupName}
               loading={isLookingUp}
               onClick={handleLookup}>
-              Lookup
+              {intl.formatMessage({ id: 'common.lookup' })}
             </FlatButton>
           </div>
 
@@ -477,14 +477,14 @@ export const MAYANameForm = ({
       {activeTab === 'owner' && (
         <>
           <Label color="input" size="big" textTransform="uppercase">
-            Owner Address
+            {intl.formatMessage({ id: 'common.ownerAddress' })}
           </Label>
           <Input
             value={ownerAddress}
             onChange={(e) => setOwnerAddress(e.target.value)}
             disabled={isLookingUpOwner}
             size="large"
-            placeholder="maya1... or any chain address"
+            placeholder={intl.formatMessage({ id: 'common.ownerAddress.placeholder' })}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault()
@@ -500,12 +500,12 @@ export const MAYANameForm = ({
             loading={isLookingUpOwner}
             onClick={handleOwnerLookup}>
             <UserIcon className="mr-2 h-5 w-5" />
-            Find Names
+            {intl.formatMessage({ id: 'common.findNames' })}
           </FlatButton>
 
           {ownerSearchDone && !isLookingUpOwner && ownerNames.length === 0 && (
             <div className="mt-4 text-center text-[14px] text-gray2 dark:text-gray2d">
-              No names found for this address
+              {intl.formatMessage({ id: 'common.noNamesFound' })}
             </div>
           )}
           {!isLookingUpOwner && ownerNames.length > 0 && (

--- a/src/renderer/components/wallet/txs/interact/thorname/NameDetailsCard.tsx
+++ b/src/renderer/components/wallet/txs/interact/thorname/NameDetailsCard.tsx
@@ -1,0 +1,83 @@
+import { useIntl } from 'react-intl'
+
+import { EstimatedExpiry } from './types'
+
+type Props = {
+  name: string
+  owner: string
+  expireBlockHeight?: number
+  estimatedExpiry?: EstimatedExpiry
+  preferredAsset?: string
+  aliases?: { chain: string; address: string }[]
+  nameLabel: string
+}
+
+export const NameDetailsCard = ({
+  name,
+  owner,
+  expireBlockHeight,
+  estimatedExpiry,
+  preferredAsset,
+  aliases,
+  nameLabel
+}: Props) => {
+  const intl = useIntl()
+
+  return (
+    <div className="rounded-lg border border-gray0 p-4 dark:border-gray0d">
+      <div className="flex gap-6">
+        <div className="flex-1">
+          <div className="text-[11px] text-gray2 dark:text-gray2d">{nameLabel}</div>
+          <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">{name}</div>
+        </div>
+        <div className="flex-1">
+          <div className="text-[11px] text-gray2 dark:text-gray2d">{intl.formatMessage({ id: 'common.expiry' })}</div>
+          {estimatedExpiry ? (
+            <>
+              <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
+                {estimatedExpiry.date.toLocaleDateString(undefined, {
+                  day: 'numeric',
+                  month: 'short',
+                  year: 'numeric'
+                })}{' '}
+                <span className="text-[12px] text-gray2 dark:text-gray2d">(~{estimatedExpiry.daysLeft} days)</span>
+              </div>
+              <div className="text-[11px] text-gray2 dark:text-gray2d">Block {expireBlockHeight?.toLocaleString()}</div>
+            </>
+          ) : (
+            <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
+              Block {expireBlockHeight?.toLocaleString()}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="mt-3">
+        <div className="text-[11px] text-gray2 dark:text-gray2d">{intl.formatMessage({ id: 'common.owner' })}</div>
+        <div className="font-mono text-[12px] break-all text-text0 dark:text-text0d">{owner}</div>
+      </div>
+      {preferredAsset && (
+        <div className="mt-3">
+          <div className="text-[11px] text-gray2 dark:text-gray2d">
+            {intl.formatMessage({ id: 'common.preferredAsset' })}
+          </div>
+          <div className="font-mono text-[12px] break-all text-text0 dark:text-text0d">{preferredAsset}</div>
+        </div>
+      )}
+      {aliases && aliases.length > 0 && (
+        <div className="mt-3">
+          <div className="mb-1 text-[11px] text-gray2 dark:text-gray2d">Chain Aliases ({aliases.length})</div>
+          <div className="space-y-1">
+            {aliases.map((alias, index) => (
+              <div key={index} className="flex items-baseline gap-3 rounded bg-bg1 px-3 py-2 dark:bg-bg1d">
+                <span className="font-mainSemiBold w-[50px] shrink-0 text-[12px] text-text0 dark:text-text0d">
+                  {alias.chain}
+                </span>
+                <span className="font-mono text-[12px] break-all text-gray2 dark:text-gray2d">{alias.address}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/wallet/txs/interact/thorname/NameDetailsCard.tsx
+++ b/src/renderer/components/wallet/txs/interact/thorname/NameDetailsCard.tsx
@@ -1,14 +1,9 @@
 import { useIntl } from 'react-intl'
 
-import { EstimatedExpiry } from './types'
+import { EstimatedExpiry, NameDetails } from './types'
 
-type Props = {
-  name: string
-  owner: string
-  expireBlockHeight?: number
+type Props = NameDetails & {
   estimatedExpiry?: EstimatedExpiry
-  preferredAsset?: string
-  aliases?: { chain: string; address: string }[]
   nameLabel: string
 }
 
@@ -40,13 +35,17 @@ export const NameDetailsCard = ({
                   month: 'short',
                   year: 'numeric'
                 })}{' '}
-                <span className="text-[12px] text-gray2 dark:text-gray2d">(~{estimatedExpiry.daysLeft} days)</span>
+                <span className="text-[12px] text-gray2 dark:text-gray2d">
+                  {intl.formatMessage({ id: 'common.daysApprox' }, { days: estimatedExpiry.daysLeft })}
+                </span>
               </div>
-              <div className="text-[11px] text-gray2 dark:text-gray2d">Block {expireBlockHeight?.toLocaleString()}</div>
+              <div className="text-[11px] text-gray2 dark:text-gray2d">
+                {intl.formatMessage({ id: 'common.block' }, { block: expireBlockHeight?.toLocaleString() })}
+              </div>
             </>
           ) : (
             <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
-              Block {expireBlockHeight?.toLocaleString()}
+              {intl.formatMessage({ id: 'common.block' }, { block: expireBlockHeight?.toLocaleString() })}
             </div>
           )}
         </div>
@@ -65,7 +64,9 @@ export const NameDetailsCard = ({
       )}
       {aliases && aliases.length > 0 && (
         <div className="mt-3">
-          <div className="mb-1 text-[11px] text-gray2 dark:text-gray2d">Chain Aliases ({aliases.length})</div>
+          <div className="mb-1 text-[11px] text-gray2 dark:text-gray2d">
+            {intl.formatMessage({ id: 'common.chainAliases' }, { count: aliases.length })}
+          </div>
           <div className="space-y-1">
             {aliases.map((alias, index) => (
               <div key={index} className="flex items-baseline gap-3 rounded bg-bg1 px-3 py-2 dark:bg-bg1d">

--- a/src/renderer/components/wallet/txs/interact/thorname/THORNameForm.tsx
+++ b/src/renderer/components/wallet/txs/interact/thorname/THORNameForm.tsx
@@ -1,0 +1,830 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import * as RD from '@devexperts/remote-data-ts'
+import {
+  MagnifyingGlassIcon,
+  MagnifyingGlassMinusIcon,
+  MagnifyingGlassPlusIcon,
+  UserIcon
+} from '@heroicons/react/24/outline'
+import { Network } from '@xchainjs/xchain-client'
+import { THORChain } from '@xchainjs/xchain-thorchain'
+import { QuoteTHORNameParams, ThorchainQuery, ThornameDetails } from '@xchainjs/xchain-thorchain-query'
+import { AnyAsset, Asset, BaseAmount, baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
+import { function as FP, option as O } from 'fp-ts'
+import { useIntl } from 'react-intl'
+
+import { AssetBTC, AssetDOGE, AssetETH, AssetRuneNative, AssetAVAX } from '../../../../../../shared/utils/asset'
+import { isKeystoreWallet, isLedgerWallet } from '../../../../../../shared/utils/guard'
+import { HDMode, WalletType } from '../../../../../../shared/wallet/types'
+import { AssetUSDT, ZERO_BASE_AMOUNT } from '../../../../../const'
+import { useSubscriptionState } from '../../../../../hooks/useSubscriptionState'
+import { FeeRD } from '../../../../../services/chain/types'
+import { GetExplorerTxUrl, OpenExplorerTxUrl } from '../../../../../services/clients'
+import { INITIAL_INTERACT_STATE } from '../../../../../services/thorchain/const'
+import { InteractState, InteractStateHandler, ThorchainLastblockRD } from '../../../../../services/thorchain/types'
+import { ValidatePasswordHandler, WalletBalance } from '../../../../../services/wallet/types'
+import { LedgerConfirmationModal, WalletPasswordConfirmationModal } from '../../../../modal/confirmation'
+import { TxModal } from '../../../../modal/tx'
+import { SendAsset } from '../../../../modal/tx/extra/SendAsset'
+import { BaseButton, FlatButton, ViewTxButton } from '../../../../uielements/button'
+import { CheckButton } from '../../../../uielements/button/CheckButton'
+import { Fees, UIFees, UIFeesRD } from '../../../../uielements/fees'
+import { InfoIcon } from '../../../../uielements/info'
+import { Input } from '../../../../uielements/input'
+import { Label } from '../../../../uielements/label'
+import { Tooltip } from '../../../../uielements/tooltip'
+import * as H from '../Interact.helpers'
+import { NameDetailsCard } from './NameDetailsCard'
+import { QuoteState, estimateExpiry } from './types'
+
+const preferredAssetMap: Record<string, AnyAsset> = {
+  [AssetBTC.symbol]: AssetBTC,
+  [AssetETH.symbol]: AssetETH,
+  [AssetUSDT.symbol]: AssetUSDT
+}
+
+type Props = {
+  walletType: WalletType
+  walletAccount: number
+  walletIndex: number
+  hdMode: HDMode
+  balance: WalletBalance
+  interact$: InteractStateHandler
+  openExplorerTxUrl: OpenExplorerTxUrl
+  getExplorerTxUrl: GetExplorerTxUrl
+  validatePassword$: ValidatePasswordHandler
+  thorchainQuery: ThorchainQuery
+  network: Network
+  fee: FeeRD
+  reloadFeesHandler: FP.Lazy<void>
+  thorchainLastblock: ThorchainLastblockRD
+}
+
+type Tab = 'lookup' | 'owner' | 'register'
+
+export const THORNameForm = ({
+  walletType,
+  walletAccount,
+  walletIndex,
+  hdMode,
+  balance,
+  interact$,
+  openExplorerTxUrl,
+  getExplorerTxUrl,
+  validatePassword$,
+  thorchainQuery,
+  network,
+  fee: feeRD,
+  reloadFeesHandler,
+  thorchainLastblock: thorchainLastblockRd
+}: Props) => {
+  const intl = useIntl()
+  const { asset, walletAddress } = balance
+
+  // Tab state
+  const [activeTab, setActiveTab] = useState<Tab>('lookup')
+
+  // Lookup tab state
+  const [lookupName, setLookupName] = useState('')
+  const [lookupResult, setLookupResult] = useState<O.Option<ThornameDetails>>(O.none)
+  const [isLookingUp, setIsLookingUp] = useState(false)
+
+  // Owner tab state
+  const [ownerAddress, setOwnerAddress] = useState('')
+  const [ownerNames, setOwnerNames] = useState<ThornameDetails[]>([])
+  const [isLookingUpOwner, setIsLookingUpOwner] = useState(false)
+  const [ownerSearchDone, setOwnerSearchDone] = useState(false)
+
+  // Register tab state
+  const [regMode, setRegMode] = useState<'register' | 'update'>('register')
+  const [regName, setRegName] = useState('')
+  const [regChainAddress, setRegChainAddress] = useState(walletAddress)
+  const [regPreferredAsset, setRegPreferredAsset] = useState<string>('')
+  const [regAliasChain, setRegAliasChain] = useState('')
+  const [regAliasAddress, setRegAliasAddress] = useState('')
+  const [regExpiry, setRegExpiry] = useState('1')
+  const [nameAvailable, setNameAvailable] = useState(false)
+  const [isNewRegistration, setIsNewRegistration] = useState(false)
+  const [isOwner, setIsOwner] = useState(false)
+
+  // Quote state (two-phase flow)
+  const [quoteState, setQuoteState] = useState<QuoteState>({ status: 'idle' })
+
+  // Tx state
+  const {
+    state: interactState,
+    reset: resetInteractState,
+    subscribe: subscribeInteractState
+  } = useSubscriptionState<InteractState>(INITIAL_INTERACT_STATE)
+  const isLoading = useMemo(() => RD.isPending(interactState.txRD), [interactState.txRD])
+  const [sendTxStartTime, setSendTxStartTime] = useState(0)
+  const [showConfirmationModal, setShowConfirmationModal] = useState(false)
+  const [showDetails, setShowDetails] = useState(true)
+
+  // Lookup handler
+  const handleLookup = useCallback(async () => {
+    if (!lookupName) return
+    setIsLookingUp(true)
+    try {
+      const details = await thorchainQuery.getThornameDetails(lookupName)
+      if (details) {
+        setLookupResult(O.some(details))
+      }
+    } catch (_error) {
+      setLookupResult(O.none)
+    } finally {
+      setIsLookingUp(false)
+    }
+  }, [lookupName, thorchainQuery])
+
+  // Owner lookup handler
+  const handleOwnerLookup = useCallback(async () => {
+    if (!ownerAddress) return
+    setIsLookingUpOwner(true)
+    setOwnerNames([])
+    setOwnerSearchDone(false)
+    try {
+      const names =
+        await thorchainQuery.thorchainCache.midgardQuery.midgardCache.midgard.getTHORNameReverseLookup(ownerAddress)
+      if (names && names.length > 0) {
+        const details = await Promise.all(names.map((n) => thorchainQuery.getThornameDetails(n)))
+        setOwnerNames(details.filter((d) => d && !d.error?.length))
+      }
+    } catch (_error) {
+      // no names found
+    } finally {
+      setIsLookingUpOwner(false)
+      setOwnerSearchDone(true)
+    }
+  }, [ownerAddress, thorchainQuery])
+
+  // Check name availability (register tab)
+  const handleCheckName = useCallback(async () => {
+    if (!regName) return
+    setQuoteState({ status: 'idle' })
+    setIsLookingUp(true)
+    try {
+      const details = await thorchainQuery.getThornameDetails(regName)
+      if (details) {
+        const available = details.owner === '' || walletAddress === details.owner
+        setNameAvailable(available)
+        setIsNewRegistration(details.name === '')
+        setIsOwner(walletAddress === details.owner)
+        if (available && walletAddress === details.owner) {
+          setRegMode('update')
+        } else {
+          setRegMode('register')
+        }
+      }
+    } catch (_error) {
+      // Name not found = available for registration
+      setNameAvailable(true)
+      setIsNewRegistration(true)
+      setIsOwner(false)
+      setRegMode('register')
+    } finally {
+      setIsLookingUp(false)
+    }
+  }, [regName, thorchainQuery, walletAddress])
+
+  // Get quote (Phase 1)
+  const handleGetQuote = useCallback(async () => {
+    const currentDate = new Date()
+    const chain = isNewRegistration ? THORChain : regAliasChain
+    const chainAddress = isNewRegistration ? regChainAddress : regAliasAddress
+    const yearsToAdd = parseInt(regExpiry || '1')
+    const expiry =
+      yearsToAdd === 1
+        ? undefined
+        : new Date(currentDate.getFullYear() + yearsToAdd, currentDate.getMonth(), currentDate.getDate())
+
+    if (!regName || !chain || !chainAddress) return
+
+    setQuoteState({ status: 'loading' })
+    try {
+      const params: QuoteTHORNameParams = {
+        name: regName,
+        chain,
+        chainAddress,
+        owner: walletAddress,
+        preferredAsset: regPreferredAsset ? (preferredAssetMap[regPreferredAsset] as Asset) : undefined,
+        expiry,
+        isUpdate: isOwner
+      }
+      const quote = await thorchainQuery.estimateThorname(params)
+      if (quote) {
+        setQuoteState({
+          status: 'success',
+          memo: quote.memo,
+          amount: quote.value.baseAmount
+        })
+      } else {
+        setQuoteState({ status: 'error', message: 'No quote returned' })
+      }
+    } catch (error) {
+      setQuoteState({ status: 'error', message: error instanceof Error ? error.message : 'Quote failed' })
+    }
+  }, [
+    regName,
+    regAliasChain,
+    regAliasAddress,
+    regChainAddress,
+    regExpiry,
+    regPreferredAsset,
+    walletAddress,
+    isNewRegistration,
+    isOwner,
+    thorchainQuery
+  ])
+
+  // Submit tx (Phase 2)
+  const submitTx = useCallback(() => {
+    if (quoteState.status !== 'success') return
+    setSendTxStartTime(Date.now())
+    subscribeInteractState(
+      interact$({
+        walletType,
+        walletAccount,
+        walletIndex,
+        hdMode,
+        amount: quoteState.amount,
+        memo: quoteState.memo,
+        asset
+      })
+    )
+  }, [subscribeInteractState, interact$, walletType, walletAccount, walletIndex, hdMode, quoteState, asset])
+
+  const resetForm = useCallback(() => {
+    resetInteractState()
+    setQuoteState({ status: 'idle' })
+    setNameAvailable(false)
+    setIsNewRegistration(false)
+    setIsOwner(false)
+    setRegName('')
+    setRegChainAddress(walletAddress)
+    setRegPreferredAsset('')
+    setRegAliasChain('')
+    setRegAliasAddress('')
+    setRegExpiry('1')
+    setRegMode('register')
+    setOwnerNames([])
+    setOwnerSearchDone(false)
+    setLookupResult(O.none)
+  }, [resetInteractState, walletAddress])
+
+  // Reset when switching tabs
+  useEffect(() => {
+    setQuoteState({ status: 'idle' })
+    setNameAvailable(false)
+  }, [activeTab])
+
+  // Current block for expiry estimation
+  const currentBlock = useMemo(
+    () =>
+      FP.pipe(
+        thorchainLastblockRd,
+        RD.toOption,
+        O.chain((blocks) => O.fromNullable(blocks.find((b) => b.thorchain))),
+        O.map((b) => b.thorchain),
+        O.toUndefined
+      ),
+    [thorchainLastblockRd]
+  )
+
+  // Fee display for quote amount
+  const quoteFees: UIFeesRD = useMemo(() => {
+    if (quoteState.status === 'success') {
+      const fees: UIFees = [{ asset: AssetRuneNative, amount: quoteState.amount }]
+      return RD.success(fees)
+    }
+    return FP.pipe(
+      feeRD,
+      RD.map((fee) => [{ asset: AssetRuneNative, amount: fee }])
+    )
+  }, [quoteState, feeRD])
+
+  // Confirmation modal
+  const renderConfirmationModal = useMemo(() => {
+    const onSuccessHandler = () => {
+      setShowConfirmationModal(false)
+      submitTx()
+    }
+    const onCloseHandler = () => {
+      setShowConfirmationModal(false)
+    }
+
+    if (isKeystoreWallet(walletType)) {
+      return (
+        <WalletPasswordConfirmationModal
+          onSuccess={onSuccessHandler}
+          onClose={onCloseHandler}
+          validatePassword$={validatePassword$}
+        />
+      )
+    }
+    if (isLedgerWallet(walletType)) {
+      return (
+        <LedgerConfirmationModal
+          network={network}
+          onSuccess={onSuccessHandler}
+          onClose={onCloseHandler}
+          visible={showConfirmationModal}
+          chain={THORChain}
+          description2={intl.formatMessage({ id: 'ledger.sign' })}
+          addresses={O.none}
+        />
+      )
+    }
+    return <></>
+  }, [walletType, submitTx, validatePassword$, network, showConfirmationModal, intl])
+
+  // Tx result modal
+  const renderTxModal = useMemo(() => {
+    const { txRD } = interactState
+    if (RD.isInitial(txRD)) return <></>
+
+    const timerValue = FP.pipe(
+      txRD,
+      RD.fold(
+        () => 0,
+        FP.flow(
+          O.map(({ loaded }) => loaded),
+          O.getOrElse(() => 0)
+        ),
+        () => 0,
+        () => 100
+      )
+    )
+    const oTxHash = RD.toOption(txRD)
+    const txRDasBoolean = FP.pipe(
+      txRD,
+      RD.map((txHash) => !!txHash)
+    )
+
+    return (
+      <TxModal
+        title={intl.formatMessage({ id: 'common.tx.sending' })}
+        onClose={resetForm}
+        onFinish={resetForm}
+        startTime={sendTxStartTime}
+        txRD={txRDasBoolean}
+        extraResult={
+          <ViewTxButton
+            txHash={oTxHash}
+            onClick={openExplorerTxUrl}
+            txUrl={FP.pipe(oTxHash, O.chain(getExplorerTxUrl))}
+            network={network}
+          />
+        }
+        timerValue={timerValue}
+        extra={
+          <SendAsset
+            asset={{ asset, amount: quoteState.status === 'success' ? quoteState.amount : ZERO_BASE_AMOUNT }}
+            network={network}
+            description={H.getInteractiveDescription({ state: interactState, intl })}
+          />
+        }
+      />
+    )
+  }, [interactState, intl, resetForm, sendTxStartTime, openExplorerTxUrl, getExplorerTxUrl, asset, quoteState, network])
+
+  return (
+    <div className="w-full sm:max-w-[630px]">
+      {/* Tab navigation */}
+      <div className="mb-4 flex border-b border-gray0 dark:border-gray0d">
+        <button
+          type="button"
+          className={`flex items-center gap-1.5 px-4 pb-2 font-main text-[14px] transition-colors ${
+            activeTab === 'lookup'
+              ? 'border-b-2 border-turquoise text-turquoise'
+              : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
+          }`}
+          onClick={() => setActiveTab('lookup')}>
+          <MagnifyingGlassIcon className="h-4 w-4" />
+          Lookup Name
+        </button>
+        <button
+          type="button"
+          className={`flex items-center gap-1.5 px-4 pb-2 font-main text-[14px] transition-colors ${
+            activeTab === 'owner'
+              ? 'border-b-2 border-turquoise text-turquoise'
+              : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
+          }`}
+          onClick={() => setActiveTab('owner')}>
+          <UserIcon className="h-4 w-4" />
+          Names by Owner
+        </button>
+        <button
+          type="button"
+          className={`flex items-center gap-1.5 px-4 pb-2 font-main text-[14px] transition-colors ${
+            activeTab === 'register'
+              ? 'border-b-2 border-turquoise text-turquoise'
+              : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
+          }`}
+          onClick={() => setActiveTab('register')}>
+          Register / Update
+        </button>
+      </div>
+
+      {/* ═══ LOOKUP TAB ═══ */}
+      {activeTab === 'lookup' && (
+        <>
+          <div className="flex items-center text-[12px]">
+            <Label color="input" size="big" textTransform="uppercase">
+              {intl.formatMessage({ id: 'common.thorname' })}
+            </Label>
+            <InfoIcon
+              className="ml-[3px] h-[15px] w-[15px] text-inherit"
+              tooltip={intl.formatMessage({ id: 'common.thornameRegistrationSpecifics' })}
+              color="primary"
+            />
+          </div>
+          <div className="flex items-start gap-2">
+            <div className="flex-1">
+              <Input
+                value={lookupName}
+                onChange={(e) => setLookupName(e.target.value)}
+                disabled={isLookingUp}
+                size="large"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleLookup()
+                  }
+                }}
+              />
+            </div>
+            <FlatButton
+              className="h-[40px] min-w-[100px]"
+              size="normal"
+              color="primary"
+              disabled={isLookingUp || !lookupName}
+              loading={isLookingUp}
+              onClick={handleLookup}>
+              Lookup
+            </FlatButton>
+          </div>
+
+          {/* Lookup result */}
+          {FP.pipe(
+            lookupResult,
+            O.map((details) => (
+              <div key={details.name} className="mt-4">
+                <NameDetailsCard
+                  name={details.name}
+                  owner={details.owner}
+                  expireBlockHeight={details.expireBlockHeight}
+                  estimatedExpiry={estimateExpiry(currentBlock, details.expireBlockHeight)}
+                  preferredAsset={details.preferredAsset}
+                  aliases={details.aliases}
+                  nameLabel={intl.formatMessage({ id: 'common.thorname' })}
+                />
+              </div>
+            )),
+            O.toNullable
+          )}
+        </>
+      )}
+
+      {/* ═══ OWNER TAB ═══ */}
+      {activeTab === 'owner' && (
+        <>
+          <Label color="input" size="big" textTransform="uppercase">
+            Owner Address
+          </Label>
+          <Input
+            value={ownerAddress}
+            onChange={(e) => setOwnerAddress(e.target.value)}
+            disabled={isLookingUpOwner}
+            size="large"
+            placeholder="thor1... or any chain address"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                handleOwnerLookup()
+              }
+            }}
+          />
+          <FlatButton
+            className="mt-4 w-full"
+            size="large"
+            color="primary"
+            disabled={isLookingUpOwner || !ownerAddress}
+            loading={isLookingUpOwner}
+            onClick={handleOwnerLookup}>
+            <UserIcon className="mr-2 h-5 w-5" />
+            Find Names
+          </FlatButton>
+
+          {ownerSearchDone && !isLookingUpOwner && ownerNames.length === 0 && (
+            <div className="mt-4 text-center text-[14px] text-gray2 dark:text-gray2d">
+              No names found for this address
+            </div>
+          )}
+          {!isLookingUpOwner && ownerNames.length > 0 && (
+            <div className="mt-4 space-y-3">
+              {ownerNames.map((details) => (
+                <NameDetailsCard
+                  key={details.name}
+                  name={details.name}
+                  owner={details.owner}
+                  expireBlockHeight={details.expireBlockHeight}
+                  estimatedExpiry={estimateExpiry(currentBlock, details.expireBlockHeight)}
+                  preferredAsset={details.preferredAsset}
+                  aliases={details.aliases}
+                  nameLabel={intl.formatMessage({ id: 'common.thorname' })}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* ═══ REGISTER / UPDATE TAB ═══ */}
+      {activeTab === 'register' && (
+        <>
+          {/* Name input + check */}
+          <div className="flex items-center text-[12px]">
+            <Label color="input" size="big" textTransform="uppercase">
+              {intl.formatMessage({ id: 'common.thorname' })}
+            </Label>
+            <InfoIcon
+              className="ml-[3px] h-[15px] w-[15px] text-inherit"
+              tooltip={intl.formatMessage({ id: 'common.thornameRegistrationSpecifics' })}
+              color="primary"
+            />
+          </div>
+          <div className="flex items-start gap-2">
+            <div className="flex-1">
+              <Input
+                value={regName}
+                onChange={(e) => {
+                  setRegName(e.target.value)
+                  setNameAvailable(false)
+                  setQuoteState({ status: 'idle' })
+                }}
+                disabled={isLoading || isLookingUp}
+                size="large"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleCheckName()
+                  }
+                }}
+              />
+            </div>
+            <FlatButton
+              className="h-[40px] min-w-[100px]"
+              size="normal"
+              color="primary"
+              disabled={isLoading || isLookingUp || !regName}
+              loading={isLookingUp}
+              onClick={handleCheckName}>
+              {intl.formatMessage({ id: 'deposit.interact.actions.checkThorname' })}
+            </FlatButton>
+          </div>
+
+          {/* Name available — show form */}
+          {nameAvailable && (
+            <div className="mt-4 rounded-lg border border-gray0 p-5 dark:border-gray0d">
+              {isOwner && (
+                <div className="mb-4">
+                  <CheckButton checked={true} clickHandler={() => {}} disabled={isLoading}>
+                    {intl.formatMessage({ id: 'common.isUpdateThorname' })}
+                  </CheckButton>
+                </div>
+              )}
+
+              <div className="space-y-5">
+                {/* Preferred Asset (update mode only) */}
+                {!isNewRegistration && (
+                  <div>
+                    <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
+                      {intl.formatMessage({ id: 'common.preferredAsset' })}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {[
+                        { value: AssetBTC.symbol, label: 'BTC' },
+                        { value: AssetETH.symbol, label: 'ETH' },
+                        { value: AssetUSDT.symbol, label: 'USDT' }
+                      ].map((item) => (
+                        <button
+                          key={item.value}
+                          type="button"
+                          className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
+                            regPreferredAsset === item.value
+                              ? 'border-turquoise bg-turquoise/10 text-turquoise'
+                              : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
+                          }`}
+                          onClick={() => setRegPreferredAsset(item.value)}>
+                          {item.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Alias Chain */}
+                <div>
+                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
+                    {intl.formatMessage({ id: 'common.aliasChain' })}
+                  </div>
+                  {isNewRegistration ? (
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className="rounded-full border border-turquoise bg-turquoise/10 px-4 py-1.5 font-main text-[13px] text-turquoise">
+                        THOR
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex flex-wrap gap-2">
+                      {[
+                        { value: AssetAVAX.chain, label: 'AVAX' },
+                        { value: AssetBTC.chain, label: 'BTC' },
+                        { value: AssetETH.chain, label: 'ETH' },
+                        { value: AssetDOGE.chain, label: 'DOGE' }
+                      ].map((item) => (
+                        <button
+                          key={item.value}
+                          type="button"
+                          className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
+                            regAliasChain === item.value
+                              ? 'border-turquoise bg-turquoise/10 text-turquoise'
+                              : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
+                          }`}
+                          onClick={() => setRegAliasChain(item.value)}>
+                          {item.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Alias Address */}
+                <div>
+                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
+                    {intl.formatMessage({ id: 'common.aliasAddress' })}
+                  </div>
+                  {isNewRegistration ? (
+                    <Input
+                      value={regChainAddress}
+                      onChange={(e) => setRegChainAddress(e.target.value)}
+                      disabled={isLoading}
+                      size="large"
+                    />
+                  ) : (
+                    <Input
+                      value={regAliasAddress}
+                      onChange={(e) => setRegAliasAddress(e.target.value)}
+                      disabled={isLoading}
+                      size="large"
+                    />
+                  )}
+                </div>
+
+                {/* Expiry */}
+                <div>
+                  <div className="font-mainSemiBold mb-2 text-[12px] text-gray2 uppercase dark:text-gray2d">
+                    {intl.formatMessage({ id: 'common.expiry' })}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {[
+                      { value: '1', label: '1 year' },
+                      { value: '2', label: '2 years' },
+                      { value: '3', label: '3 years' },
+                      { value: '5', label: '5 years' }
+                    ].map((item) => (
+                      <button
+                        key={item.value}
+                        type="button"
+                        className={`rounded-full border px-4 py-1.5 font-main text-[13px] transition-colors ${
+                          regExpiry === item.value
+                            ? 'border-turquoise bg-turquoise/10 text-turquoise'
+                            : 'border-gray0 text-gray2 hover:border-gray2 dark:border-gray0d dark:text-gray2d dark:hover:border-gray2d'
+                        }`}
+                        onClick={() => setRegExpiry(item.value)}>
+                        {item.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Get Quote button */}
+                <FlatButton
+                  className="mt-2 w-full"
+                  size="large"
+                  color="primary"
+                  disabled={
+                    isLoading ||
+                    quoteState.status === 'loading' ||
+                    (!isNewRegistration && (!regAliasChain || !regAliasAddress)) ||
+                    (isNewRegistration && !regChainAddress)
+                  }
+                  loading={quoteState.status === 'loading'}
+                  onClick={handleGetQuote}>
+                  {intl.formatMessage({ id: 'deposit.interact.actions.getQuote' })}
+                </FlatButton>
+              </div>
+
+              {/* Quote error */}
+              {quoteState.status === 'error' && (
+                <div className="mt-4 rounded-lg border border-error0 bg-error0/10 p-3 dark:border-error0d dark:bg-error0d/10">
+                  <div className="text-[13px] text-error0 dark:text-error0d">{quoteState.message}</div>
+                </div>
+              )}
+
+              {/* Quote result */}
+              {quoteState.status === 'success' && (
+                <div className="mt-4 rounded-lg border border-turquoise/30 bg-turquoise/5 p-4">
+                  <div className="flex gap-6">
+                    <div className="flex-1">
+                      <div className="text-[11px] text-gray2 dark:text-gray2d">
+                        {intl.formatMessage({ id: 'common.amount' })}
+                      </div>
+                      <div className="font-mainSemiBold text-[14px] text-text0 dark:text-text0d">
+                        {formatAssetAmountCurrency({
+                          amount: baseToAsset(quoteState.amount),
+                          asset: AssetRuneNative,
+                          trimZeros: true
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mt-2">
+                    <div className="text-[11px] text-gray2 dark:text-gray2d">
+                      {intl.formatMessage({ id: 'common.memo' })}
+                    </div>
+                    <div className="font-mono text-[11px] break-all text-text0 dark:text-text0d">
+                      <Tooltip title={quoteState.memo}>{quoteState.memo}</Tooltip>
+                    </div>
+                  </div>
+
+                  {/* Execute button (Phase 2) */}
+                  <FlatButton
+                    className="mt-4 w-full"
+                    size="large"
+                    loading={isLoading}
+                    disabled={isLoading}
+                    onClick={() => setShowConfirmationModal(true)}>
+                    {isOwner
+                      ? intl.formatMessage({ id: 'common.isUpdateThorname' })
+                      : intl.formatMessage({ id: 'deposit.interact.actions.buyThorname' })}
+                  </FlatButton>
+                </div>
+              )}
+
+              {/* Fees */}
+              <Fees className="mt-4" fees={quoteFees} reloadFees={reloadFeesHandler} disabled={isLoading} />
+            </div>
+          )}
+
+          {/* Name not available */}
+          {!nameAvailable && regName && !isLookingUp && quoteState.status === 'idle' && regName.length > 0 && <></>}
+        </>
+      )}
+
+      {/* Details section — only render when there's a quote */}
+      {quoteState.status === 'success' && (
+        <div className="pt-10px font-main text-[14px] text-gray2 dark:text-gray2d">
+          <div className="my-20px w-full font-main text-[12px] uppercase dark:border-gray1d">
+            <BaseButton
+              className="group font-mainSemiBold flex w-full !justify-between !p-0 text-[16px] text-text2 hover:text-turquoise dark:text-text2d dark:hover:text-turquoise"
+              onClick={() => setShowDetails((current) => !current)}>
+              {intl.formatMessage({ id: 'common.details' })}
+              {showDetails ? (
+                <MagnifyingGlassMinusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
+              ) : (
+                <MagnifyingGlassPlusIcon className="ease h-[20px] w-[20px] text-inherit group-hover:scale-125" />
+              )}
+            </BaseButton>
+            {showDetails && (
+              <>
+                <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
+                  {intl.formatMessage({ id: 'common.amount' })}
+                  <div className="truncate pl-10px font-main text-[12px]">
+                    {formatAssetAmountCurrency({
+                      amount: baseToAsset(quoteState.amount),
+                      asset: AssetRuneNative,
+                      trimZeros: true
+                    })}
+                  </div>
+                </div>
+                <div className="font-mainBold ml-[-2px] flex w-full justify-between pt-10px text-[14px]">
+                  {intl.formatMessage({ id: 'common.memo' })}
+                  <div className="overflow pl-10px font-main text-[12px] break-normal">
+                    <Tooltip title={quoteState.memo}>{quoteState.memo}</Tooltip>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {showConfirmationModal && renderConfirmationModal}
+      {renderTxModal}
+    </div>
+  )
+}

--- a/src/renderer/components/wallet/txs/interact/thorname/THORNameForm.tsx
+++ b/src/renderer/components/wallet/txs/interact/thorname/THORNameForm.tsx
@@ -10,7 +10,7 @@ import {
 import { Network } from '@xchainjs/xchain-client'
 import { THORChain } from '@xchainjs/xchain-thorchain'
 import { QuoteTHORNameParams, ThorchainQuery, ThornameDetails } from '@xchainjs/xchain-thorchain-query'
-import { AnyAsset, Asset, BaseAmount, baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
+import { AnyAsset, Asset, baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
 import { function as FP, option as O } from 'fp-ts'
 import { useIntl } from 'react-intl'
 
@@ -97,7 +97,6 @@ export const THORNameForm = ({
   const [ownerSearchDone, setOwnerSearchDone] = useState(false)
 
   // Register tab state
-  const [regMode, setRegMode] = useState<'register' | 'update'>('register')
   const [regName, setRegName] = useState('')
   const [regChainAddress, setRegChainAddress] = useState(walletAddress)
   const [regPreferredAsset, setRegPreferredAsset] = useState<string>('')
@@ -171,18 +170,13 @@ export const THORNameForm = ({
         setNameAvailable(available)
         setIsNewRegistration(details.name === '')
         setIsOwner(walletAddress === details.owner)
-        if (available && walletAddress === details.owner) {
-          setRegMode('update')
-        } else {
-          setRegMode('register')
-        }
+        // isOwner and isNewRegistration drive the UI mode
       }
     } catch (_error) {
       // Name not found = available for registration
       setNameAvailable(true)
       setIsNewRegistration(true)
       setIsOwner(false)
-      setRegMode('register')
     } finally {
       setIsLookingUp(false)
     }
@@ -267,7 +261,6 @@ export const THORNameForm = ({
     setRegAliasChain('')
     setRegAliasAddress('')
     setRegExpiry('1')
-    setRegMode('register')
     setOwnerNames([])
     setOwnerSearchDone(false)
     setLookupResult(O.none)
@@ -402,7 +395,7 @@ export const THORNameForm = ({
           }`}
           onClick={() => setActiveTab('lookup')}>
           <MagnifyingGlassIcon className="h-4 w-4" />
-          Lookup Name
+          {intl.formatMessage({ id: 'common.lookupName' })}
         </button>
         <button
           type="button"
@@ -413,7 +406,7 @@ export const THORNameForm = ({
           }`}
           onClick={() => setActiveTab('owner')}>
           <UserIcon className="h-4 w-4" />
-          Names by Owner
+          {intl.formatMessage({ id: 'common.namesByOwner' })}
         </button>
         <button
           type="button"
@@ -423,7 +416,7 @@ export const THORNameForm = ({
               : 'text-gray2 hover:text-text0 dark:text-gray2d dark:hover:text-text0d'
           }`}
           onClick={() => setActiveTab('register')}>
-          Register / Update
+          {intl.formatMessage({ id: 'common.registerUpdate' })}
         </button>
       </div>
 
@@ -462,7 +455,7 @@ export const THORNameForm = ({
               disabled={isLookingUp || !lookupName}
               loading={isLookingUp}
               onClick={handleLookup}>
-              Lookup
+              {intl.formatMessage({ id: 'common.lookup' })}
             </FlatButton>
           </div>
 
@@ -491,14 +484,14 @@ export const THORNameForm = ({
       {activeTab === 'owner' && (
         <>
           <Label color="input" size="big" textTransform="uppercase">
-            Owner Address
+            {intl.formatMessage({ id: 'common.ownerAddress' })}
           </Label>
           <Input
             value={ownerAddress}
             onChange={(e) => setOwnerAddress(e.target.value)}
             disabled={isLookingUpOwner}
             size="large"
-            placeholder="thor1... or any chain address"
+            placeholder={intl.formatMessage({ id: 'common.ownerAddress.placeholder' })}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault()
@@ -514,12 +507,12 @@ export const THORNameForm = ({
             loading={isLookingUpOwner}
             onClick={handleOwnerLookup}>
             <UserIcon className="mr-2 h-5 w-5" />
-            Find Names
+            {intl.formatMessage({ id: 'common.findNames' })}
           </FlatButton>
 
           {ownerSearchDone && !isLookingUpOwner && ownerNames.length === 0 && (
             <div className="mt-4 text-center text-[14px] text-gray2 dark:text-gray2d">
-              No names found for this address
+              {intl.formatMessage({ id: 'common.noNamesFound' })}
             </div>
           )}
           {!isLookingUpOwner && ownerNames.length > 0 && (

--- a/src/renderer/components/wallet/txs/interact/thorname/types.ts
+++ b/src/renderer/components/wallet/txs/interact/thorname/types.ts
@@ -1,0 +1,33 @@
+import { BaseAmount } from '@xchainjs/xchain-util'
+
+export type QuoteState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'success'; memo: string; amount: BaseAmount }
+
+export type NameDetails = {
+  name: string
+  owner: string
+  expireBlockHeight: number
+  preferredAsset?: string
+  aliases: { chain: string; address: string }[]
+}
+
+export type EstimatedExpiry = {
+  date: Date
+  daysLeft: number
+}
+
+export const estimateExpiry = (
+  currentBlock: number | undefined,
+  expireBlockHeight: number | undefined
+): EstimatedExpiry | undefined => {
+  if (!currentBlock || !expireBlockHeight) return undefined
+  const blocksLeft = expireBlockHeight - currentBlock
+  if (blocksLeft <= 0) return undefined
+  const secondsLeft = blocksLeft * 6
+  const daysLeft = Math.round(secondsLeft / 86400)
+  const date = new Date(Date.now() + secondsLeft * 1000)
+  return { date, daysLeft }
+}

--- a/src/renderer/i18n/de/common.ts
+++ b/src/renderer/i18n/de/common.ts
@@ -225,7 +225,18 @@ const common: CommonMessages = {
   'common.importTokens': 'Token importieren',
   'common.searchToken': 'Token suchen',
   'common.warning.token.import':
-    'Jeder kann Token erstellen, einschließlich gefälschter Versionen bestehender Token. Bitte seien Sie vorsichtig bei Betrügereien und Sicherheitsrisiken.'
+    'Jeder kann Token erstellen, einschließlich gefälschter Versionen bestehender Token. Bitte seien Sie vorsichtig bei Betrügereien und Sicherheitsrisiken.',
+  'common.lookupName': 'Name suchen',
+  'common.namesByOwner': 'Namen nach Besitzer',
+  'common.registerUpdate': 'Registrieren / Aktualisieren',
+  'common.ownerAddress': 'Besitzeradresse',
+  'common.ownerAddress.placeholder': 'thor1... oder eine beliebige Kettenadresse',
+  'common.noNamesFound': 'Keine Namen für diese Adresse gefunden',
+  'common.lookup': 'Suchen',
+  'common.findNames': 'Namen finden',
+  'common.chainAliases': 'Ketten-Aliase ({count})',
+  'common.daysApprox': '(~{days} Tage)',
+  'common.block': 'Block {block}'
 }
 
 export default common

--- a/src/renderer/i18n/de/deposit.ts
+++ b/src/renderer/i18n/de/deposit.ts
@@ -14,6 +14,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'MAYAName kaufen',
   'deposit.interact.actions.checkThorname': 'Verfügbarkeit prüfen',
   'deposit.interact.actions.addBondProvider': 'Bond Provider hinzufügen',
+  'deposit.interact.actions.getQuote': 'Get Quote',
   'deposit.share.title': 'Dein Poolanteil',
   'deposit.share.units': 'Liquiditäts-Einheiten',
   'deposit.share.poolshare': 'Poolanteil',

--- a/src/renderer/i18n/de/deposit.ts
+++ b/src/renderer/i18n/de/deposit.ts
@@ -14,7 +14,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'MAYAName kaufen',
   'deposit.interact.actions.checkThorname': 'Verfügbarkeit prüfen',
   'deposit.interact.actions.addBondProvider': 'Bond Provider hinzufügen',
-  'deposit.interact.actions.getQuote': 'Get Quote',
+  'deposit.interact.actions.getQuote': 'Angebot erhalten',
   'deposit.share.title': 'Dein Poolanteil',
   'deposit.share.units': 'Liquiditäts-Einheiten',
   'deposit.share.poolshare': 'Poolanteil',

--- a/src/renderer/i18n/en/common.ts
+++ b/src/renderer/i18n/en/common.ts
@@ -224,7 +224,18 @@ const common: CommonMessages = {
   'common.importTokens': 'Import Tokens',
   'common.searchToken': 'Search token',
   'common.warning.token.import':
-    'Anyone can create tokens, including fake versions of existing ones. Please be cautious of scams and security risks.'
+    'Anyone can create tokens, including fake versions of existing ones. Please be cautious of scams and security risks.',
+  'common.lookupName': 'Lookup Name',
+  'common.namesByOwner': 'Names by Owner',
+  'common.registerUpdate': 'Register / Update',
+  'common.ownerAddress': 'Owner Address',
+  'common.ownerAddress.placeholder': 'thor1... or any chain address',
+  'common.noNamesFound': 'No names found for this address',
+  'common.lookup': 'Lookup',
+  'common.findNames': 'Find Names',
+  'common.chainAliases': 'Chain Aliases ({count})',
+  'common.daysApprox': '(~{days} days)',
+  'common.block': 'Block {block}'
 }
 
 export default common

--- a/src/renderer/i18n/en/deposit.ts
+++ b/src/renderer/i18n/en/deposit.ts
@@ -14,6 +14,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'Buy MAYAName',
   'deposit.interact.actions.checkThorname': 'Check Availability',
   'deposit.interact.actions.addBondProvider': 'Add Bond Provider',
+  'deposit.interact.actions.getQuote': 'Get Quote',
   'deposit.share.title': 'Your pool share',
   'deposit.share.units': 'Liquidity units',
   'deposit.share.total': 'Total value',

--- a/src/renderer/i18n/es/common.ts
+++ b/src/renderer/i18n/es/common.ts
@@ -225,7 +225,18 @@ const common: CommonMessages = {
   'common.importTokens': 'Importar tokens',
   'common.searchToken': 'Buscar token',
   'common.warning.token.import':
-    'Cualquiera puede crear tokens, incluidas versiones falsas de los existentes. Por favor, tenga cuidado con las estafas y los riesgos de seguridad.'
+    'Cualquiera puede crear tokens, incluidas versiones falsas de los existentes. Por favor, tenga cuidado con las estafas y los riesgos de seguridad.',
+  'common.lookupName': 'Buscar nombre',
+  'common.namesByOwner': 'Nombres por propietario',
+  'common.registerUpdate': 'Registrar / Actualizar',
+  'common.ownerAddress': 'Dirección del propietario',
+  'common.ownerAddress.placeholder': 'thor1... o cualquier dirección de cadena',
+  'common.noNamesFound': 'No se encontraron nombres para esta dirección',
+  'common.lookup': 'Buscar',
+  'common.findNames': 'Buscar nombres',
+  'common.chainAliases': 'Alias de cadena ({count})',
+  'common.daysApprox': '(~{days} días)',
+  'common.block': 'Bloque {block}'
 }
 
 export default common

--- a/src/renderer/i18n/es/deposit.ts
+++ b/src/renderer/i18n/es/deposit.ts
@@ -14,6 +14,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'Comprar MAYANombre',
   'deposit.interact.actions.checkThorname': 'Comprobar disponibilidad',
   'deposit.interact.actions.addBondProvider': 'Añadir proveedor de bonos',
+  'deposit.interact.actions.getQuote': 'Get Quote',
   'deposit.share.title': 'Su participación en el fondo común',
   'deposit.share.units': 'Unidades de liquidez',
   'deposit.share.total': 'Valor total',

--- a/src/renderer/i18n/es/deposit.ts
+++ b/src/renderer/i18n/es/deposit.ts
@@ -14,7 +14,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'Comprar MAYANombre',
   'deposit.interact.actions.checkThorname': 'Comprobar disponibilidad',
   'deposit.interact.actions.addBondProvider': 'Añadir proveedor de bonos',
-  'deposit.interact.actions.getQuote': 'Get Quote',
+  'deposit.interact.actions.getQuote': 'Obtener cotización',
   'deposit.share.title': 'Su participación en el fondo común',
   'deposit.share.units': 'Unidades de liquidez',
   'deposit.share.total': 'Valor total',

--- a/src/renderer/i18n/fr/common.ts
+++ b/src/renderer/i18n/fr/common.ts
@@ -222,7 +222,18 @@ const common: CommonMessages = {
   'common.importTokens': 'Importer des tokens',
   'common.searchToken': 'Rechercher un token',
   'common.warning.token.import':
-    "N'importe qui peut créer des tokens, y compris de fausses versions de tokens existants. Veuillez faire attention aux arnaques et aux risques de sécurité."
+    "N'importe qui peut créer des tokens, y compris de fausses versions de tokens existants. Veuillez faire attention aux arnaques et aux risques de sécurité.",
+  'common.lookupName': 'Rechercher un nom',
+  'common.namesByOwner': 'Noms par propriétaire',
+  'common.registerUpdate': 'Enregistrer / Mettre à jour',
+  'common.ownerAddress': 'Adresse du propriétaire',
+  'common.ownerAddress.placeholder': 'thor1... ou toute adresse de chaîne',
+  'common.noNamesFound': 'Aucun nom trouvé pour cette adresse',
+  'common.lookup': 'Rechercher',
+  'common.findNames': 'Trouver des noms',
+  'common.chainAliases': 'Alias de chaîne ({count})',
+  'common.daysApprox': '(~{days} jours)',
+  'common.block': 'Bloc {block}'
 }
 
 export default common

--- a/src/renderer/i18n/fr/deposit.ts
+++ b/src/renderer/i18n/fr/deposit.ts
@@ -14,7 +14,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'Acheter MAYAName',
   'deposit.interact.actions.checkThorname': 'Vérifier la disponibilité',
   'deposit.interact.actions.addBondProvider': 'Ajouter un fournisseur de caution',
-  'deposit.interact.actions.getQuote': 'Get Quote',
+  'deposit.interact.actions.getQuote': 'Obtenir un devis',
   'deposit.share.title': 'Votre part dans la pool',
   'deposit.share.units': 'Unités de liquidité',
   'deposit.share.total': 'Valeur totale',

--- a/src/renderer/i18n/fr/deposit.ts
+++ b/src/renderer/i18n/fr/deposit.ts
@@ -14,6 +14,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'Acheter MAYAName',
   'deposit.interact.actions.checkThorname': 'Vérifier la disponibilité',
   'deposit.interact.actions.addBondProvider': 'Ajouter un fournisseur de caution',
+  'deposit.interact.actions.getQuote': 'Get Quote',
   'deposit.share.title': 'Votre part dans la pool',
   'deposit.share.units': 'Unités de liquidité',
   'deposit.share.total': 'Valeur totale',

--- a/src/renderer/i18n/hi/common.ts
+++ b/src/renderer/i18n/hi/common.ts
@@ -223,6 +223,17 @@ const common: CommonMessages = {
   'common.importTokens': 'टोकन आयात करें',
   'common.searchToken': 'टोकन खोजें',
   'common.warning.token.import':
-    'कोई भी टोकन बना सकता है, जिसमें मौजूदा टोकन के नकली संस्करण शामिल हैं। कृपया घोटालों और सुरक्षा जोखिमों से सावधान रहें।'
+    'कोई भी टोकन बना सकता है, जिसमें मौजूदा टोकन के नकली संस्करण शामिल हैं। कृपया घोटालों और सुरक्षा जोखिमों से सावधान रहें।',
+  'common.lookupName': 'नाम खोजें',
+  'common.namesByOwner': 'स्वामी द्वारा नाम',
+  'common.registerUpdate': 'पंजीकरण / अपडेट',
+  'common.ownerAddress': 'स्वामी का पता',
+  'common.ownerAddress.placeholder': 'thor1... या कोई भी चेन पता',
+  'common.noNamesFound': 'इस पते के लिए कोई नाम नहीं मिला',
+  'common.lookup': 'खोजें',
+  'common.findNames': 'नाम खोजें',
+  'common.chainAliases': 'चेन उपनाम ({count})',
+  'common.daysApprox': '(~{days} दिन)',
+  'common.block': 'ब्लॉक {block}'
 }
 export default common

--- a/src/renderer/i18n/hi/deposit.ts
+++ b/src/renderer/i18n/hi/deposit.ts
@@ -11,6 +11,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'MAYAName खरीदें',
   'deposit.interact.actions.checkThorname': 'उपलब्धता जांचें',
   'deposit.interact.actions.addBondProvider': 'बांड प्रदाता जोड़ें',
+  'deposit.interact.actions.getQuote': 'Get Quote',
   'deposit.interact.title': 'जमा',
   'deposit.interact.subtitle': '{chain}Chain के साथ इंटरैक्ट करें',
   'deposit.interact.label.bondprovider': 'बांड प्रदाता (वैकल्पिक)',

--- a/src/renderer/i18n/hi/deposit.ts
+++ b/src/renderer/i18n/hi/deposit.ts
@@ -11,7 +11,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'MAYAName खरीदें',
   'deposit.interact.actions.checkThorname': 'उपलब्धता जांचें',
   'deposit.interact.actions.addBondProvider': 'बांड प्रदाता जोड़ें',
-  'deposit.interact.actions.getQuote': 'Get Quote',
+  'deposit.interact.actions.getQuote': 'कोटेशन प्राप्त करें',
   'deposit.interact.title': 'जमा',
   'deposit.interact.subtitle': '{chain}Chain के साथ इंटरैक्ट करें',
   'deposit.interact.label.bondprovider': 'बांड प्रदाता (वैकल्पिक)',

--- a/src/renderer/i18n/ko/common.ts
+++ b/src/renderer/i18n/ko/common.ts
@@ -223,7 +223,18 @@ const common: CommonMessages = {
   'common.importTokens': '토큰 가져오기',
   'common.searchToken': '토큰 검색',
   'common.warning.token.import':
-    '누구나 토큰을 생성할 수 있으며, 기존 토큰의 가짜 버전도 포함됩니다. 사기 및 보안 위험에 주의하시기 바랍니다.'
+    '누구나 토큰을 생성할 수 있으며, 기존 토큰의 가짜 버전도 포함됩니다. 사기 및 보안 위험에 주의하시기 바랍니다.',
+  'common.lookupName': '이름 조회',
+  'common.namesByOwner': '소유자별 이름',
+  'common.registerUpdate': '등록 / 업데이트',
+  'common.ownerAddress': '소유자 주소',
+  'common.ownerAddress.placeholder': 'thor1... 또는 체인 주소',
+  'common.noNamesFound': '이 주소에 대한 이름을 찾을 수 없습니다',
+  'common.lookup': '조회',
+  'common.findNames': '이름 찾기',
+  'common.chainAliases': '체인 별칭 ({count})',
+  'common.daysApprox': '(~{days}일)',
+  'common.block': '블록 {block}'
 }
 
 export default common

--- a/src/renderer/i18n/ko/deposit.ts
+++ b/src/renderer/i18n/ko/deposit.ts
@@ -14,7 +14,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'MAYAName 구매',
   'deposit.interact.actions.checkThorname': '사용 가능 여부 확인',
   'deposit.interact.actions.addBondProvider': '채권 제공자 추가',
-  'deposit.interact.actions.getQuote': 'Get Quote',
+  'deposit.interact.actions.getQuote': '견적 받기',
   'deposit.share.title': '당신의 풀 지분',
   'deposit.share.units': '유동성 단위',
   'deposit.share.total': '총 가치',

--- a/src/renderer/i18n/ko/deposit.ts
+++ b/src/renderer/i18n/ko/deposit.ts
@@ -14,6 +14,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'MAYAName 구매',
   'deposit.interact.actions.checkThorname': '사용 가능 여부 확인',
   'deposit.interact.actions.addBondProvider': '채권 제공자 추가',
+  'deposit.interact.actions.getQuote': 'Get Quote',
   'deposit.share.title': '당신의 풀 지분',
   'deposit.share.units': '유동성 단위',
   'deposit.share.total': '총 가치',

--- a/src/renderer/i18n/ru/common.ts
+++ b/src/renderer/i18n/ru/common.ts
@@ -224,7 +224,18 @@ const common: CommonMessages = {
   'common.importTokens': 'Импортировать токены',
   'common.searchToken': 'Поиск токена',
   'common.warning.token.import':
-    'Любой может создавать токены, включая поддельные версии существующих. Пожалуйста, будьте осторожны с мошенничеством и рисками безопасности.'
+    'Любой может создавать токены, включая поддельные версии существующих. Пожалуйста, будьте осторожны с мошенничеством и рисками безопасности.',
+  'common.lookupName': 'Поиск имени',
+  'common.namesByOwner': 'Имена по владельцу',
+  'common.registerUpdate': 'Регистрация / Обновление',
+  'common.ownerAddress': 'Адрес владельца',
+  'common.ownerAddress.placeholder': 'thor1... или любой адрес цепочки',
+  'common.noNamesFound': 'Имена для этого адреса не найдены',
+  'common.lookup': 'Поиск',
+  'common.findNames': 'Найти имена',
+  'common.chainAliases': 'Псевдонимы цепочек ({count})',
+  'common.daysApprox': '(~{days} дней)',
+  'common.block': 'Блок {block}'
 }
 
 export default common

--- a/src/renderer/i18n/ru/deposit.ts
+++ b/src/renderer/i18n/ru/deposit.ts
@@ -11,6 +11,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'Купить MAYAName',
   'deposit.interact.actions.checkThorname': 'Проверить доступность',
   'deposit.interact.actions.addBondProvider': 'Добавить поставщика обеспечения',
+  'deposit.interact.actions.getQuote': 'Get Quote',
   'deposit.interact.title': 'Вклад',
   'deposit.interact.subtitle': 'Взаимодействие с {chain}Chain',
   'deposit.interact.label.bondprovider': 'Поставщик бондов (опционально)',

--- a/src/renderer/i18n/ru/deposit.ts
+++ b/src/renderer/i18n/ru/deposit.ts
@@ -11,7 +11,7 @@ const deposit: DepositMessages = {
   'deposit.interact.actions.buyMayaname': 'Купить MAYAName',
   'deposit.interact.actions.checkThorname': 'Проверить доступность',
   'deposit.interact.actions.addBondProvider': 'Добавить поставщика обеспечения',
-  'deposit.interact.actions.getQuote': 'Get Quote',
+  'deposit.interact.actions.getQuote': 'Получить котировку',
   'deposit.interact.title': 'Вклад',
   'deposit.interact.subtitle': 'Взаимодействие с {chain}Chain',
   'deposit.interact.label.bondprovider': 'Поставщик бондов (опционально)',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -222,6 +222,17 @@ export type CommonMessageKey =
   | 'common.searchToken'
   | 'common.warning.token.import'
   | 'common.noData'
+  | 'common.lookupName'
+  | 'common.namesByOwner'
+  | 'common.registerUpdate'
+  | 'common.ownerAddress'
+  | 'common.ownerAddress.placeholder'
+  | 'common.noNamesFound'
+  | 'common.lookup'
+  | 'common.findNames'
+  | 'common.chainAliases'
+  | 'common.daysApprox'
+  | 'common.block'
 
 export type CommonMessages = {
   [key in CommonMessageKey]: string

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -633,6 +633,7 @@ type DepositMessageKey =
   | 'deposit.interact.actions.buyThorname'
   | 'deposit.interact.actions.buyMayaname'
   | 'deposit.interact.actions.checkThorname'
+  | 'deposit.interact.actions.getQuote'
   | 'deposit.share.title'
   | 'deposit.share.units'
   | 'deposit.share.poolshare'


### PR DESCRIPTION
Extract THORName registration/update from InteractFormThor (1900→1200 lines) and MAYAName from InteractFormMaya (2000→1380 lines) into dedicated components:
- THORNameForm.tsx — 3-tab UI (Lookup, Names by Owner, Register/Update)
- MAYANameForm.tsx — same pattern for MAYAChain
- NameDetailsCard.tsx — shared card for displaying name details
- types.ts — QuoteState union type, estimateExpiry helper

Fixes: regMode never resetting to 'register', duplicate DETAILS section, details showing when empty. Adds new i18n key for quote action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated MAYAName and THORName interfaces with three-tab UI: Lookup, Owner, Register/Update
  * Quote retrieval to estimate transaction cost and memo before submitting
  * Alias chain selection and expiry management in name registration flows
  * Name details display for inspected records

* **Localization**
  * Added translations for quote action and new UI labels across supported languages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->