### PR TITLE
Fix ERC20 approval polling and remove startWith(pending)

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -1675,6 +1675,12 @@ export const Swap = ({
   const approvalParamsRef = useRef<ApproveParams | null>(null)
   // Guard against double-handling of confirmation
   const approvalHandledRef = useRef(false)
+  // Capture amountToSwap so polling doesn't restart when user changes input
+  const amountToSwapRef = useRef(amountToSwap)
+  amountToSwapRef.current = amountToSwap
+
+  // Max polling attempts (~2.5 min: 10s initial + 24 × 5s)
+  const MAX_APPROVAL_POLLS = 24
 
   // Trigger approval check with sequential polling after approval tx succeeds
   useEffect(() => {
@@ -1701,7 +1707,7 @@ export const Swap = ({
       await delay(10000)
 
       // Sequential polling — wait for each check to complete before starting the next
-      while (!cancelled && !approvalHandledRef.current) {
+      for (let attempt = 0; attempt < MAX_APPROVAL_POLLS && !cancelled && !approvalHandledRef.current; attempt++) {
         try {
           const approved = await new Promise<boolean>((resolve) => {
             const sub = isApprovedERC20Token$({
@@ -1726,7 +1732,7 @@ export const Swap = ({
           if (approved) {
             approvalHandledRef.current = true
             setAwaitingApprovalConfirmation(false)
-            fetchSwap(amountToSwap)
+            fetchSwap(amountToSwapRef.current)
             break
           }
         } catch {
@@ -1734,7 +1740,12 @@ export const Swap = ({
         }
 
         // Wait before next attempt
-        await delay(5000)
+        if (!cancelled) await delay(5000)
+      }
+
+      // Timed out without confirmation
+      if (!cancelled && !approvalHandledRef.current) {
+        setAwaitingApprovalConfirmation(false)
       }
     }
 
@@ -1746,7 +1757,7 @@ export const Swap = ({
     }
     // Intentionally exclude oApproveParams — we capture params via ref to survive re-fetch clearing the quote
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [approveState, isApprovedERC20Token$, fetchSwap, amountToSwap])
+  }, [approveState, isApprovedERC20Token$, fetchSwap])
 
   // Reset approval tracking when approveState resets (e.g. asset change)
   useEffect(() => {

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -1688,32 +1688,70 @@ export const Swap = ({
   ])
 
   const [awaitingApprovalConfirmation, setAwaitingApprovalConfirmation] = useState(false)
+  // Capture approve params at time of approval so polling survives oApproveParams going O.none during re-fetch
+  const approvalParamsRef = useRef<ApproveParams | null>(null)
+  // Guard against double-handling of confirmation
+  const approvalHandledRef = useRef(false)
 
-  // Trigger approval check with polling retry after approval tx succeeds
+  // Trigger approval check with sequential polling after approval tx succeeds
   useEffect(() => {
-    if (!RD.isSuccess(approveState)) return
+    if (!RD.isSuccess(approveState)) {
+      approvalHandledRef.current = false
+      return
+    }
 
-    const params = FP.pipe(oApproveParams, O.toUndefined)
-    if (!params) return
+    // Capture params once — don't depend on oApproveParams for ongoing polling
+    if (!approvalParamsRef.current) {
+      const params = FP.pipe(oApproveParams, O.toUndefined)
+      if (!params) return
+      approvalParamsRef.current = params
+    }
 
-    let cancelled = false
+    const params = approvalParamsRef.current
     prevApproveParams.current = O.some(params)
     setAwaitingApprovalConfirmation(true)
+
+    let cancelled = false
 
     const pollApproval = async () => {
       // Initial delay to allow on-chain confirmation
       await delay(10000)
 
-      // Poll up to 3 times, 5s apart
-      for (let attempt = 0; attempt < 3; attempt++) {
-        if (cancelled) return
-        checkApprovedStatus(params)
-        // Wait 5s before next attempt (skip wait on last attempt)
-        if (attempt < 2) await delay(5000)
-      }
+      // Sequential polling — wait for each check to complete before starting the next
+      while (!cancelled && !approvalHandledRef.current) {
+        try {
+          const approved = await new Promise<boolean>((resolve) => {
+            const sub = isApprovedERC20Token$({
+              contractAddress: params.contractAddress,
+              spenderAddress: params.spenderAddress,
+              fromAddress: params.fromAddress
+            }).subscribe((rd) => {
+              if (RD.isSuccess(rd)) {
+                sub.unsubscribe()
+                resolve(rd.value)
+              }
+              if (RD.isFailure(rd)) {
+                sub.unsubscribe()
+                resolve(false)
+              }
+              // Skip RD.pending — wait for resolution
+            })
+          })
 
-      if (!cancelled) {
-        setAwaitingApprovalConfirmation(false)
+          if (cancelled || approvalHandledRef.current) break
+
+          if (approved) {
+            approvalHandledRef.current = true
+            setAwaitingApprovalConfirmation(false)
+            fetchSwap(amountToSwap)
+            break
+          }
+        } catch {
+          // RPC error — continue polling
+        }
+
+        // Wait before next attempt
+        await delay(5000)
       }
     }
 
@@ -1723,16 +1761,17 @@ export const Swap = ({
       cancelled = true
       setAwaitingApprovalConfirmation(false)
     }
-  }, [approveState, oApproveParams, checkApprovedStatus])
+    // Intentionally exclude oApproveParams — we capture params via ref to survive re-fetch clearing the quote
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [approveState, isApprovedERC20Token$, fetchSwap, amountToSwap])
 
-  // Refetch quote when approval is confirmed
+  // Reset approval tracking when approveState resets (e.g. asset change)
   useEffect(() => {
-    if (RD.isSuccess(approveState) && RD.isSuccess(isApprovedState)) {
+    if (RD.isInitial(approveState)) {
+      approvalParamsRef.current = null
       setAwaitingApprovalConfirmation(false)
-      fetchSwap(amountToSwap)
-      resetIsApprovedState()
     }
-  }, [approveState, isApprovedState, amountToSwap, fetchSwap, resetIsApprovedState])
+  }, [approveState])
 
   const reloadFeesHandler = useCallback(() => {
     reloadFees({
@@ -2488,9 +2527,11 @@ export const Swap = ({
   const isApproved = useMemo(() => {
     // No approval needed if not an ERC20 token
     if (O.isNone(needApprovement)) return true
-    // Approved if no approval error in quote AND no pending approval
-    return !needsApproval || RD.isSuccess(approveState)
-  }, [needApprovement, needsApproval, approveState])
+    // Still waiting for on-chain confirmation — keep showing approve button
+    if (awaitingApprovalConfirmation) return false
+    // Approved if quote has no approval error
+    return !needsApproval
+  }, [needApprovement, needsApproval, awaitingApprovalConfirmation])
 
   const priceApproveFee: CryptoAmount = useMemo(() => {
     const assetAmount = isApproved

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -1011,24 +1011,7 @@ export const Swap = ({
   } = useSubscriptionState<TxHashRD>(RD.initial)
 
   // State for values of `isApprovedERC20Token$`
-  const {
-    state: isApprovedState,
-    reset: resetIsApprovedState,
-    subscribe: subscribeIsApprovedState
-  } = useSubscriptionState<IsApprovedRD>(RD.initial)
-
-  const checkApprovedStatus = useCallback(
-    ({ contractAddress, spenderAddress, fromAddress }: ApproveParams) => {
-      subscribeIsApprovedState(
-        isApprovedERC20Token$({
-          contractAddress,
-          spenderAddress,
-          fromAddress
-        })
-      )
-    },
-    [isApprovedERC20Token$, subscribeIsApprovedState]
-  )
+  const { reset: resetIsApprovedState } = useSubscriptionState<IsApprovedRD>(RD.initial)
 
   const fetchSwap = useCallback(
     async (amount: BaseAmount) => {

--- a/src/renderer/services/arb/transaction.ts
+++ b/src/renderer/services/arb/transaction.ts
@@ -337,8 +337,7 @@ export const createTransactionService = (
               errorId: ErrorId.APPROVE_TX
             })
           )
-      ),
-      RxOp.startWith(RD.pending)
+      )
     )
   }
 

--- a/src/renderer/services/avax/transaction.ts
+++ b/src/renderer/services/avax/transaction.ts
@@ -330,8 +330,7 @@ export const createTransactionService = (
               errorId: ErrorId.APPROVE_TX
             })
           )
-      ),
-      RxOp.startWith(RD.pending)
+      )
     )
   }
 

--- a/src/renderer/services/base/transaction.ts
+++ b/src/renderer/services/base/transaction.ts
@@ -329,8 +329,7 @@ export const createTransactionService = (
               errorId: ErrorId.APPROVE_TX
             })
           )
-      ),
-      RxOp.startWith(RD.pending)
+      )
     )
   }
 

--- a/src/renderer/services/bsc/transaction.ts
+++ b/src/renderer/services/bsc/transaction.ts
@@ -328,8 +328,7 @@ export const createTransactionService = (
               errorId: ErrorId.APPROVE_TX
             })
           )
-      ),
-      RxOp.startWith(RD.pending)
+      )
     )
   }
 

