### PR TITLE
fix: thread coin control through Ledger IPC pipeline

### DIFF
--- a/src/main/api/ledger/bitcoin/transaction.ts
+++ b/src/main/api/ledger/bitcoin/transaction.ts
@@ -35,6 +35,7 @@ export const send = async ({
   hdMode,
   addressFormat,
   apiKey,
+  sendMax,
   selectedUtxos,
   utxoSelectionPreferences
 }: {
@@ -50,6 +51,7 @@ export const send = async ({
   hdMode?: HDMode
   addressFormat?: AddressFormat
   apiKey: string
+  sendMax?: boolean
   selectedUtxos?: Array<{ hash: string; index: number; value: number }>
   utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }): Promise<E.Either<LedgerError, TxHash>> => {
@@ -113,6 +115,12 @@ export const send = async ({
       const allUtxos = await clientLedger.getUTXOs(sender)
       const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
       const fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
+      if (fullSelectedUtxos.length !== selectedUtxos.length) {
+        return E.left({
+          errorId: LedgerErrorId.INVALID_RESPONSE,
+          msg: `Some selected BTC UTXOs are no longer available. Please refresh and retry.`
+        })
+      }
 
       const result = await clientLedger.transferMax({
         walletIndex,
@@ -120,6 +128,24 @@ export const send = async ({
         memo,
         feeRate,
         selectedUtxos: fullSelectedUtxos,
+        utxoSelectionPreferences
+      })
+      if (!result?.hash) {
+        return E.left({
+          errorId: LedgerErrorId.INVALID_RESPONSE,
+          msg: `Post request to send BTC transaction using Ledger failed`
+        })
+      }
+      return E.right(result.hash)
+    }
+
+    // Use transferMax() when sendMax is true (user pressed "Max")
+    if (sendMax) {
+      const result = await clientLedger.transferMax({
+        walletIndex,
+        recipient,
+        memo,
+        feeRate,
         utxoSelectionPreferences
       })
       if (!result?.hash) {

--- a/src/main/api/ledger/bitcoin/transaction.ts
+++ b/src/main/api/ledger/bitcoin/transaction.ts
@@ -34,7 +34,9 @@ export const send = async ({
   walletIndex,
   hdMode,
   addressFormat,
-  apiKey
+  apiKey,
+  selectedUtxos,
+  utxoSelectionPreferences
 }: {
   transport: Transport
   network: Network
@@ -48,6 +50,8 @@ export const send = async ({
   hdMode?: HDMode
   addressFormat?: AddressFormat
   apiKey: string
+  selectedUtxos?: Array<{ hash: string; index: number; value: number }>
+  utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }): Promise<E.Either<LedgerError, TxHash>> => {
   if (!sender) {
     return E.left({
@@ -103,13 +107,38 @@ export const send = async ({
     const fee = await clientLedger.getFeesWithRates({ sender, memo })
     const feeRate = fee.rates[feeOption]
 
+    // Ledger's transfer() doesn't accept selectedUtxos — use transferMax() when UTXOs are specified
+    // IPC only sends {hash, index, value} identifiers; re-fetch full UTXOs (with witnessUtxo) from the data provider
+    if (selectedUtxos && selectedUtxos.length > 0) {
+      const allUtxos = await clientLedger.getUTXOs(sender)
+      const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
+      const fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
+
+      const result = await clientLedger.transferMax({
+        walletIndex,
+        recipient,
+        memo,
+        feeRate,
+        selectedUtxos: fullSelectedUtxos,
+        utxoSelectionPreferences
+      })
+      if (!result?.hash) {
+        return E.left({
+          errorId: LedgerErrorId.INVALID_RESPONSE,
+          msg: `Post request to send BTC transaction using Ledger failed`
+        })
+      }
+      return E.right(result.hash)
+    }
+
     const txHash = await clientLedger.transfer({
       walletIndex,
       asset: AssetBTC,
       recipient,
       amount,
       memo,
-      feeRate
+      feeRate,
+      utxoSelectionPreferences
     })
     if (!txHash) {
       return E.left({

--- a/src/main/api/ledger/bitcoin/transaction.ts
+++ b/src/main/api/ledger/bitcoin/transaction.ts
@@ -109,17 +109,20 @@ export const send = async ({
     const fee = await clientLedger.getFeesWithRates({ sender, memo })
     const feeRate = fee.rates[feeOption]
 
-    // Ledger's transfer() doesn't accept selectedUtxos — use transferMax() when UTXOs are specified
+    // Ledger's transfer() doesn't accept selectedUtxos/utxoSelectionPreferences — use transferMax() for coin control
     // IPC only sends {hash, index, value} identifiers; re-fetch full UTXOs (with witnessUtxo) from the data provider
-    if (selectedUtxos && selectedUtxos.length > 0) {
-      const allUtxos = await clientLedger.getUTXOs(sender)
-      const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
-      const fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
-      if (fullSelectedUtxos.length !== selectedUtxos.length) {
-        return E.left({
-          errorId: LedgerErrorId.INVALID_RESPONSE,
-          msg: `Some selected BTC UTXOs are no longer available. Please refresh and retry.`
-        })
+    if ((selectedUtxos && selectedUtxos.length > 0) || utxoSelectionPreferences) {
+      let fullSelectedUtxos
+      if (selectedUtxos && selectedUtxos.length > 0) {
+        const allUtxos = await clientLedger.getUTXOs(sender)
+        const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
+        fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
+        if (fullSelectedUtxos.length !== selectedUtxos.length) {
+          return E.left({
+            errorId: LedgerErrorId.INVALID_RESPONSE,
+            msg: `Some selected BTC UTXOs are no longer available. Please refresh and retry.`
+          })
+        }
       }
 
       const result = await clientLedger.transferMax({
@@ -145,8 +148,7 @@ export const send = async ({
         walletIndex,
         recipient,
         memo,
-        feeRate,
-        utxoSelectionPreferences
+        feeRate
       })
       if (!result?.hash) {
         return E.left({
@@ -163,8 +165,7 @@ export const send = async ({
       recipient,
       amount,
       memo,
-      feeRate,
-      utxoSelectionPreferences
+      feeRate
     })
     if (!txHash) {
       return E.left({

--- a/src/main/api/ledger/bitcoincash/transaction.ts
+++ b/src/main/api/ledger/bitcoincash/transaction.ts
@@ -20,7 +20,9 @@ export const send = async ({
   feeOption,
   memo,
   walletAccount,
-  walletIndex
+  walletIndex,
+  selectedUtxos,
+  utxoSelectionPreferences
 }: {
   transport: Transport
   network: Network
@@ -32,6 +34,8 @@ export const send = async ({
   memo?: string
   walletAccount: number
   walletIndex: number
+  selectedUtxos?: Array<{ hash: string; index: number; value: number }>
+  utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }): Promise<E.Either<LedgerError, TxHash>> => {
   if (!sender) {
     return E.left({
@@ -49,6 +53,33 @@ export const send = async ({
     })
     const fee = await clientLedger.getFeesWithRates({ sender, memo })
     const feeRate = fee.rates[feeOption]
+
+    // Ledger's transfer() doesn't accept selectedUtxos/utxoSelectionPreferences — use transferMax() for coin control
+    // IPC only sends {hash, index, value} identifiers; re-fetch full UTXOs (with witnessUtxo) from the data provider
+    if ((selectedUtxos && selectedUtxos.length > 0) || utxoSelectionPreferences) {
+      let fullSelectedUtxos
+      if (selectedUtxos && selectedUtxos.length > 0) {
+        const allUtxos = await clientLedger.getUTXOs(sender)
+        const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
+        fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
+      }
+
+      const result = await clientLedger.transferMax({
+        walletIndex,
+        recipient,
+        memo,
+        feeRate,
+        selectedUtxos: fullSelectedUtxos,
+        utxoSelectionPreferences
+      })
+      if (!result?.hash) {
+        return E.left({
+          errorId: LedgerErrorId.INVALID_RESPONSE,
+          msg: `Post request to send BCH transaction using Ledger failed`
+        })
+      }
+      return E.right(result.hash)
+    }
 
     const txHash = await clientLedger.transfer({
       walletIndex,

--- a/src/main/api/ledger/bitcoincash/transaction.ts
+++ b/src/main/api/ledger/bitcoincash/transaction.ts
@@ -21,6 +21,7 @@ export const send = async ({
   memo,
   walletAccount,
   walletIndex,
+  sendMax,
   selectedUtxos,
   utxoSelectionPreferences
 }: {
@@ -34,6 +35,7 @@ export const send = async ({
   memo?: string
   walletAccount: number
   walletIndex: number
+  sendMax?: boolean
   selectedUtxos?: Array<{ hash: string; index: number; value: number }>
   utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }): Promise<E.Either<LedgerError, TxHash>> => {
@@ -62,6 +64,12 @@ export const send = async ({
         const allUtxos = await clientLedger.getUTXOs(sender)
         const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
         fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
+        if (fullSelectedUtxos.length !== selectedUtxos.length) {
+          return E.left({
+            errorId: LedgerErrorId.INVALID_RESPONSE,
+            msg: `Some selected BCH UTXOs are no longer available. Please refresh and retry.`
+          })
+        }
       }
 
       const result = await clientLedger.transferMax({
@@ -71,6 +79,23 @@ export const send = async ({
         feeRate,
         selectedUtxos: fullSelectedUtxos,
         utxoSelectionPreferences
+      })
+      if (!result?.hash) {
+        return E.left({
+          errorId: LedgerErrorId.INVALID_RESPONSE,
+          msg: `Post request to send BCH transaction using Ledger failed`
+        })
+      }
+      return E.right(result.hash)
+    }
+
+    // Use transferMax() when sendMax is true (user pressed "Max")
+    if (sendMax) {
+      const result = await clientLedger.transferMax({
+        walletIndex,
+        recipient,
+        memo,
+        feeRate
       })
       if (!result?.hash) {
         return E.left({

--- a/src/main/api/ledger/dash/transaction.ts
+++ b/src/main/api/ledger/dash/transaction.ts
@@ -30,7 +30,9 @@ export const send = async ({
   memo,
   walletAccount,
   walletIndex,
-  apiKey
+  apiKey,
+  selectedUtxos,
+  utxoSelectionPreferences
 }: {
   transport: Transport
   network: Network
@@ -42,6 +44,8 @@ export const send = async ({
   walletAccount: number
   walletIndex: number
   apiKey: string
+  selectedUtxos?: Array<{ hash: string; index: number; value: number }>
+  utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }): Promise<E.Either<LedgerError, TxHash>> => {
   if (!sender) {
     return E.left({
@@ -76,6 +80,34 @@ export const send = async ({
       network: network
     })
     const newMemo = memo !== undefined ? removeAffiliate(memo) : memo // removes affilaite to shorten memo.
+
+    // Ledger's transfer() doesn't accept selectedUtxos/utxoSelectionPreferences — use transferMax() for coin control
+    // IPC only sends {hash, index, value} identifiers; re-fetch full UTXOs (with witnessUtxo) from the data provider
+    if ((selectedUtxos && selectedUtxos.length > 0) || utxoSelectionPreferences) {
+      let fullSelectedUtxos
+      if (selectedUtxos && selectedUtxos.length > 0) {
+        const allUtxos = await dashClient.getUTXOs(sender)
+        const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
+        fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
+      }
+
+      const result = await dashClient.transferMax({
+        walletIndex,
+        recipient,
+        memo: newMemo,
+        feeRate,
+        selectedUtxos: fullSelectedUtxos,
+        utxoSelectionPreferences
+      })
+      if (!result?.hash) {
+        return E.left({
+          errorId: LedgerErrorId.INVALID_RESPONSE,
+          msg: `Post request to send DASH transaction using Ledger failed`
+        })
+      }
+      return E.right(result.hash)
+    }
+
     const txHash = await dashClient.transfer({
       asset: AssetDASH,
       recipient,

--- a/src/main/api/ledger/dash/transaction.ts
+++ b/src/main/api/ledger/dash/transaction.ts
@@ -31,6 +31,7 @@ export const send = async ({
   walletAccount,
   walletIndex,
   apiKey,
+  sendMax,
   selectedUtxos,
   utxoSelectionPreferences
 }: {
@@ -44,6 +45,7 @@ export const send = async ({
   walletAccount: number
   walletIndex: number
   apiKey: string
+  sendMax?: boolean
   selectedUtxos?: Array<{ hash: string; index: number; value: number }>
   utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }): Promise<E.Either<LedgerError, TxHash>> => {
@@ -89,6 +91,12 @@ export const send = async ({
         const allUtxos = await dashClient.getUTXOs(sender)
         const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
         fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
+        if (fullSelectedUtxos.length !== selectedUtxos.length) {
+          return E.left({
+            errorId: LedgerErrorId.INVALID_RESPONSE,
+            msg: `Some selected DASH UTXOs are no longer available. Please refresh and retry.`
+          })
+        }
       }
 
       const result = await dashClient.transferMax({
@@ -98,6 +106,23 @@ export const send = async ({
         feeRate,
         selectedUtxos: fullSelectedUtxos,
         utxoSelectionPreferences
+      })
+      if (!result?.hash) {
+        return E.left({
+          errorId: LedgerErrorId.INVALID_RESPONSE,
+          msg: `Post request to send DASH transaction using Ledger failed`
+        })
+      }
+      return E.right(result.hash)
+    }
+
+    // Use transferMax() when sendMax is true (user pressed "Max")
+    if (sendMax) {
+      const result = await dashClient.transferMax({
+        walletIndex,
+        recipient,
+        memo: newMemo,
+        feeRate
       })
       if (!result?.hash) {
         return E.left({

--- a/src/main/api/ledger/doge/transaction.ts
+++ b/src/main/api/ledger/doge/transaction.ts
@@ -24,6 +24,7 @@ export const send = async ({
   walletAccount,
   walletIndex,
   apiKey,
+  sendMax,
   selectedUtxos,
   utxoSelectionPreferences
 }: {
@@ -37,6 +38,7 @@ export const send = async ({
   walletAccount: number
   walletIndex: number
   apiKey: string
+  sendMax?: boolean
   selectedUtxos?: Array<{ hash: string; index: number; value: number }>
   utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }): Promise<E.Either<LedgerError, TxHash>> => {
@@ -86,6 +88,12 @@ export const send = async ({
         const allUtxos = await dogeClient.getUTXOs(sender)
         const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
         fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
+        if (fullSelectedUtxos.length !== selectedUtxos.length) {
+          return E.left({
+            errorId: LedgerErrorId.INVALID_RESPONSE,
+            msg: `Some selected DOGE UTXOs are no longer available. Please refresh and retry.`
+          })
+        }
       }
 
       const result = await dogeClient.transferMax({
@@ -95,6 +103,23 @@ export const send = async ({
         feeRate,
         selectedUtxos: fullSelectedUtxos,
         utxoSelectionPreferences
+      })
+      if (!result?.hash) {
+        return E.left({
+          errorId: LedgerErrorId.INVALID_RESPONSE,
+          msg: `Post request to send DOGE transaction using Ledger failed`
+        })
+      }
+      return E.right(result.hash)
+    }
+
+    // Use transferMax() when sendMax is true (user pressed "Max")
+    if (sendMax) {
+      const result = await dogeClient.transferMax({
+        walletIndex,
+        recipient,
+        memo: newMemo,
+        feeRate
       })
       if (!result?.hash) {
         return E.left({

--- a/src/main/api/ledger/doge/transaction.ts
+++ b/src/main/api/ledger/doge/transaction.ts
@@ -23,7 +23,9 @@ export const send = async ({
   memo,
   walletAccount,
   walletIndex,
-  apiKey
+  apiKey,
+  selectedUtxos,
+  utxoSelectionPreferences
 }: {
   transport: Transport
   network: Network
@@ -35,6 +37,8 @@ export const send = async ({
   walletAccount: number
   walletIndex: number
   apiKey: string
+  selectedUtxos?: Array<{ hash: string; index: number; value: number }>
+  utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }): Promise<E.Either<LedgerError, TxHash>> => {
   if (!sender) {
     return E.left({
@@ -73,6 +77,33 @@ export const send = async ({
       network: network
     })
     const newMemo = memo !== undefined ? removeAffiliate(memo) : memo // removes affiliate to shorten memo.
+
+    // Ledger's transfer() doesn't accept selectedUtxos/utxoSelectionPreferences — use transferMax() for coin control
+    // IPC only sends {hash, index, value} identifiers; re-fetch full UTXOs (with witnessUtxo) from the data provider
+    if ((selectedUtxos && selectedUtxos.length > 0) || utxoSelectionPreferences) {
+      let fullSelectedUtxos
+      if (selectedUtxos && selectedUtxos.length > 0) {
+        const allUtxos = await dogeClient.getUTXOs(sender)
+        const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
+        fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
+      }
+
+      const result = await dogeClient.transferMax({
+        walletIndex,
+        recipient,
+        memo: newMemo,
+        feeRate,
+        selectedUtxos: fullSelectedUtxos,
+        utxoSelectionPreferences
+      })
+      if (!result?.hash) {
+        return E.left({
+          errorId: LedgerErrorId.INVALID_RESPONSE,
+          msg: `Post request to send DOGE transaction using Ledger failed`
+        })
+      }
+      return E.right(result.hash)
+    }
 
     const txHash = await dogeClient.transfer({
       walletIndex,

--- a/src/main/api/ledger/litecoin/transaction.ts
+++ b/src/main/api/ledger/litecoin/transaction.ts
@@ -22,6 +22,7 @@ export const send = async ({
   walletAccount,
   walletIndex,
   apiKey,
+  sendMax,
   selectedUtxos,
   utxoSelectionPreferences
 }: {
@@ -36,6 +37,7 @@ export const send = async ({
   walletAccount: number
   walletIndex: number
   apiKey: string
+  sendMax?: boolean
   selectedUtxos?: Array<{ hash: string; index: number; value: number }>
   utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }): Promise<E.Either<LedgerError, TxHash>> => {
@@ -91,6 +93,12 @@ export const send = async ({
         const allUtxos = await clientLedger.getUTXOs(sender)
         const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
         fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
+        if (fullSelectedUtxos.length !== selectedUtxos.length) {
+          return E.left({
+            errorId: LedgerErrorId.INVALID_RESPONSE,
+            msg: `Some selected LTC UTXOs are no longer available. Please refresh and retry.`
+          })
+        }
       }
 
       const result = await clientLedger.transferMax({
@@ -100,6 +108,23 @@ export const send = async ({
         feeRate,
         selectedUtxos: fullSelectedUtxos,
         utxoSelectionPreferences
+      })
+      if (!result?.hash) {
+        return E.left({
+          errorId: LedgerErrorId.INVALID_RESPONSE,
+          msg: `Post request to send LTC transaction using Ledger failed`
+        })
+      }
+      return E.right(result.hash)
+    }
+
+    // Use transferMax() when sendMax is true (user pressed "Max")
+    if (sendMax) {
+      const result = await clientLedger.transferMax({
+        walletIndex,
+        recipient,
+        memo,
+        feeRate
       })
       if (!result?.hash) {
         return E.left({

--- a/src/main/api/ledger/litecoin/transaction.ts
+++ b/src/main/api/ledger/litecoin/transaction.ts
@@ -21,7 +21,9 @@ export const send = async ({
   memo,
   walletAccount,
   walletIndex,
-  apiKey
+  apiKey,
+  selectedUtxos,
+  utxoSelectionPreferences
 }: {
   transport: Transport
   network: Network
@@ -34,6 +36,8 @@ export const send = async ({
   walletAccount: number
   walletIndex: number
   apiKey: string
+  selectedUtxos?: Array<{ hash: string; index: number; value: number }>
+  utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
 }): Promise<E.Either<LedgerError, TxHash>> => {
   if (!sender) {
     return E.left({
@@ -78,6 +82,34 @@ export const send = async ({
 
     const fee = await clientLedger.getFeesWithRates({ sender, memo })
     const feeRate = fee.rates[feeOption]
+
+    // Ledger's transfer() doesn't accept selectedUtxos/utxoSelectionPreferences — use transferMax() for coin control
+    // IPC only sends {hash, index, value} identifiers; re-fetch full UTXOs (with witnessUtxo) from the data provider
+    if ((selectedUtxos && selectedUtxos.length > 0) || utxoSelectionPreferences) {
+      let fullSelectedUtxos
+      if (selectedUtxos && selectedUtxos.length > 0) {
+        const allUtxos = await clientLedger.getUTXOs(sender)
+        const selectedSet = new Set(selectedUtxos.map((u) => `${u.hash}:${u.index}`))
+        fullSelectedUtxos = allUtxos.filter((u) => selectedSet.has(`${u.hash}:${u.index}`))
+      }
+
+      const result = await clientLedger.transferMax({
+        walletIndex,
+        recipient,
+        memo,
+        feeRate,
+        selectedUtxos: fullSelectedUtxos,
+        utxoSelectionPreferences
+      })
+      if (!result?.hash) {
+        return E.left({
+          errorId: LedgerErrorId.INVALID_RESPONSE,
+          msg: `Post request to send LTC transaction using Ledger failed`
+        })
+      }
+      return E.right(result.hash)
+    }
+
     const txHash = await clientLedger.transfer({
       walletIndex,
       asset: AssetLTC,

--- a/src/main/api/ledger/transaction.ts
+++ b/src/main/api/ledger/transaction.ts
@@ -348,7 +348,9 @@ export const sendTx = async ({
   destinationTag,
   evmRpcUrl,
   gasMultiplier,
-  sendMax
+  sendMax,
+  selectedUtxos,
+  utxoSelectionPreferences
 }: IPCLedgerSendTxParams): Promise<E.Either<LedgerError, TxHash>> => {
   try {
     const transport = await TransportNodeHidSingleton.default.create()
@@ -389,7 +391,9 @@ export const sendTx = async ({
       destinationTag,
       evmRpcUrl,
       gasMultiplier,
-      sendMax
+      sendMax,
+      selectedUtxos,
+      utxoSelectionPreferences
     })
     await transport.close()
     return res

--- a/src/renderer/components/wallet/txs/send/SendForm.tsx
+++ b/src/renderer/components/wallet/txs/send/SendForm.tsx
@@ -317,9 +317,7 @@ export const SendForm = (props: Props): JSX.Element => {
     if (!isManualWithSelection) {
       // Reset isSendMax when coin control is not in manual-with-selection mode
       // to prevent stale max-send behavior on subsequent submits
-      if (isUTXOChain && isSendMax) {
-        setIsSendMax(false)
-      }
+      setIsSendMax(false)
       return
     }
 
@@ -334,7 +332,7 @@ export const SendForm = (props: Props): JSX.Element => {
     setAmountToSend(netAmount)
     setValue('amount', baseToAsset(netAmount).amount())
     setIsSendMax(true)
-  }, [coinControlState, isUTXOChain, selectedFee, balance.amount.decimal, setValue, isSendMax])
+  }, [coinControlState, isUTXOChain, selectedFee, balance.amount.decimal, setValue])
 
   const oAssetAmount: O.Option<BaseAmount> = useMemo(() => {
     if (isEVMChain) {
@@ -1502,14 +1500,11 @@ export const SendForm = (props: Props): JSX.Element => {
               chain={effectiveChain}
               asset={asset}
               address={walletAddress}
-              walletType={walletType}
               disabled={isLoading}
               targetAmount={FP.pipe(
                 selectedFee,
                 O.map((fee) => {
-                  const sendAmt = isEVMChain
-                    ? O.getOrElse(() => ZERO_BASE_AMOUNT)(amountToSend as O.Option<BaseAmount>)
-                    : (amountToSend as BaseAmount)
+                  const sendAmt = amountToSend as BaseAmount
                   return sendAmt.amount().toNumber() + fee.amount().toNumber()
                 }),
                 O.toUndefined

--- a/src/renderer/components/wallet/txs/send/coinControl/CoinControlPanel.tsx
+++ b/src/renderer/components/wallet/txs/send/coinControl/CoinControlPanel.tsx
@@ -2,11 +2,10 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { Address, AnyAsset, Chain } from '@xchainjs/xchain-util'
+
 import type { UTXO } from '@xchainjs/xchain-utxo-providers'
 import { useIntl } from 'react-intl'
 
-import { isKeystoreWallet } from '../../../../../../shared/utils/guard'
-import { WalletType } from '../../../../../../shared/wallet/types'
 import { utxosByChain$, UTXOsRD } from '../../../../../services/utxo/coinControl'
 import {
   CoinControlStrategy,
@@ -23,21 +22,12 @@ type Props = {
   chain: Chain
   asset: AnyAsset
   address: Address
-  walletType: WalletType
   disabled: boolean
   targetAmount?: number
   onChange: (state: CoinControlState) => void
 }
 
-export const CoinControlPanel = ({
-  chain,
-  asset,
-  address,
-  walletType,
-  disabled,
-  targetAmount,
-  onChange
-}: Props): JSX.Element => {
+export const CoinControlPanel = ({ chain, asset, address, disabled, targetAmount, onChange }: Props): JSX.Element => {
   const intl = useIntl()
 
   const [isOpen, setIsOpen] = useState(false)
@@ -46,7 +36,6 @@ export const CoinControlPanel = ({
   const [utxosRD, setUtxosRD] = useState<UTXOsRD>(RD.initial)
 
   const isManual = strategy === CoinControlStrategy.MANUAL
-  const manualDisabled = !isKeystoreWallet(walletType)
 
   // Fetch UTXOs when panel is opened
   useEffect(() => {
@@ -69,8 +58,8 @@ export const CoinControlPanel = ({
       isEnabled: true
     })
 
-    // We intentionally don't include onChange in deps to avoid re-render loop.
-    // The parent sets onChange via useCallback and it stays stable.
+    // onChange is a useState setter (setCoinControlState) and is inherently stable,
+    // so we intentionally omit it from deps to avoid unnecessary re-renders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, strategy, selectedUtxos, isManual])
 
@@ -110,12 +99,7 @@ export const CoinControlPanel = ({
     <div className="mt-2">
       <Collapse header={header} isOpen={isOpen} onToggle={() => setIsOpen((prev) => !prev)}>
         <div className="flex flex-col gap-3 px-4 pb-4">
-          <StrategySelector
-            strategy={strategy}
-            onChange={handleStrategyChange}
-            manualDisabled={manualDisabled}
-            disabled={disabled}
-          />
+          <StrategySelector strategy={strategy} onChange={handleStrategyChange} disabled={disabled} />
 
           {isManual && (
             <UTXOList

--- a/src/renderer/components/wallet/txs/send/coinControl/StrategySelector.tsx
+++ b/src/renderer/components/wallet/txs/send/coinControl/StrategySelector.tsx
@@ -7,7 +7,6 @@ import { Radio, RadioGroup } from '../../../../uielements/radio'
 type Props = {
   strategy: CoinControlStrategy
   onChange: (strategy: CoinControlStrategy) => void
-  manualDisabled: boolean
   disabled: boolean
 }
 
@@ -19,7 +18,7 @@ const STRATEGY_I18N: Record<CoinControlStrategy, string> = {
   [CoinControlStrategy.SMALLEST_FIRST]: 'wallet.send.coinControl.smallestFirst'
 }
 
-export const StrategySelector = ({ strategy, onChange, manualDisabled, disabled }: Props): JSX.Element => {
+export const StrategySelector = ({ strategy, onChange, disabled }: Props): JSX.Element => {
   const intl = useIntl()
 
   return (
@@ -28,25 +27,13 @@ export const StrategySelector = ({ strategy, onChange, manualDisabled, disabled 
         {intl.formatMessage({ id: 'wallet.send.coinControl.strategy' })}
       </Label>
       <RadioGroup className="flex flex-row flex-wrap gap-2" value={strategy} onChange={onChange} disabled={disabled}>
-        {Object.values(CoinControlStrategy).map((s) => {
-          const isManual = s === CoinControlStrategy.MANUAL
-          const isDisabledOption = isManual && manualDisabled
-
-          return (
-            <Radio value={s} key={s} disabled={isDisabledOption}>
-              <span
-                title={
-                  isDisabledOption
-                    ? intl.formatMessage({ id: 'wallet.send.coinControl.manualKeystoreOnly' })
-                    : undefined
-                }>
-                <Label disabled={disabled || isDisabledOption} textTransform="uppercase">
-                  {intl.formatMessage({ id: STRATEGY_I18N[s] })}
-                </Label>
-              </span>
-            </Radio>
-          )
-        })}
+        {Object.values(CoinControlStrategy).map((s) => (
+          <Radio value={s} key={s}>
+            <Label disabled={disabled} textTransform="uppercase">
+              {intl.formatMessage({ id: STRATEGY_I18N[s] })}
+            </Label>
+          </Radio>
+        ))}
       </RadioGroup>
     </div>
   )

--- a/src/renderer/components/wallet/txs/send/coinControl/UTXOList.tsx
+++ b/src/renderer/components/wallet/txs/send/coinControl/UTXOList.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react'
+
 import * as RD from '@devexperts/remote-data-ts'
 import type { AnyAsset } from '@xchainjs/xchain-util'
 import type { UTXO } from '@xchainjs/xchain-utxo-providers'
@@ -18,7 +20,10 @@ type Props = {
 export const UTXOList = ({ utxosRD, asset, selectedUtxos, disabled, onToggle }: Props): JSX.Element => {
   const intl = useIntl()
 
-  const isSelected = (utxo: UTXO): boolean => selectedUtxos.some((s) => s.hash === utxo.hash && s.index === utxo.index)
+  const isSelected = useCallback(
+    (utxo: UTXO): boolean => selectedUtxos.some((s) => s.hash === utxo.hash && s.index === utxo.index),
+    [selectedUtxos]
+  )
 
   return FP.pipe(
     utxosRD,

--- a/src/renderer/i18n/de/wallet.ts
+++ b/src/renderer/i18n/de/wallet.ts
@@ -126,17 +126,15 @@ const wallet: WalletMessages = {
   'wallet.derivationPath.taproot': 'Taproot P2TR',
   'wallet.ledger.fetchDescription': 'Adresse von Ihrem Hardware-Wallet abrufen',
   'wallet.send.coinControl': 'Coin Control',
-  'wallet.send.coinControl.strategy': 'Selection Strategy',
-  'wallet.send.coinControl.auto': 'Automatic',
-  'wallet.send.coinControl.manual': 'Manual',
-  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
-  'wallet.send.coinControl.largestFirst': 'Largest First',
-  'wallet.send.coinControl.smallestFirst': 'Smallest First',
-  'wallet.send.coinControl.selected': '{count} UTXOs selected',
-  'wallet.send.coinControl.totalSelected': 'Total Selected',
-  'wallet.send.coinControl.change': 'Change',
-  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
-  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
+  'wallet.send.coinControl.strategy': 'Auswahlstrategie',
+  'wallet.send.coinControl.auto': 'Automatisch',
+  'wallet.send.coinControl.manual': 'Manuell',
+  'wallet.send.coinControl.minimizeFee': 'Gebühren minimieren',
+  'wallet.send.coinControl.largestFirst': 'Größte zuerst',
+  'wallet.send.coinControl.smallestFirst': 'Kleinste zuerst',
+  'wallet.send.coinControl.selected': '{count} UTXOs ausgewählt',
+  'wallet.send.coinControl.totalSelected': 'Gesamt ausgewählt',
+  'wallet.send.coinControl.insufficient': 'Ausgewählte UTXOs reichen nicht für Betrag + Gebühren'
 }
 
 export default wallet

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -129,9 +129,7 @@ const wallet: WalletMessages = {
   'wallet.send.coinControl.smallestFirst': 'Smallest First',
   'wallet.send.coinControl.selected': '{count} UTXOs selected',
   'wallet.send.coinControl.totalSelected': 'Total Selected',
-  'wallet.send.coinControl.change': 'Change',
-  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
-  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
+  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee'
 }
 
 export default wallet

--- a/src/renderer/i18n/es/wallet.ts
+++ b/src/renderer/i18n/es/wallet.ts
@@ -122,17 +122,15 @@ const wallet: WalletMessages = {
   'wallet.derivationPath.taproot': 'Taproot P2TR',
   'wallet.ledger.fetchDescription': 'Obtener dirección de tu billetera de hardware',
   'wallet.send.coinControl': 'Coin Control',
-  'wallet.send.coinControl.strategy': 'Selection Strategy',
-  'wallet.send.coinControl.auto': 'Automatic',
+  'wallet.send.coinControl.strategy': 'Estrategia de selección',
+  'wallet.send.coinControl.auto': 'Automático',
   'wallet.send.coinControl.manual': 'Manual',
-  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
-  'wallet.send.coinControl.largestFirst': 'Largest First',
-  'wallet.send.coinControl.smallestFirst': 'Smallest First',
-  'wallet.send.coinControl.selected': '{count} UTXOs selected',
-  'wallet.send.coinControl.totalSelected': 'Total Selected',
-  'wallet.send.coinControl.change': 'Change',
-  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
-  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
+  'wallet.send.coinControl.minimizeFee': 'Minimizar comisión',
+  'wallet.send.coinControl.largestFirst': 'Mayor primero',
+  'wallet.send.coinControl.smallestFirst': 'Menor primero',
+  'wallet.send.coinControl.selected': '{count} UTXOs seleccionados',
+  'wallet.send.coinControl.totalSelected': 'Total seleccionado',
+  'wallet.send.coinControl.insufficient': 'Los UTXOs seleccionados son insuficientes para el importe + comisión'
 }
 
 export default wallet

--- a/src/renderer/i18n/fr/wallet.ts
+++ b/src/renderer/i18n/fr/wallet.ts
@@ -123,17 +123,15 @@ const wallet: WalletMessages = {
   'wallet.derivationPath.taproot': 'Taproot P2TR',
   'wallet.ledger.fetchDescription': "Obtenir l'adresse de votre portefeuille matériel",
   'wallet.send.coinControl': 'Coin Control',
-  'wallet.send.coinControl.strategy': 'Selection Strategy',
-  'wallet.send.coinControl.auto': 'Automatic',
-  'wallet.send.coinControl.manual': 'Manual',
-  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
-  'wallet.send.coinControl.largestFirst': 'Largest First',
-  'wallet.send.coinControl.smallestFirst': 'Smallest First',
-  'wallet.send.coinControl.selected': '{count} UTXOs selected',
-  'wallet.send.coinControl.totalSelected': 'Total Selected',
-  'wallet.send.coinControl.change': 'Change',
-  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
-  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
+  'wallet.send.coinControl.strategy': 'Stratégie de sélection',
+  'wallet.send.coinControl.auto': 'Automatique',
+  'wallet.send.coinControl.manual': 'Manuel',
+  'wallet.send.coinControl.minimizeFee': 'Minimiser les frais',
+  'wallet.send.coinControl.largestFirst': 'Plus grands en premier',
+  'wallet.send.coinControl.smallestFirst': 'Plus petits en premier',
+  'wallet.send.coinControl.selected': '{count} UTXOs sélectionnés',
+  'wallet.send.coinControl.totalSelected': 'Total sélectionné',
+  'wallet.send.coinControl.insufficient': 'Les UTXOs sélectionnés sont insuffisants pour le montant + les frais'
 }
 
 export default wallet

--- a/src/renderer/i18n/hi/wallet.ts
+++ b/src/renderer/i18n/hi/wallet.ts
@@ -123,17 +123,15 @@ const wallet: WalletMessages = {
   'wallet.derivationPath.taproot': 'Taproot P2TR',
   'wallet.ledger.fetchDescription': 'अपने हार्डवेयर वॉलेट से पता प्राप्त करें',
   'wallet.send.coinControl': 'Coin Control',
-  'wallet.send.coinControl.strategy': 'Selection Strategy',
-  'wallet.send.coinControl.auto': 'Automatic',
-  'wallet.send.coinControl.manual': 'Manual',
-  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
-  'wallet.send.coinControl.largestFirst': 'Largest First',
-  'wallet.send.coinControl.smallestFirst': 'Smallest First',
-  'wallet.send.coinControl.selected': '{count} UTXOs selected',
-  'wallet.send.coinControl.totalSelected': 'Total Selected',
-  'wallet.send.coinControl.change': 'Change',
-  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
-  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
+  'wallet.send.coinControl.strategy': 'चयन रणनीति',
+  'wallet.send.coinControl.auto': 'स्वचालित',
+  'wallet.send.coinControl.manual': 'मैन्युअल',
+  'wallet.send.coinControl.minimizeFee': 'शुल्क न्यूनतम करें',
+  'wallet.send.coinControl.largestFirst': 'सबसे बड़ा पहले',
+  'wallet.send.coinControl.smallestFirst': 'सबसे छोटा पहले',
+  'wallet.send.coinControl.selected': '{count} UTXOs चयनित',
+  'wallet.send.coinControl.totalSelected': 'कुल चयनित',
+  'wallet.send.coinControl.insufficient': 'चयनित UTXOs राशि + शुल्क के लिए अपर्याप्त हैं'
 }
 
 export default wallet

--- a/src/renderer/i18n/ko/wallet.ts
+++ b/src/renderer/i18n/ko/wallet.ts
@@ -122,17 +122,15 @@ const wallet: WalletMessages = {
   'wallet.derivationPath.taproot': 'Taproot P2TR',
   'wallet.ledger.fetchDescription': '하드웨어 지갑에서 주소 가져오기',
   'wallet.send.coinControl': 'Coin Control',
-  'wallet.send.coinControl.strategy': 'Selection Strategy',
-  'wallet.send.coinControl.auto': 'Automatic',
-  'wallet.send.coinControl.manual': 'Manual',
-  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
-  'wallet.send.coinControl.largestFirst': 'Largest First',
-  'wallet.send.coinControl.smallestFirst': 'Smallest First',
-  'wallet.send.coinControl.selected': '{count} UTXOs selected',
-  'wallet.send.coinControl.totalSelected': 'Total Selected',
-  'wallet.send.coinControl.change': 'Change',
-  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
-  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
+  'wallet.send.coinControl.strategy': '선택 전략',
+  'wallet.send.coinControl.auto': '자동',
+  'wallet.send.coinControl.manual': '수동',
+  'wallet.send.coinControl.minimizeFee': '수수료 최소화',
+  'wallet.send.coinControl.largestFirst': '큰 금액 우선',
+  'wallet.send.coinControl.smallestFirst': '작은 금액 우선',
+  'wallet.send.coinControl.selected': '{count}개 UTXOs 선택됨',
+  'wallet.send.coinControl.totalSelected': '선택된 총액',
+  'wallet.send.coinControl.insufficient': '선택된 UTXOs가 금액 + 수수료에 부족합니다'
 }
 
 export default wallet

--- a/src/renderer/i18n/ru/wallet.ts
+++ b/src/renderer/i18n/ru/wallet.ts
@@ -123,17 +123,15 @@ const wallet: WalletMessages = {
   'wallet.derivationPath.taproot': 'Taproot P2TR',
   'wallet.ledger.fetchDescription': 'Получить адрес с вашего аппаратного кошелька',
   'wallet.send.coinControl': 'Coin Control',
-  'wallet.send.coinControl.strategy': 'Selection Strategy',
-  'wallet.send.coinControl.auto': 'Automatic',
-  'wallet.send.coinControl.manual': 'Manual',
-  'wallet.send.coinControl.minimizeFee': 'Minimize Fee',
-  'wallet.send.coinControl.largestFirst': 'Largest First',
-  'wallet.send.coinControl.smallestFirst': 'Smallest First',
-  'wallet.send.coinControl.selected': '{count} UTXOs selected',
-  'wallet.send.coinControl.totalSelected': 'Total Selected',
-  'wallet.send.coinControl.change': 'Change',
-  'wallet.send.coinControl.insufficient': 'Selected UTXOs insufficient for amount + fee',
-  'wallet.send.coinControl.manualKeystoreOnly': 'Manual selection available for Keystore wallets only'
+  'wallet.send.coinControl.strategy': 'Стратегия выбора',
+  'wallet.send.coinControl.auto': 'Автоматически',
+  'wallet.send.coinControl.manual': 'Вручную',
+  'wallet.send.coinControl.minimizeFee': 'Минимизировать комиссию',
+  'wallet.send.coinControl.largestFirst': 'Сначала крупные',
+  'wallet.send.coinControl.smallestFirst': 'Сначала мелкие',
+  'wallet.send.coinControl.selected': '{count} UTXOs выбрано',
+  'wallet.send.coinControl.totalSelected': 'Итого выбрано',
+  'wallet.send.coinControl.insufficient': 'Выбранных UTXOs недостаточно для суммы + комиссии'
 }
 
 export default wallet

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -438,9 +438,7 @@ type WalletMessageKey =
   | 'wallet.send.coinControl.smallestFirst'
   | 'wallet.send.coinControl.selected'
   | 'wallet.send.coinControl.totalSelected'
-  | 'wallet.send.coinControl.change'
   | 'wallet.send.coinControl.insufficient'
-  | 'wallet.send.coinControl.manualKeystoreOnly'
   | 'wallet.ledger.fetchDescription'
 
 export type WalletMessages = { [key in WalletMessageKey]: string }

--- a/src/renderer/services/bitcoin/index.ts
+++ b/src/renderer/services/bitcoin/index.ts
@@ -18,6 +18,7 @@ const { subscribeTx, txRD$, resetTx, sendTx, txs$, tx$, txStatus$ } = createTran
 const { fees$, reloadFees, feesWithRates$, reloadFeesWithRates } = createFeesService(combinedClient$)
 
 export {
+  combinedClient$,
   client$,
   clientState$,
   explorerUrl$,

--- a/src/renderer/services/bitcoin/transaction.ts
+++ b/src/renderer/services/bitcoin/transaction.ts
@@ -44,7 +44,20 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
 
   const sendLedgerTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD => {
-    const { amount, sender, recipient, memo, walletAccount, walletIndex, feeRate, feeOption, hdMode, sendMax } = params
+    const {
+      amount,
+      sender,
+      recipient,
+      memo,
+      walletAccount,
+      walletIndex,
+      feeRate,
+      feeOption,
+      hdMode,
+      sendMax,
+      selectedUtxos,
+      utxoSelectionPreferences
+    } = params
     const sendLedgerTxParams: IPCLedgerSendTxParams = {
       chain: BTCChain,
       asset: AssetBTC,
@@ -65,7 +78,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       destinationTag: undefined,
       evmRpcUrl: undefined,
       gasMultiplier: undefined,
-      sendMax
+      sendMax,
+      selectedUtxos: selectedUtxos?.map(({ hash, index, value }) => ({ hash, index, value })),
+      utxoSelectionPreferences
     }
 
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)

--- a/src/renderer/services/bitcoincash/index.ts
+++ b/src/renderer/services/bitcoincash/index.ts
@@ -18,6 +18,7 @@ const { fees$, feesWithRates$, reloadFees, reloadFeesWithRates } = createFeesSer
 const { txs$, tx$, txStatus$, subscribeTx, resetTx, sendTx, txRD$ } = createTransactionService(client$, network$)
 
 export {
+  combinedClient$,
   client$,
   clientState$,
   explorerUrl$,

--- a/src/renderer/services/bitcoincash/transaction.ts
+++ b/src/renderer/services/bitcoincash/transaction.ts
@@ -43,7 +43,20 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
 
   const sendLedgerTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD => {
-    const { amount, sender, recipient, memo, walletAccount, walletIndex, feeRate, feeOption, hdMode, sendMax } = params
+    const {
+      amount,
+      sender,
+      recipient,
+      memo,
+      walletAccount,
+      walletIndex,
+      feeRate,
+      feeOption,
+      hdMode,
+      sendMax,
+      selectedUtxos,
+      utxoSelectionPreferences
+    } = params
     const sendLedgerTxParams: IPCLedgerSendTxParams = {
       chain: BCHChain,
       asset: AssetBCH,
@@ -64,7 +77,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       destinationTag: undefined,
       evmRpcUrl: undefined,
       gasMultiplier: undefined,
-      sendMax
+      sendMax,
+      selectedUtxos: selectedUtxos?.map(({ hash, index, value }) => ({ hash, index, value })),
+      utxoSelectionPreferences
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -8,10 +8,10 @@ import * as Rx from 'rxjs'
 
 import { WalletType, WalletAddress, HDMode } from '../../../shared/wallet/types'
 import { LiveData } from '../../helpers/rx/liveData'
-import type { UtxoSelectionPreferences } from '../utxo/coinControl.types'
 import { AssetWithDecimal, AssetWithAmount } from '../../types/asgardex'
 import { PoolAddress } from '../midgard/midgardTypes'
 import { TxStagesRD } from '../thorchain/types'
+import type { UtxoSelectionPreferences } from '../utxo/coinControl.types'
 import { ApiError, TxHashRD } from '../wallet/types'
 
 export type TxTypes = 'DEPOSIT' | 'SWAP' | 'WITHDRAW' | 'APPROVE' | 'SEND'

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -8,6 +8,7 @@ import * as Rx from 'rxjs'
 
 import { WalletType, WalletAddress, HDMode } from '../../../shared/wallet/types'
 import { LiveData } from '../../helpers/rx/liveData'
+import type { UtxoSelectionPreferences } from '../utxo/coinControl.types'
 import { AssetWithDecimal, AssetWithAmount } from '../../types/asgardex'
 import { PoolAddress } from '../midgard/midgardTypes'
 import { TxStagesRD } from '../thorchain/types'
@@ -110,7 +111,7 @@ export type SendTxParams = {
   destinationTag?: number
   sendMax?: boolean
   selectedUtxos?: UTXO[]
-  utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
+  utxoSelectionPreferences?: UtxoSelectionPreferences
 }
 
 export type SendPoolTxParams = SendTxParams & {

--- a/src/renderer/services/dash/index.ts
+++ b/src/renderer/services/dash/index.ts
@@ -18,6 +18,7 @@ const { subscribeTx, txRD$, resetTx, sendTx, txs$, tx$, txStatus$ } = createTran
 const { fees$, reloadFees, feesWithRates$, reloadFeesWithRates } = createFeesService(combinedClient$)
 
 export {
+  combinedClient$,
   client$,
   clientState$,
   explorerUrl$,

--- a/src/renderer/services/dash/transaction.ts
+++ b/src/renderer/services/dash/transaction.ts
@@ -58,7 +58,19 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
 
   const sendLedgerTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD => {
-    const { amount, sender, recipient, memo, walletIndex, feeRate, walletAccount, hdMode, sendMax } = params
+    const {
+      amount,
+      sender,
+      recipient,
+      memo,
+      walletIndex,
+      feeRate,
+      walletAccount,
+      hdMode,
+      sendMax,
+      selectedUtxos,
+      utxoSelectionPreferences
+    } = params
     const sendLedgerTxParams: IPCLedgerSendTxParams = {
       chain: DASHChain,
       asset: AssetDASH,
@@ -79,7 +91,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       destinationTag: undefined,
       evmRpcUrl: undefined,
       gasMultiplier: undefined,
-      sendMax
+      sendMax,
+      selectedUtxos: selectedUtxos?.map(({ hash, index, value }) => ({ hash, index, value })),
+      utxoSelectionPreferences
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
     return FP.pipe(

--- a/src/renderer/services/doge/index.ts
+++ b/src/renderer/services/doge/index.ts
@@ -18,6 +18,7 @@ const { subscribeTx, txRD$, resetTx, sendTx, txs$, tx$, txStatus$ } = createTran
 const { fees$, reloadFees, feesWithRates$, reloadFeesWithRates } = createFeesService(combinedClient$)
 
 export {
+  combinedClient$,
   address$,
   addressUI$,
   explorerUrl$,

--- a/src/renderer/services/doge/transaction.ts
+++ b/src/renderer/services/doge/transaction.ts
@@ -44,7 +44,19 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
 
   const sendLedgerTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD => {
-    const { amount, sender, recipient, memo, walletIndex, feeRate, walletAccount, hdMode, sendMax } = params
+    const {
+      amount,
+      sender,
+      recipient,
+      memo,
+      walletIndex,
+      feeRate,
+      walletAccount,
+      hdMode,
+      sendMax,
+      selectedUtxos,
+      utxoSelectionPreferences
+    } = params
     const sendLedgerTxParams: IPCLedgerSendTxParams = {
       chain: DOGEChain,
       asset: AssetDOGE,
@@ -65,7 +77,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       destinationTag: undefined,
       evmRpcUrl: undefined,
       gasMultiplier: undefined,
-      sendMax
+      sendMax,
+      selectedUtxos: selectedUtxos?.map(({ hash, index, value }) => ({ hash, index, value })),
+      utxoSelectionPreferences
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/litecoin/index.ts
+++ b/src/renderer/services/litecoin/index.ts
@@ -18,6 +18,7 @@ const { txs$, tx$, txStatus$, subscribeTx, resetTx, sendTx, txRD$ } = createTran
 const { reloadFees, fees$, feesWithRates$, reloadFeesWithRates } = createFeesService(combinedClient$)
 
 export {
+  combinedClient$,
   client$,
   clientState$,
   address$,

--- a/src/renderer/services/litecoin/transaction.ts
+++ b/src/renderer/services/litecoin/transaction.ts
@@ -44,7 +44,20 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
 
   const sendLedgerTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD => {
-    const { amount, sender, recipient, memo, walletAccount, walletIndex, feeRate, feeOption, hdMode, sendMax } = params
+    const {
+      amount,
+      sender,
+      recipient,
+      memo,
+      walletAccount,
+      walletIndex,
+      feeRate,
+      feeOption,
+      hdMode,
+      sendMax,
+      selectedUtxos,
+      utxoSelectionPreferences
+    } = params
     const sendLedgerTxParams: IPCLedgerSendTxParams = {
       chain: LTCChain,
       asset: AssetLTC,
@@ -65,7 +78,9 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       destinationTag: undefined,
       evmRpcUrl: undefined,
       gasMultiplier: undefined,
-      sendMax
+      sendMax,
+      selectedUtxos: selectedUtxos?.map(({ hash, index, value }) => ({ hash, index, value })),
+      utxoSelectionPreferences
     }
     const encoded = ipcLedgerSendTxParamsIO.encode(sendLedgerTxParams)
 

--- a/src/renderer/services/utxo/coinControl.ts
+++ b/src/renderer/services/utxo/coinControl.ts
@@ -1,11 +1,11 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { BTCChain } from '@xchainjs/xchain-bitcoin'
 import { BCHChain } from '@xchainjs/xchain-bitcoincash'
-import { XChainClient } from '@xchainjs/xchain-client'
 import { DASHChain } from '@xchainjs/xchain-dash'
 import { DOGEChain } from '@xchainjs/xchain-doge'
 import { LTCChain } from '@xchainjs/xchain-litecoin'
 import { Address, Chain } from '@xchainjs/xchain-util'
+import { Client as UTXOClient } from '@xchainjs/xchain-utxo'
 import type { UTXO } from '@xchainjs/xchain-utxo-providers'
 import { ZECChain } from '@xchainjs/xchain-zcash'
 import { function as FP, option as O } from 'fp-ts'
@@ -26,16 +26,15 @@ export type UTXOsLD = LiveData<Error, UTXO[]>
 /**
  * Fetch UTXOs for a given address using the chain client's getUTXOs method
  */
-const getUTXOs$ = (client$: Rx.Observable<O.Option<XChainClient>>, address: Address): UTXOsLD =>
+const getUTXOs$ = (client$: Rx.Observable<O.Option<UTXOClient>>, address: Address): UTXOsLD =>
   FP.pipe(
     client$,
     RxOp.switchMap(
-      O.fold<XChainClient, UTXOsLD>(
+      O.fold<UTXOClient, UTXOsLD>(
         () => Rx.of(RD.initial),
         (client) =>
           FP.pipe(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            Rx.from((client as any).getUTXOs(address, false) as Promise<UTXO[]>),
+            Rx.from(client.getUTXOs(address, false)),
             RxOp.map((utxos) => RD.success(utxos)),
             RxOp.catchError((e: Error) => Rx.of(RD.failure(e))),
             RxOp.startWith(RD.pending)
@@ -50,17 +49,17 @@ const getUTXOs$ = (client$: Rx.Observable<O.Option<XChainClient>>, address: Addr
 export const utxosByChain$ = (chain: Chain, address: Address): UTXOsLD => {
   switch (chain) {
     case BTCChain:
-      return getUTXOs$(BTC.client$, address)
+      return getUTXOs$(BTC.combinedClient$, address)
     case LTCChain:
-      return getUTXOs$(LTC.client$, address)
+      return getUTXOs$(LTC.combinedClient$, address)
     case DOGEChain:
-      return getUTXOs$(DOGE.client$, address)
+      return getUTXOs$(DOGE.combinedClient$, address)
     case BCHChain:
-      return getUTXOs$(BCH.client$, address)
+      return getUTXOs$(BCH.combinedClient$, address)
     case DASHChain:
-      return getUTXOs$(DASH.client$, address)
+      return getUTXOs$(DASH.combinedClient$, address)
     case ZECChain:
-      return getUTXOs$(ZEC.client$, address)
+      return getUTXOs$(ZEC.combinedClient$, address)
     default:
       return Rx.of(RD.failure(new Error(`${chain} is not a UTXO chain`)))
   }

--- a/src/renderer/services/utxo/coinControl.types.ts
+++ b/src/renderer/services/utxo/coinControl.types.ts
@@ -20,12 +20,16 @@ export const INITIAL_COIN_CONTROL_STATE: CoinControlState = {
   isEnabled: false
 }
 
+export type UtxoSelectionPreferences = {
+  minimizeFee?: boolean
+  minimizeInputs?: boolean
+  consolidateSmallUtxos?: boolean
+}
+
 /**
  * Maps CoinControlStrategy to xchainjs UtxoSelectionPreferences
  */
-export const strategyToPreferences = (
-  strategy: CoinControlStrategy
-): { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean } | undefined => {
+export const strategyToPreferences = (strategy: CoinControlStrategy): UtxoSelectionPreferences | undefined => {
   switch (strategy) {
     case CoinControlStrategy.MINIMIZE_FEE:
       return { minimizeFee: true }

--- a/src/renderer/services/utxo/types.ts
+++ b/src/renderer/services/utxo/types.ts
@@ -7,6 +7,7 @@ import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { LiveData } from '../../helpers/rx/liveData'
 import { Memo } from '../chain/types'
 import * as C from '../clients'
+import type { UtxoSelectionPreferences } from './coinControl.types'
 
 export type FeesWithRatesRD = RD.RemoteData<Error, FeesWithRates>
 export type FeesWithRatesLD = LiveData<Error, FeesWithRates>
@@ -25,7 +26,7 @@ export type SendTxParams = {
   hdMode: HDMode
   sendMax?: boolean
   selectedUtxos?: UTXO[]
-  utxoSelectionPreferences?: { minimizeFee?: boolean; minimizeInputs?: boolean; consolidateSmallUtxos?: boolean }
+  utxoSelectionPreferences?: UtxoSelectionPreferences
 }
 
 export type TransactionService = C.TransactionService<SendTxParams>

--- a/src/renderer/services/zcash/index.ts
+++ b/src/renderer/services/zcash/index.ts
@@ -18,6 +18,7 @@ const { subscribeTx, txRD$, resetTx, sendTx, txs$, tx$, txStatus$ } = createTran
 const { fees$, reloadFees, feesWithRates$, reloadFeesWithRates } = createFeesService(combinedClient$)
 
 export {
+  combinedClient$,
   client$,
   clientState$,
   explorerUrl$,

--- a/src/shared/api/io.ts
+++ b/src/shared/api/io.ts
@@ -106,28 +106,38 @@ export const feeOptionIO = new t.Type(
   t.identity
 )
 
-export const ipcLedgerSendTxParamsIO = t.type({
-  chain: chainIO,
-  network: networkIO,
-  sender: t.union([t.string, t.undefined]),
-  recipient: t.string,
-  asset: assetIO,
-  feeAsset: t.union([assetIO, t.undefined]),
-  amount: baseAmountIO,
-  memo: t.union([t.string, t.undefined]),
-  walletAccount: t.number,
-  walletIndex: t.number,
-  feeRate: t.number,
-  feeOption: t.union([feeOptionIO, t.undefined]),
-  feeAmount: t.union([baseAmountIO, t.undefined]),
-  nodeUrl: t.union([t.string, t.undefined]),
-  hdMode: hdModeIO,
-  apiKey: t.union([t.string, t.undefined]),
-  destinationTag: t.union([t.number, t.undefined]),
-  evmRpcUrl: t.union([t.string, t.undefined]),
-  gasMultiplier: t.union([t.number, t.undefined]),
-  sendMax: t.union([t.boolean, t.undefined])
-})
+export const ipcLedgerSendTxParamsIO = t.intersection([
+  t.type({
+    chain: chainIO,
+    network: networkIO,
+    sender: t.union([t.string, t.undefined]),
+    recipient: t.string,
+    asset: assetIO,
+    feeAsset: t.union([assetIO, t.undefined]),
+    amount: baseAmountIO,
+    memo: t.union([t.string, t.undefined]),
+    walletAccount: t.number,
+    walletIndex: t.number,
+    feeRate: t.number,
+    feeOption: t.union([feeOptionIO, t.undefined]),
+    feeAmount: t.union([baseAmountIO, t.undefined]),
+    nodeUrl: t.union([t.string, t.undefined]),
+    hdMode: hdModeIO,
+    apiKey: t.union([t.string, t.undefined]),
+    destinationTag: t.union([t.number, t.undefined]),
+    evmRpcUrl: t.union([t.string, t.undefined]),
+    gasMultiplier: t.union([t.number, t.undefined]),
+    sendMax: t.union([t.boolean, t.undefined])
+  }),
+  t.partial({
+    selectedUtxos: t.array(t.type({ hash: t.string, index: t.number, value: t.number })),
+    utxoSelectionPreferences: t.partial({
+      minimizeFee: t.boolean,
+      minimizeInputs: t.boolean,
+      consolidateSmallUtxos: t.boolean
+    })
+  })
+])
 
 export type IPCLedgerSendTxParams = t.TypeOf<typeof ipcLedgerSendTxParamsIO>
 


### PR DESCRIPTION
Coin control was keystore-only because the Ledger IPC pipeline didn't forward UTXO selection params. This threads selectedUtxos and utxoSelectionPreferences end-to-end so all wallet types get full coin control.

- Add optional selectedUtxos/utxoSelectionPreferences to IPC codec (io.ts) using t.intersection + t.partial for backward compat
- Forward params through renderer services, IPC router, and into chain-specific Ledger handlers for BTC/LTC/DOGE/BCH/DASH
- Ledger transfer() doesn't accept selectedUtxos, so handlers use transferMax() when coin control is active
- Re-fetch full UTXOs (with witnessUtxo) in main process via getUTXOs() since IPC can't serialize Buffer fields
- Export combinedClient$ from all UTXO chain services and use it in coinControl.ts so UTXO fetching works for all wallet types
- Remove keystore-only gate from SendForm coin control panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UTXO coin-control for BTC, BCH, DASH, DOGE, LTC: manual UTXO selection, send‑max, and selection preferences (minimize fee/minimize inputs/consolidate small UTXOs).

* **API**
  * Ledger send IPC and renderer send params now accept optional UTXO selection and preference fields; related public types updated. Several coin clients expose a combined client export.

* **UI**
  * Coin Control panel/strategy selector simplified; send‑max reset and manual selection behavior refined.

* **Localization**
  * Coin control translations updated for DE, ES, FR, HI, KO, RU; a few legacy keys removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->