### PR TITLE
feat: add coin control for UTXO chains

### DIFF
--- a/src/renderer/components/wallet/txs/send/SendForm.tsx
+++ b/src/renderer/components/wallet/txs/send/SendForm.tsx
@@ -63,6 +63,12 @@ import {
 import { TxParams } from '../../../../services/evm/types'
 import { PoolDetails as PoolDetailsMaya } from '../../../../services/midgard/mayaMidgard/types'
 import { PoolAddress, PoolDetails } from '../../../../services/midgard/midgardTypes'
+import type { CoinControlState } from '../../../../services/utxo/coinControl.types'
+import {
+  CoinControlStrategy,
+  INITIAL_COIN_CONTROL_STATE,
+  strategyToPreferences
+} from '../../../../services/utxo/coinControl.types'
 import { FeesWithRatesRD } from '../../../../services/utxo/types'
 import { SelectedWalletAsset, ValidatePasswordHandler, WalletBalance } from '../../../../services/wallet/types'
 import { LedgerConfirmationModal, WalletPasswordConfirmationModal } from '../../../modal/confirmation'
@@ -78,6 +84,7 @@ import { Slider } from '../../../uielements/slider'
 import { AccountSelector } from '../../account'
 import { matchedWalletType, renderedWalletType } from '../TxForm.helpers'
 import { validateTxAmountInput } from '../TxForm.util'
+import { CoinControlPanel } from './coinControl'
 import { DEFAULT_FEE_OPTION } from './Send.const'
 import * as Shared from './Send.shared'
 
@@ -198,6 +205,7 @@ export const SendForm = (props: Props): JSX.Element => {
   const [destinationTagRequired, setDestinationTagRequired] = useState<boolean>(false)
   const [isRouterAddress, setIsRouterAddress] = useState<boolean>(false)
   const [isSendMax, setIsSendMax] = useState<boolean>(false)
+  const [coinControlState, setCoinControlState] = useState<CoinControlState>(INITIAL_COIN_CONTROL_STATE)
 
   const [assetFee, setAssetFee] = useState<CryptoAmount>(new CryptoAmount(baseAmount(0), asset))
   const [feePriceValue, setFeePriceValue] = useState<CryptoAmount>(new CryptoAmount(baseAmount(0), asset))
@@ -296,6 +304,37 @@ export const SendForm = (props: Props): JSX.Element => {
       )
     }
   }, [isEVMChain, isUTXOChain, oFees, oFeesWithRates, selectedFeeOption, selectedFeeOptionKey, asset, effectiveChain])