--- a/src/renderer/services/ethereum/transaction.ts
+++ b/src/renderer/services/ethereum/transaction.ts
@@ -328,8 +328,7 @@ export const createTransactionService = (
               errorId: ErrorId.APPROVE_TX
             })
           )
-      ),
-      RxOp.startWith(RD.pending)
+      )
     )
   }
 


### PR DESCRIPTION
## Summary
- **Rewrite ERC20 approval polling** in `Swap.tsx`: capture approve params and swap amount in refs so polling survives quote re-fetches clearing `oApproveParams`. Sequential polling waits for each RPC check to resolve before retrying.
- **Cap polling at 24 attempts** (~2.5 min) to prevent unbounded polling if the approval tx fails on-chain.
- **Fix `isApproved` timing**: keep the approve button visible until on-chain confirmation, instead of hiding it immediately when `approveState` succeeds.
- **Remove `startWith(RD.pending)`** from `isApprovedERC20Token$` across all 5 EVM chains (ETH, ARB, AVAX, BSC, BASE) — the new polling skips pending emissions, so the synthetic initial pending is unnecessary.

## Test plan
- [x] ERC20 swap: approve a token, verify polling detects on-chain approval and auto-refetches the quote
- [x] Verify approve button stays visible during on-chain confirmation wait
- [x] Change swap amount while approval is pending — polling should continue without restarting
- [x] If approval tx reverts, polling should stop after ~2.5 min and unblock the UI
- [x] Swap non-ERC20 assets — no approval flow triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced approval confirmation flow in swap operations with a more efficient polling mechanism.
  * Streamlined transaction state indicators across blockchain networks (Arbitrum, Avalanche, Base, BSC, and Ethereum).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->