+
+  // When manual UTXOs are selected, auto-fill the amount (total selected minus fee).
+  // When leaving manual mode, clear the stale isSendMax flag.
+  useEffect(() => {
+    const isManualWithSelection =
+      isUTXOChain &&
+      coinControlState.isEnabled &&
+      coinControlState.strategy === CoinControlStrategy.MANUAL &&
+      coinControlState.selectedUtxos.length > 0
+
+    if (!isManualWithSelection) {
+      // Reset isSendMax when coin control is not in manual-with-selection mode
+      // to prevent stale max-send behavior on subsequent submits
+      if (isUTXOChain && isSendMax) {
+        setIsSendMax(false)
+      }
+      return
+    }
+
+    const totalSats = coinControlState.selectedUtxos.reduce((sum, u) => sum + u.value, 0)
+    const feeAmount = FP.pipe(
+      selectedFee,
+      O.getOrElse(() => ZERO_BASE_AMOUNT)
+    )
+    const netSats = totalSats - feeAmount.amount().toNumber()
+    const netAmount = baseAmount(Math.max(netSats, 0), balance.amount.decimal)
+
+    setAmountToSend(netAmount)
+    setValue('amount', baseToAsset(netAmount).amount())
+    setIsSendMax(true)
+  }, [coinControlState, isUTXOChain, selectedFee, balance.amount.decimal, setValue, isSendMax])
 
   const oAssetAmount: O.Option<BaseAmount> = useMemo(() => {
     if (isEVMChain) {
@@ -1021,6 +1060,17 @@ export const SendForm = (props: Props): JSX.Element => {
       ? O.getOrElse(() => '')(recipientAddress as O.Option<Address>)
       : (recipientAddress as Address)
 
+    // Build coin control params for UTXO chains
+    const ccSelectedUtxos =
+      isUTXOChain &&
+      coinControlState.isEnabled &&
+      coinControlState.strategy === CoinControlStrategy.MANUAL &&
+      coinControlState.selectedUtxos.length > 0
+        ? coinControlState.selectedUtxos
+        : undefined
+    const ccPreferences =
+      isUTXOChain && coinControlState.isEnabled ? strategyToPreferences(coinControlState.strategy) : undefined
+
     subscribeSendTxState(
       transfer$({
         walletType,
@@ -1034,7 +1084,9 @@ export const SendForm = (props: Props): JSX.Element => {
         feeOption: isEVMChain ? selectedFeeOption : selectedFeeOptionKey,
         memo: currentMemo,
         destinationTag: watch('destinationTag'),
-        sendMax: isUTXOChain ? isSendMax : undefined
+        sendMax: isUTXOChain ? isSendMax : undefined,
+        selectedUtxos: ccSelectedUtxos,
+        utxoSelectionPreferences: ccPreferences
       })
     )
   }, [
@@ -1054,7 +1106,8 @@ export const SendForm = (props: Props): JSX.Element => {
     selectedFeeOption,
     selectedFeeOptionKey,
     currentMemo,
-    watch
+    watch,
+    coinControlState
   ])
 
   // Confirmation modal
@@ -1441,6 +1494,28 @@ export const SendForm = (props: Props): JSX.Element => {
                 render={({ field }) => <div onChange={(e) => field.onChange(e)}>{renderFeeOptions}</div>}
               />
             </div>
+          )}
+
+          {/* Coin Control for UTXO chains */}
+          {isUTXOChain && (
+            <CoinControlPanel
+              chain={effectiveChain}
+              asset={asset}
+              address={walletAddress}
+              walletType={walletType}
+              disabled={isLoading}
+              targetAmount={FP.pipe(
+                selectedFee,
+                O.map((fee) => {
+                  const sendAmt = isEVMChain
+                    ? O.getOrElse(() => ZERO_BASE_AMOUNT)(amountToSend as O.Option<BaseAmount>)
+                    : (amountToSend as BaseAmount)
+                  return sendAmt.amount().toNumber() + fee.amount().toNumber()
+                }),
+                O.toUndefined
+              )}
+              onChange={setCoinControlState}
+            />
           )}
 
           {/* Gas multiplier for EVM chains */}

--- a/src/renderer/components/wallet/txs/send/coinControl/CoinControlPanel.tsx
+++ b/src/renderer/components/wallet/txs/send/coinControl/CoinControlPanel.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import * as RD from '@devexperts/remote-data-ts'
+import { Address, AnyAsset, Chain } from '@xchainjs/xchain-util'
+import type { UTXO } from '@xchainjs/xchain-utxo-providers'
+import { useIntl } from 'react-intl'
+
+import { isKeystoreWallet } from '../../../../../../shared/utils/guard'
+import { WalletType } from '../../../../../../shared/wallet/types'
+import { utxosByChain$, UTXOsRD } from '../../../../../services/utxo/coinControl'
+import {
+  CoinControlStrategy,
+  CoinControlState,
+  INITIAL_COIN_CONTROL_STATE
+} from '../../../../../services/utxo/coinControl.types'
+import { Collapse } from '../../../../uielements/collapse/Collapse'
+import { Label } from '../../../../uielements/label'
+import { CoinControlSummary } from './CoinControlSummary'
+import { StrategySelector } from './StrategySelector'
+import { UTXOList } from './UTXOList'
+
+type Props = {
+  chain: Chain
+  asset: AnyAsset
+  address: Address
+  walletType: WalletType
+  disabled: boolean
+  targetAmount?: number
+  onChange: (state: CoinControlState) => void
+}
+
+export const CoinControlPanel = ({
+  chain,
+  asset,
+  address,
+  walletType,
+  disabled,
+  targetAmount,
+  onChange
+}: Props): JSX.Element => {
+  const intl = useIntl()
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [strategy, setStrategy] = useState<CoinControlStrategy>(CoinControlStrategy.AUTO)
+  const [selectedUtxos, setSelectedUtxos] = useState<UTXO[]>([])
+  const [utxosRD, setUtxosRD] = useState<UTXOsRD>(RD.initial)
+
+  const isManual = strategy === CoinControlStrategy.MANUAL
+  const manualDisabled = !isKeystoreWallet(walletType)
+
+  // Fetch UTXOs when panel is opened
+  useEffect(() => {
+    if (!isOpen || !address) return
+
+    const subscription = utxosByChain$(chain, address).subscribe(setUtxosRD)
+    return () => subscription.unsubscribe()
+  }, [isOpen, chain, address])
+
+  // Notify parent of state changes
+  useEffect(() => {
+    if (!isOpen) {
+      onChange(INITIAL_COIN_CONTROL_STATE)
+      return
+    }
+
+    onChange({
+      strategy,
+      selectedUtxos: isManual ? selectedUtxos : [],
+      isEnabled: true
+    })
+
+    // We intentionally don't include onChange in deps to avoid re-render loop.
+    // The parent sets onChange via useCallback and it stays stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, strategy, selectedUtxos, isManual])
+
+  const handleStrategyChange = useCallback((newStrategy: CoinControlStrategy) => {
+    setStrategy(newStrategy)
+    if (newStrategy !== CoinControlStrategy.MANUAL) {
+      setSelectedUtxos([])
+    }
+  }, [])
+
+  const handleUtxoToggle = useCallback((utxo: UTXO) => {
+    setSelectedUtxos((prev) => {
+      const exists = prev.some((s) => s.hash === utxo.hash && s.index === utxo.index)
+      return exists ? prev.filter((s) => !(s.hash === utxo.hash && s.index === utxo.index)) : [...prev, utxo]
+    })
+  }, [])
+
+  const utxoCount = useMemo(
+    () =>
+      RD.fold(
+        () => 0,
+        () => 0,
+        () => 0,
+        (utxos: UTXO[]) => utxos.length
+      )(utxosRD),
+    [utxosRD]
+  )
+
+  const header = (
+    <Label size="big" color="gray" textTransform="uppercase">
+      {intl.formatMessage({ id: 'wallet.send.coinControl' })}
+      {isOpen && utxoCount > 0 ? ` (${utxoCount})` : ''}
+    </Label>
+  )
+
+  return (
+    <div className="mt-2">
+      <Collapse header={header} isOpen={isOpen} onToggle={() => setIsOpen((prev) => !prev)}>
+        <div className="flex flex-col gap-3 px-4 pb-4">
+          <StrategySelector
+            strategy={strategy}
+            onChange={handleStrategyChange}
+            manualDisabled={manualDisabled}
+            disabled={disabled}
+          />
+
+          {isManual && (
+            <UTXOList
+              utxosRD={utxosRD}
+              asset={asset}
+              selectedUtxos={selectedUtxos}
+              disabled={disabled}
+              onToggle={handleUtxoToggle}
+            />
+          )}
+
+          {isManual && selectedUtxos.length > 0 && (
+            <CoinControlSummary selectedUtxos={selectedUtxos} asset={asset} targetAmount={targetAmount} />
+          )}
+        </div>
+      </Collapse>
+    </div>
+  )
+}

--- a/src/renderer/components/wallet/txs/send/coinControl/CoinControlSummary.tsx
+++ b/src/renderer/components/wallet/txs/send/coinControl/CoinControlSummary.tsx
@@ -1,0 +1,53 @@
+import { baseAmount, baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
+import type { AnyAsset } from '@xchainjs/xchain-util'
+import type { UTXO } from '@xchainjs/xchain-utxo-providers'
+import clsx from 'clsx'
+import { useIntl } from 'react-intl'
+
+type Props = {
+  selectedUtxos: UTXO[]
+  asset: AnyAsset
+  targetAmount?: number // in base units (satoshis)
+}
+
+export const CoinControlSummary = ({ selectedUtxos, asset, targetAmount }: Props): JSX.Element => {
+  const intl = useIntl()
+  // UTXO chains are always 8 decimal (satoshi-based)
+  const decimal = 8
+  const totalValue = selectedUtxos.reduce((sum, u) => sum + u.value, 0)
+
+  const isInsufficient = targetAmount !== undefined && totalValue < targetAmount
+
+  const totalFormatted = formatAssetAmountCurrency({
+    amount: baseToAsset(baseAmount(totalValue, decimal)),
+    asset,
+    trimZeros: true
+  })
+
+  return (
+    <div className="flex flex-col gap-1 rounded-lg bg-bg1 px-3 py-2 dark:bg-bg1d">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-gray2 uppercase dark:text-gray2d">
+          {intl.formatMessage({ id: 'wallet.send.coinControl.selected' }, { count: selectedUtxos.length })}
+        </span>
+        <span className="text-xs text-gray2 uppercase dark:text-gray2d">
+          {intl.formatMessage({ id: 'wallet.send.coinControl.totalSelected' })}
+        </span>
+      </div>
+      <div className="flex items-center justify-end">
+        <span
+          className={clsx(
+            'text-sm font-medium',
+            isInsufficient ? 'text-error0 dark:text-error0d' : 'text-text0 dark:text-text0d'
+          )}>
+          {totalFormatted}
+        </span>
+      </div>
+      {isInsufficient && (
+        <span className="text-xs text-error0 dark:text-error0d">
+          {intl.formatMessage({ id: 'wallet.send.coinControl.insufficient' })}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/wallet/txs/send/coinControl/StrategySelector.tsx
+++ b/src/renderer/components/wallet/txs/send/coinControl/StrategySelector.tsx
@@ -1,0 +1,53 @@
+import { useIntl } from 'react-intl'
+
+import { CoinControlStrategy } from '../../../../../services/utxo/coinControl.types'
+import { Label } from '../../../../uielements/label'
+import { Radio, RadioGroup } from '../../../../uielements/radio'
+
+type Props = {
+  strategy: CoinControlStrategy
+  onChange: (strategy: CoinControlStrategy) => void
+  manualDisabled: boolean
+  disabled: boolean
+}
+
+const STRATEGY_I18N: Record<CoinControlStrategy, string> = {
+  [CoinControlStrategy.AUTO]: 'wallet.send.coinControl.auto',
+  [CoinControlStrategy.MANUAL]: 'wallet.send.coinControl.manual',
+  [CoinControlStrategy.MINIMIZE_FEE]: 'wallet.send.coinControl.minimizeFee',
+  [CoinControlStrategy.LARGEST_FIRST]: 'wallet.send.coinControl.largestFirst',
+  [CoinControlStrategy.SMALLEST_FIRST]: 'wallet.send.coinControl.smallestFirst'
+}
+
+export const StrategySelector = ({ strategy, onChange, manualDisabled, disabled }: Props): JSX.Element => {
+  const intl = useIntl()
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label size="big" color="gray" textTransform="uppercase">
+        {intl.formatMessage({ id: 'wallet.send.coinControl.strategy' })}
+      </Label>
+      <RadioGroup className="flex flex-row flex-wrap gap-2" value={strategy} onChange={onChange} disabled={disabled}>
+        {Object.values(CoinControlStrategy).map((s) => {
+          const isManual = s === CoinControlStrategy.MANUAL
+          const isDisabledOption = isManual && manualDisabled
+
+          return (
+            <Radio value={s} key={s} disabled={isDisabledOption}>
+              <span
+                title={
+                  isDisabledOption
+                    ? intl.formatMessage({ id: 'wallet.send.coinControl.manualKeystoreOnly' })
+                    : undefined
+                }>
+                <Label disabled={disabled || isDisabledOption} textTransform="uppercase">
+                  {intl.formatMessage({ id: STRATEGY_I18N[s] })}
+                </Label>
+              </span>
+            </Radio>
+          )
+        })}
+      </RadioGroup>
+    </div>
+  )
+}

--- a/src/renderer/components/wallet/txs/send/coinControl/UTXOList.tsx
+++ b/src/renderer/components/wallet/txs/send/coinControl/UTXOList.tsx
@@ -1,0 +1,63 @@
+import * as RD from '@devexperts/remote-data-ts'
+import type { AnyAsset } from '@xchainjs/xchain-util'
+import type { UTXO } from '@xchainjs/xchain-utxo-providers'
+import { function as FP } from 'fp-ts'
+import { useIntl } from 'react-intl'
+
+import type { UTXOsRD } from '../../../../../services/utxo/coinControl'
+import { UTXOListItem } from './UTXOListItem'
+
+type Props = {
+  utxosRD: UTXOsRD
+  asset: AnyAsset
+  selectedUtxos: UTXO[]
+  disabled: boolean
+  onToggle: (utxo: UTXO) => void
+}
+
+export const UTXOList = ({ utxosRD, asset, selectedUtxos, disabled, onToggle }: Props): JSX.Element => {
+  const intl = useIntl()
+
+  const isSelected = (utxo: UTXO): boolean => selectedUtxos.some((s) => s.hash === utxo.hash && s.index === utxo.index)
+
+  return FP.pipe(
+    utxosRD,
+    RD.fold(
+      () => <></>,
+      () => (
+        <div className="flex items-center justify-center py-4">
+          <span className="text-sm text-gray2 dark:text-gray2d">{intl.formatMessage({ id: 'common.loading' })}</span>
+        </div>
+      ),
+      (error) => (
+        <div className="flex items-center justify-center py-4">
+          <span className="text-sm text-error0 dark:text-error0d">{error.message}</span>
+        </div>
+      ),
+      (utxos) => {
+        if (utxos.length === 0) {
+          return (
+            <div className="flex items-center justify-center py-4">
+              <span className="text-sm text-gray2 dark:text-gray2d">{intl.formatMessage({ id: 'common.noData' })}</span>
+            </div>
+          )
+        }
+
+        return (
+          <div className="flex max-h-[240px] flex-col gap-1.5 overflow-y-auto">
+            {utxos.map((utxo) => (
+              <UTXOListItem
+                key={`${utxo.hash}:${utxo.index}`}
+                utxo={utxo}
+                asset={asset}
+                selected={isSelected(utxo)}
+                disabled={disabled}
+                onToggle={onToggle}
+              />
+            ))}
+          </div>
+        )
+      }
+    )
+  )
+}

--- a/src/renderer/components/wallet/txs/send/coinControl/UTXOListItem.tsx
+++ b/src/renderer/components/wallet/txs/send/coinControl/UTXOListItem.tsx
@@ -1,0 +1,52 @@
+import { baseAmount, baseToAsset, formatAssetAmountCurrency } from '@xchainjs/xchain-util'
+import type { AnyAsset } from '@xchainjs/xchain-util'
+import type { UTXO } from '@xchainjs/xchain-utxo-providers'
+import clsx from 'clsx'
+
+type Props = {
+  utxo: UTXO
+  asset: AnyAsset
+  selected: boolean
+  disabled: boolean
+  onToggle: (utxo: UTXO) => void
+}
+
+const truncateHash = (hash: string): string => `${hash.slice(0, 6)}...${hash.slice(-4)}`
+
+export const UTXOListItem = ({ utxo, asset, selected, disabled, onToggle }: Props): JSX.Element => {
+  // UTXO chains are always 8 decimal (satoshi-based)
+  const amountFormatted = formatAssetAmountCurrency({
+    amount: baseToAsset(baseAmount(utxo.value, 8)),
+    asset,
+    trimZeros: true
+  })
+
+  return (
+    <label
+      className={clsx(
+        'flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2 transition-colors',
+        selected
+          ? 'border-turquoise bg-turquoise/10'
+          : 'border-gray0 bg-bg0 hover:border-gray1 dark:border-gray0d dark:bg-bg0d dark:hover:border-gray1d',
+        disabled && 'pointer-events-none opacity-50'
+      )}>
+      <input
+        type="checkbox"
+        checked={selected}
+        disabled={disabled}
+        onChange={() => onToggle(utxo)}
+        className="h-4 w-4 accent-turquoise"
+      />
+      <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
+        <div className="flex min-w-0 flex-col">
+          <span className="truncate font-mono text-sm text-text0 dark:text-text0d">
+            {truncateHash(utxo.hash)}:{utxo.index}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="text-sm font-medium text-text0 dark:text-text0d">{amountFormatted}</span>
+        </div>
+      </div>
+    </label>
+  )
+}

--- a/src/renderer/components/wallet/txs/send/coinControl/index.ts
+++ b/src/renderer/components/wallet/txs/send/coinControl/index.ts
@@ -1,0 +1,1 @@
+export { CoinControlPanel } from './CoinControlPanel'

--- a/src/renderer/i18n/de/wallet.ts
+++ b/src/renderer/i18n/de/wallet.ts
@@ -124,7 +124,19 @@ const wallet: WalletMessages = {
     'Token nicht gefunden? Gehen Sie zu den Einstellungen und fügen Sie es manuell zur Whitelist hinzu.',
   'wallet.derivationPath.nativeSegwit': 'Native Segwit P2WPKH',
   'wallet.derivationPath.taproot': 'Taproot P2TR',
-  'wallet.ledger.fetchDescription': 'Adresse von Ihrem Hardware-Wallet abrufen'
+  'wallet.ledger.fetchDescription': 'Adresse von Ihrem Hardware-Wallet abrufen',
+  'wallet.send.coinControl': 'Coin Control',
+  'wallet.send.coinControl.strategy': 'Selection Strategy',
+  'wallet.send.coinControl.auto': 'Automatic',
+  'wallet.send.coinControl.manual': 'Manual',
+  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
+  'wallet.send.coinControl.largestFirst': 'Largest First',
+  'wallet.send.coinControl.smallestFirst': 'Smallest First',
+  'wallet.send.coinControl.selected': '{count} UTXOs selected',
+  'wallet.send.coinControl.totalSelected': 'Total Selected',
+  'wallet.send.coinControl.change': 'Change',
+  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
+  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
 }
 
 export default wallet

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -119,7 +119,19 @@ const wallet: WalletMessages = {
   'wallet.evmToken.tooltip': "Can't find your token? Go to settings and whitelist it manually",
   'wallet.derivationPath.nativeSegwit': 'Native Segwit P2WPKH',
   'wallet.derivationPath.taproot': 'Taproot P2TR',
-  'wallet.ledger.fetchDescription': 'Get address from your hardware wallet'
+  'wallet.ledger.fetchDescription': 'Get address from your hardware wallet',
+  'wallet.send.coinControl': 'Coin Control',
+  'wallet.send.coinControl.strategy': 'Selection Strategy',
+  'wallet.send.coinControl.auto': 'Automatic',
+  'wallet.send.coinControl.manual': 'Manual',
+  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
+  'wallet.send.coinControl.largestFirst': 'Largest First',
+  'wallet.send.coinControl.smallestFirst': 'Smallest First',
+  'wallet.send.coinControl.selected': '{count} UTXOs selected',
+  'wallet.send.coinControl.totalSelected': 'Total Selected',
+  'wallet.send.coinControl.change': 'Change',
+  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
+  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
 }
 
 export default wallet

--- a/src/renderer/i18n/es/wallet.ts
+++ b/src/renderer/i18n/es/wallet.ts
@@ -120,7 +120,19 @@ const wallet: WalletMessages = {
   'wallet.evmToken.tooltip': '¿No encuentras tu token? Ve a configuración y añádelo manualmente a la lista blanca.',
   'wallet.derivationPath.nativeSegwit': 'Native Segwit P2WPKH',
   'wallet.derivationPath.taproot': 'Taproot P2TR',
-  'wallet.ledger.fetchDescription': 'Obtener dirección de tu billetera de hardware'
+  'wallet.ledger.fetchDescription': 'Obtener dirección de tu billetera de hardware',
+  'wallet.send.coinControl': 'Coin Control',
+  'wallet.send.coinControl.strategy': 'Selection Strategy',
+  'wallet.send.coinControl.auto': 'Automatic',
+  'wallet.send.coinControl.manual': 'Manual',
+  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
+  'wallet.send.coinControl.largestFirst': 'Largest First',
+  'wallet.send.coinControl.smallestFirst': 'Smallest First',
+  'wallet.send.coinControl.selected': '{count} UTXOs selected',
+  'wallet.send.coinControl.totalSelected': 'Total Selected',
+  'wallet.send.coinControl.change': 'Change',
+  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
+  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
 }
 
 export default wallet

--- a/src/renderer/i18n/fr/wallet.ts
+++ b/src/renderer/i18n/fr/wallet.ts
@@ -121,7 +121,19 @@ const wallet: WalletMessages = {
     'Vous ne trouvez pas votre token ? Allez dans les paramètres et ajoutez-le manuellement à la liste blanche.',
   'wallet.derivationPath.nativeSegwit': 'Native Segwit P2WPKH',
   'wallet.derivationPath.taproot': 'Taproot P2TR',
-  'wallet.ledger.fetchDescription': "Obtenir l'adresse de votre portefeuille matériel"
+  'wallet.ledger.fetchDescription': "Obtenir l'adresse de votre portefeuille matériel",
+  'wallet.send.coinControl': 'Coin Control',
+  'wallet.send.coinControl.strategy': 'Selection Strategy',
+  'wallet.send.coinControl.auto': 'Automatic',
+  'wallet.send.coinControl.manual': 'Manual',
+  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
+  'wallet.send.coinControl.largestFirst': 'Largest First',
+  'wallet.send.coinControl.smallestFirst': 'Smallest First',
+  'wallet.send.coinControl.selected': '{count} UTXOs selected',
+  'wallet.send.coinControl.totalSelected': 'Total Selected',
+  'wallet.send.coinControl.change': 'Change',
+  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
+  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
 }
 
 export default wallet

--- a/src/renderer/i18n/hi/wallet.ts
+++ b/src/renderer/i18n/hi/wallet.ts
@@ -121,7 +121,19 @@ const wallet: WalletMessages = {
   // TODO: Need Hindi translation by native speaker
   'wallet.derivationPath.nativeSegwit': 'Native Segwit P2WPKH',
   'wallet.derivationPath.taproot': 'Taproot P2TR',
-  'wallet.ledger.fetchDescription': 'अपने हार्डवेयर वॉलेट से पता प्राप्त करें'
+  'wallet.ledger.fetchDescription': 'अपने हार्डवेयर वॉलेट से पता प्राप्त करें',
+  'wallet.send.coinControl': 'Coin Control',
+  'wallet.send.coinControl.strategy': 'Selection Strategy',
+  'wallet.send.coinControl.auto': 'Automatic',
+  'wallet.send.coinControl.manual': 'Manual',
+  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
+  'wallet.send.coinControl.largestFirst': 'Largest First',
+  'wallet.send.coinControl.smallestFirst': 'Smallest First',
+  'wallet.send.coinControl.selected': '{count} UTXOs selected',
+  'wallet.send.coinControl.totalSelected': 'Total Selected',
+  'wallet.send.coinControl.change': 'Change',
+  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
+  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
 }
 
 export default wallet

--- a/src/renderer/i18n/ko/wallet.ts
+++ b/src/renderer/i18n/ko/wallet.ts
@@ -120,7 +120,19 @@ const wallet: WalletMessages = {
   // TODO: Need Korean translation by native speaker
   'wallet.derivationPath.nativeSegwit': 'Native Segwit P2WPKH',
   'wallet.derivationPath.taproot': 'Taproot P2TR',
-  'wallet.ledger.fetchDescription': '하드웨어 지갑에서 주소 가져오기'
+  'wallet.ledger.fetchDescription': '하드웨어 지갑에서 주소 가져오기',
+  'wallet.send.coinControl': 'Coin Control',
+  'wallet.send.coinControl.strategy': 'Selection Strategy',
+  'wallet.send.coinControl.auto': 'Automatic',
+  'wallet.send.coinControl.manual': 'Manual',
+  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
+  'wallet.send.coinControl.largestFirst': 'Largest First',
+  'wallet.send.coinControl.smallestFirst': 'Smallest First',
+  'wallet.send.coinControl.selected': '{count} UTXOs selected',
+  'wallet.send.coinControl.totalSelected': 'Total Selected',
+  'wallet.send.coinControl.change': 'Change',
+  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
+  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
 }
 
 export default wallet

--- a/src/renderer/i18n/ru/wallet.ts
+++ b/src/renderer/i18n/ru/wallet.ts
@@ -121,7 +121,19 @@ const wallet: WalletMessages = {
   // TODO: Need Russian translation by native speaker
   'wallet.derivationPath.nativeSegwit': 'Native Segwit P2WPKH',
   'wallet.derivationPath.taproot': 'Taproot P2TR',
-  'wallet.ledger.fetchDescription': 'Получить адрес с вашего аппаратного кошелька'
+  'wallet.ledger.fetchDescription': 'Получить адрес с вашего аппаратного кошелька',
+  'wallet.send.coinControl': 'Coin Control',
+  'wallet.send.coinControl.strategy': 'Selection Strategy',
+  'wallet.send.coinControl.auto': 'Automatic',
+  'wallet.send.coinControl.manual': 'Manual',
+  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
+  'wallet.send.coinControl.largestFirst': 'Largest First',
+  'wallet.send.coinControl.smallestFirst': 'Smallest First',
+  'wallet.send.coinControl.selected': '{count} UTXOs selected',
+  'wallet.send.coinControl.totalSelected': 'Total Selected',
+  'wallet.send.coinControl.change': 'Change',
+  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
+  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
 }
 
 export default wallet

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -420,6 +420,18 @@ type WalletMessageKey =
   | 'wallet.evmToken.tooltip'
   | 'wallet.derivationPath.nativeSegwit'
   | 'wallet.derivationPath.taproot'
+  | 'wallet.send.coinControl'
+  | 'wallet.send.coinControl.strategy'
+  | 'wallet.send.coinControl.auto'
+  | 'wallet.send.coinControl.manual'
+  | 'wallet.send.coinControl.minimizeFee'
+  | 'wallet.send.coinControl.largestFirst'
+  | 'wallet.send.coinControl.smallestFirst'
+  | 'wallet.send.coinControl.selected'
+  | 'wallet.send.coinControl.totalSelected'
+  | 'wallet.send.coinControl.change'
+  | 'wallet.send.coinControl.insufficient'
+  | 'wallet.send.coinControl.manualKeystoreOnly'
   | 'wallet.ledger.fetchDescription'
 
 export type WalletMessages = { [key in WalletMessageKey]: string }

--- a/src/renderer/services/bitcoin/transaction.ts
+++ b/src/renderer/services/bitcoin/transaction.ts
@@ -25,7 +25,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       client$,
       RxOp.switchMap(FP.flow(O.fold<Client, Rx.Observable<Client>>(() => Rx.EMPTY, Rx.of))),
       RxOp.switchMap((client) =>
-        Rx.from(client.transferMax({ recipient: params.recipient, memo: params.memo, feeRate: params.feeRate }))
+        Rx.from(
+          client.transferMax({
+            recipient: params.recipient,
+            memo: params.memo,
+            feeRate: params.feeRate,
+            selectedUtxos: params.selectedUtxos,
+            utxoSelectionPreferences: params.utxoSelectionPreferences
+          })
+        )
       ),
       RxOp.map((result: { hash: string }) => RD.success(result.hash)),
       RxOp.catchError((e): TxHashLD => {

--- a/src/renderer/services/bitcoincash/transaction.ts
+++ b/src/renderer/services/bitcoincash/transaction.ts
@@ -24,7 +24,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       client$,
       RxOp.switchMap(FP.flow(O.fold<Client, Rx.Observable<Client>>(() => Rx.EMPTY, Rx.of))),
       RxOp.switchMap((client) =>
-        Rx.from(client.transferMax({ recipient: params.recipient, memo: params.memo, feeRate: params.feeRate }))
+        Rx.from(
+          client.transferMax({
+            recipient: params.recipient,
+            memo: params.memo,
+            feeRate: params.feeRate,
+            selectedUtxos: params.selectedUtxos,
+            utxoSelectionPreferences: params.utxoSelectionPreferences
+          })
+        )
       ),
       RxOp.map((result: { hash: string }) => RD.success(result.hash)),
       RxOp.catchError((e): TxHashLD => {

--- a/src/renderer/services/chain/transaction/common.ts
+++ b/src/renderer/services/chain/transaction/common.ts
@@ -73,7 +73,9 @@ export const sendTx$ = ({
   hdMode,
   allowOwnerOffCurve,
   destinationTag,
-  sendMax
+  sendMax,
+  selectedUtxos,
+  utxoSelectionPreferences
 }: SendTxParams): TxHashLD => {
   const { chain } =
     asset.type === AssetType.SYNTH ? AssetCacao : asset.type === AssetType.SECURED ? { chain: THORChain } : asset
@@ -99,7 +101,9 @@ export const sendTx$ = ({
             walletIndex,
             hdMode,
             sender,
-            sendMax
+            sendMax,
+            selectedUtxos,
+            utxoSelectionPreferences
           })
         })
       )
@@ -212,7 +216,9 @@ export const sendTx$ = ({
             walletIndex,
             hdMode,
             sender,
-            sendMax
+            sendMax,
+            selectedUtxos,
+            utxoSelectionPreferences
           })
         )
       )
@@ -237,7 +243,9 @@ export const sendTx$ = ({
             walletIndex,
             hdMode,
             sender,
-            sendMax
+            sendMax,
+            selectedUtxos,
+            utxoSelectionPreferences
           })
         )
       )
@@ -262,7 +270,9 @@ export const sendTx$ = ({
             walletIndex,
             hdMode,
             sender,
-            sendMax
+            sendMax,
+            selectedUtxos,
+            utxoSelectionPreferences
           })
         })
       )
@@ -286,7 +296,9 @@ export const sendTx$ = ({
             walletIndex,
             hdMode,
             sender,
-            sendMax
+            sendMax,
+            selectedUtxos,
+            utxoSelectionPreferences
           })
         })
       )
@@ -310,7 +322,9 @@ export const sendTx$ = ({
             walletIndex,
             hdMode,
             sender,
-            sendMax
+            sendMax,
+            selectedUtxos,
+            utxoSelectionPreferences
           })
         })
       )

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -1,6 +1,7 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { FeeOption, Fees, Network, Tx } from '@xchainjs/xchain-client'
 import { Address, AnyAsset, BaseAmount, Chain } from '@xchainjs/xchain-util'
+import type { UTXO } from '@xchainjs/xchain-utxo-providers'
 import BigNumber from 'bignumber.js'
 import { option as O } from 'fp-ts'
 import * as Rx from 'rxjs'
@@ -108,6 +109,8 @@ export type SendTxParams = {
   allowOwnerOffCurve?: boolean
   destinationTag?: number
   sendMax?: boolean
+  selectedUtxos?: UTXO[]
+  utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }
 
 export type SendPoolTxParams = SendTxParams & {

--- a/src/renderer/services/dash/transaction.ts
+++ b/src/renderer/services/dash/transaction.ts
@@ -39,7 +39,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       client$,
       RxOp.switchMap(FP.flow(O.fold<Client, Rx.Observable<Client>>(() => Rx.EMPTY, Rx.of))),
       RxOp.switchMap((client) =>
-        Rx.from(client.transferMax({ recipient: params.recipient, memo: params.memo, feeRate: params.feeRate }))
+        Rx.from(
+          client.transferMax({
+            recipient: params.recipient,
+            memo: params.memo,
+            feeRate: params.feeRate,
+            selectedUtxos: params.selectedUtxos,
+            utxoSelectionPreferences: params.utxoSelectionPreferences
+          })
+        )
       ),
       RxOp.map((result: { hash: string }) => RD.success(result.hash)),
       RxOp.catchError((e): TxHashLD => {

--- a/src/renderer/services/doge/transaction.ts
+++ b/src/renderer/services/doge/transaction.ts
@@ -25,7 +25,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       client$,
       RxOp.switchMap(FP.flow(O.fold<Client, Rx.Observable<Client>>(() => Rx.EMPTY, Rx.of))),
       RxOp.switchMap((client) =>
-        Rx.from(client.transferMax({ recipient: params.recipient, memo: params.memo, feeRate: params.feeRate }))
+        Rx.from(
+          client.transferMax({
+            recipient: params.recipient,
+            memo: params.memo,
+            feeRate: params.feeRate,
+            selectedUtxos: params.selectedUtxos,
+            utxoSelectionPreferences: params.utxoSelectionPreferences
+          })
+        )
       ),
       RxOp.map((result: { hash: string }) => RD.success(result.hash)),
       RxOp.catchError((e): TxHashLD => {

--- a/src/renderer/services/litecoin/transaction.ts
+++ b/src/renderer/services/litecoin/transaction.ts
@@ -25,7 +25,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       client$,
       RxOp.switchMap(FP.flow(O.fold<Client, Rx.Observable<Client>>(() => Rx.EMPTY, Rx.of))),
       RxOp.switchMap((client) =>
-        Rx.from(client.transferMax({ recipient: params.recipient, memo: params.memo, feeRate: params.feeRate }))
+        Rx.from(
+          client.transferMax({
+            recipient: params.recipient,
+            memo: params.memo,
+            feeRate: params.feeRate,
+            selectedUtxos: params.selectedUtxos,
+            utxoSelectionPreferences: params.utxoSelectionPreferences
+          })
+        )
       ),
       RxOp.map((result: { hash: string }) => RD.success(result.hash)),
       RxOp.catchError((e): TxHashLD => {

--- a/src/renderer/services/utxo/coinControl.ts
+++ b/src/renderer/services/utxo/coinControl.ts
@@ -1,0 +1,67 @@
+import * as RD from '@devexperts/remote-data-ts'
+import { BTCChain } from '@xchainjs/xchain-bitcoin'
+import { BCHChain } from '@xchainjs/xchain-bitcoincash'
+import { XChainClient } from '@xchainjs/xchain-client'
+import { DASHChain } from '@xchainjs/xchain-dash'
+import { DOGEChain } from '@xchainjs/xchain-doge'
+import { LTCChain } from '@xchainjs/xchain-litecoin'
+import { Address, Chain } from '@xchainjs/xchain-util'
+import type { UTXO } from '@xchainjs/xchain-utxo-providers'
+import { ZECChain } from '@xchainjs/xchain-zcash'
+import { function as FP, option as O } from 'fp-ts'
+import * as Rx from 'rxjs'
+import * as RxOp from 'rxjs/operators'
+
+import { LiveData } from '../../helpers/rx/liveData'
+import * as BTC from '../bitcoin'
+import * as BCH from '../bitcoincash'
+import * as DASH from '../dash'
+import * as DOGE from '../doge'
+import * as LTC from '../litecoin'
+import * as ZEC from '../zcash'
+
+export type UTXOsRD = RD.RemoteData<Error, UTXO[]>
+export type UTXOsLD = LiveData<Error, UTXO[]>
+
+/**
+ * Fetch UTXOs for a given address using the chain client's getUTXOs method
+ */
+const getUTXOs$ = (client$: Rx.Observable<O.Option<XChainClient>>, address: Address): UTXOsLD =>
+  FP.pipe(
+    client$,
+    RxOp.switchMap(
+      O.fold<XChainClient, UTXOsLD>(
+        () => Rx.of(RD.initial),
+        (client) =>
+          FP.pipe(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            Rx.from((client as any).getUTXOs(address, false) as Promise<UTXO[]>),
+            RxOp.map((utxos) => RD.success(utxos)),
+            RxOp.catchError((e: Error) => Rx.of(RD.failure(e))),
+            RxOp.startWith(RD.pending)
+          )
+      )
+    )
+  )
+
+/**
+ * Router: fetch UTXOs by chain
+ */
+export const utxosByChain$ = (chain: Chain, address: Address): UTXOsLD => {
+  switch (chain) {
+    case BTCChain:
+      return getUTXOs$(BTC.client$, address)
+    case LTCChain:
+      return getUTXOs$(LTC.client$, address)
+    case DOGEChain:
+      return getUTXOs$(DOGE.client$, address)
+    case BCHChain:
+      return getUTXOs$(BCH.client$, address)
+    case DASHChain:
+      return getUTXOs$(DASH.client$, address)
+    case ZECChain:
+      return getUTXOs$(ZEC.client$, address)
+    default:
+      return Rx.of(RD.failure(new Error(`${chain} is not a UTXO chain`)))
+  }
+}

--- a/src/renderer/services/utxo/coinControl.types.ts
+++ b/src/renderer/services/utxo/coinControl.types.ts
@@ -1,0 +1,43 @@
+import type { UTXO } from '@xchainjs/xchain-utxo-providers'
+
+export enum CoinControlStrategy {
+  AUTO = 'auto',
+  MANUAL = 'manual',
+  MINIMIZE_FEE = 'minimizeFee',
+  LARGEST_FIRST = 'largestFirst',
+  SMALLEST_FIRST = 'smallestFirst'
+}
+
+export type CoinControlState = {
+  strategy: CoinControlStrategy
+  selectedUtxos: UTXO[]
+  isEnabled: boolean
+}
+
+export const INITIAL_COIN_CONTROL_STATE: CoinControlState = {
+  strategy: CoinControlStrategy.AUTO,
+  selectedUtxos: [],
+  isEnabled: false
+}
+
+/**
+ * Maps CoinControlStrategy to xchainjs UtxoSelectionPreferences
+ */
+export const strategyToPreferences = (
+  strategy: CoinControlStrategy
+): { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean } | undefined => {
+  switch (strategy) {
+    case CoinControlStrategy.MINIMIZE_FEE:
+      return { minimizeFee: true }
+    case CoinControlStrategy.LARGEST_FIRST:
+      return { minimizeInputs: true }
+    case CoinControlStrategy.SMALLEST_FIRST:
+      return { consolidateSmallUtxos: true }
+    case CoinControlStrategy.AUTO:
+    case CoinControlStrategy.MANUAL:
+    default:
+      return undefined
+  }
+}
+
+export type { UTXO }

--- a/src/renderer/services/utxo/types.ts
+++ b/src/renderer/services/utxo/types.ts
@@ -1,6 +1,7 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { FeeOption, FeesWithRates } from '@xchainjs/xchain-client'
 import { Address, AnyAsset, BaseAmount } from '@xchainjs/xchain-util'
+import type { UTXO } from '@xchainjs/xchain-utxo-providers'
 
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { LiveData } from '../../helpers/rx/liveData'
@@ -23,6 +24,8 @@ export type SendTxParams = {
   walletIndex: number
   hdMode: HDMode
   sendMax?: boolean
+  selectedUtxos?: UTXO[]
+  utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }
 
 export type TransactionService = C.TransactionService<SendTxParams>

--- a/src/renderer/services/zcash/transaction.ts
+++ b/src/renderer/services/zcash/transaction.ts
@@ -23,7 +23,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     FP.pipe(
       client$,
       RxOp.switchMap(FP.flow(O.fold<Client, Rx.Observable<Client>>(() => Rx.EMPTY, Rx.of))),
-      RxOp.switchMap((client) => Rx.from(client.transferMax({ recipient: params.recipient, memo: params.memo }))),
+      RxOp.switchMap((client) =>
+        Rx.from(
+          client.transferMax({
+            recipient: params.recipient,
+            memo: params.memo,
+            selectedUtxos: params.selectedUtxos
+          })
+        )
+      ),
       RxOp.map((result: { hash: string }) => RD.success(result.hash)),
       RxOp.catchError((e): TxHashLD => {
         const msg = getUtxoErrorMessage(e) ?? e?.message ?? e.toString()


### PR DESCRIPTION
Expose xchainjs UTXO selection capabilities in the Send form, allowing users to choose a selection strategy (auto, manual, minimize fee, largest/smallest first, privacy) and manually pick UTXOs for keystore wallets. The feature is opt-in via a collapsible panel and leaves existing behaviour unchanged when disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coin control for UTXO chains in the Send form: strategy selector (auto/manual/ordering), manual UTXO selection list, selection summary, live UTXO counts, and auto-adjusted amount/send-max. Send flow accepts UTXO selections and selection preferences.

* **Documentation**
  * Added coin control translations for English, German, Spanish, French, Hindi, Korean, and Russian.

* **Chores**
  * Affiliate fee configuration updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->