### PR TITLE
refactor: replace echarts with pure SVG donut chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,8 +118,6 @@
     "axios": "^1.13.5",
     "bignumber.js": "^9.0.0",
     "clsx": "^2.1.1",
-    "echarts": "^5.5.1",
-    "echarts-for-react": "^3.0.2",
     "electron-debug": "^3.2.0",
     "electron-log": "^4.4.8",
     "electron-updater": "6.3.4",

--- a/src/renderer/components/uielements/charts/pieChart.tsx
+++ b/src/renderer/components/uielements/charts/pieChart.tsx
@@ -38,14 +38,24 @@ const polar = (cx: number, cy: number, r: number, angle: number) => ({
 const usdFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
 
 const buildSlices = (data: { name: string; value: number }[], outerR: number, innerR: number): SliceData[] => {
-  const n = data.length
+  // Normalize: treat non-finite / non-positive values as 0
+  const normalized = data.map((d) => ({
+    ...d,
+    value: Number.isFinite(d.value) && d.value > 0 ? d.value : 0
+  }))
+  const n = normalized.length
   if (n === 0) return []
 
-  const total = data.reduce((s, d) => s + d.value, 0)
+  const total = normalized.reduce((s, d) => s + d.value, 0)
   if (total === 0) return []
 
-  // Single item: full donut ring (two semicircular arcs to avoid SVG limitation)
-  if (n === 1) {
+  // Filter to only positive entries for geometry
+  const positiveCount = normalized.filter((d) => d.value > 0).length
+
+  // Single positive item: full donut ring (two semicircular arcs to avoid SVG limitation)
+  if (positiveCount === 1) {
+    const idx = normalized.findIndex((d) => d.value > 0)
+    const d = normalized[idx]
     const t = polar(CX, CY, outerR, -Math.PI / 2)
     const b = polar(CX, CY, outerR, Math.PI / 2)
     const ti = polar(CX, CY, innerR, -Math.PI / 2)
@@ -55,9 +65,9 @@ const buildSlices = (data: { name: string; value: number }[], outerR: number, in
         startAngle: -Math.PI / 2,
         endAngle: (3 * Math.PI) / 2,
         midAngle: Math.PI / 2,
-        color: ChartColors[0],
-        name: data[0].name,
-        value: data[0].value,
+        color: ChartColors[idx % ChartColors.length],
+        name: d.name,
+        value: d.value,
         path: [
           `M${t.x},${t.y}`,
           `A${outerR},${outerR} 0 1 1 ${b.x},${b.y}`,
@@ -72,8 +82,10 @@ const buildSlices = (data: { name: string; value: number }[], outerR: number, in
   }
 
   // Calculate proportional angles with total padding removed
-  const available = Math.max(2 * Math.PI - PAD_ANGLE * n, 0)
-  const angles = data.map((d) => (d.value / total) * available)
+  const available = Math.max(2 * Math.PI - PAD_ANGLE * positiveCount, 0)
+  // Scale minAngle down if too many slices to fit
+  const minAngle = positiveCount > 0 ? Math.min(MIN_ANGLE, available / positiveCount) : 0
+  const angles = normalized.map((d) => (d.value > 0 ? (d.value / total) * available : 0))
 
   // Clamp small slices to minAngle, redistribute deficit from larger slices
   for (let iter = 0; iter < 10; iter++) {
@@ -81,49 +93,54 @@ const buildSlices = (data: { name: string; value: number }[], outerR: number, in
     let shrinkable = 0
     let changed = false
     for (let i = 0; i < n; i++) {
-      if (angles[i] < MIN_ANGLE) {
-        deficit += MIN_ANGLE - angles[i]
-        angles[i] = MIN_ANGLE
+      if (angles[i] > 0 && angles[i] < minAngle) {
+        deficit += minAngle - angles[i]
+        angles[i] = minAngle
         changed = true
-      } else {
+      } else if (angles[i] > minAngle) {
         shrinkable += angles[i]
       }
     }
     if (!changed || shrinkable === 0) break
     for (let i = 0; i < n; i++) {
-      if (angles[i] > MIN_ANGLE) angles[i] -= deficit * (angles[i] / shrinkable)
+      if (angles[i] > minAngle) angles[i] -= deficit * (angles[i] / shrinkable)
     }
   }
 
   // Build slice paths starting from top (−π/2), going clockwise
   let cur = -Math.PI / 2
-  return data.map((d, i) => {
-    const start = cur + PAD_ANGLE / 2
-    const end = start + angles[i]
-    cur = end + PAD_ANGLE / 2
+  return normalized
+    .map((d, i) => {
+      // Skip zero-value entries
+      if (angles[i] <= 0) return null
 
-    const os = polar(CX, CY, outerR, start)
-    const oe = polar(CX, CY, outerR, end)
-    const ie = polar(CX, CY, innerR, end)
-    const is_ = polar(CX, CY, innerR, start)
-    const large = angles[i] > Math.PI ? 1 : 0
+      const start = cur + PAD_ANGLE / 2
+      const end = start + angles[i]
+      cur = end + PAD_ANGLE / 2
 
-    return {
-      startAngle: start,
-      endAngle: end,
-      midAngle: (start + end) / 2,
-      color: ChartColors[i % ChartColors.length],
-      name: d.name,
-      value: d.value,
-      path: [
-        `M${os.x},${os.y}`,
-        `A${outerR},${outerR} 0 ${large} 1 ${oe.x},${oe.y}`,
-        `L${ie.x},${ie.y}`,
-        `A${innerR},${innerR} 0 ${large} 0 ${is_.x},${is_.y}`,
-        'Z'
-      ].join(' ')
-    }
-  })
+      const os = polar(CX, CY, outerR, start)
+      const oe = polar(CX, CY, outerR, end)
+      const ie = polar(CX, CY, innerR, end)
+      const is_ = polar(CX, CY, innerR, start)
+      const large = angles[i] > Math.PI ? 1 : 0
+
+      return {
+        startAngle: start,
+        endAngle: end,
+        midAngle: (start + end) / 2,
+        color: ChartColors[i % ChartColors.length],
+        name: d.name,
+        value: d.value,
+        path: [
+          `M${os.x},${os.y}`,
+          `A${outerR},${outerR} 0 ${large} 1 ${oe.x},${oe.y}`,
+          `L${ie.x},${ie.y}`,
+          `A${innerR},${innerR} 0 ${large} 0 ${is_.x},${is_.y}`,
+          'Z'
+        ].join(' ')
+      }
+    })
+    .filter((s): s is SliceData => s !== null)
 }
 
 export const PieChart = ({
@@ -163,6 +180,9 @@ export const PieChart = ({
             key={i}
             d={s.path}
             fill={s.color}
+            role="img"
+            tabIndex={0}
+            aria-label={`${s.name}: ${isPrivate ? hiddenString : usdFormatter.format(s.value)}`}
             style={{
               opacity: hovered !== null && hovered !== i ? 0.6 : 1,
               transition: 'opacity 0.2s',
@@ -171,6 +191,8 @@ export const PieChart = ({
             onMouseEnter={() => setHovered(i)}
             onMouseMove={handleMouseMove}
             onMouseLeave={() => setHovered(null)}
+            onFocus={() => setHovered(i)}
+            onBlur={() => setHovered(null)}
           />
         ))}
 

--- a/src/renderer/components/uielements/charts/pieChart.tsx
+++ b/src/renderer/components/uielements/charts/pieChart.tsx
@@ -1,6 +1,4 @@
-import { useMemo } from 'react'
-
-import ReactECharts from 'echarts-for-react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 
 import { hiddenString } from '../../../helpers/stringHelper'
 import { useTheme } from '../../../hooks/useTheme'
@@ -16,6 +14,118 @@ type ChartProps = {
   showLabelLine?: boolean
 }
 
+type SliceData = {
+  startAngle: number
+  endAngle: number
+  midAngle: number
+  color: string
+  name: string
+  value: number
+  path: string
+}
+
+const DEG2RAD = Math.PI / 180
+const MIN_ANGLE = 5 * DEG2RAD
+const PAD_ANGLE = 3 * DEG2RAD
+const CX = 100
+const CY = 100
+
+const polar = (cx: number, cy: number, r: number, angle: number) => ({
+  x: cx + r * Math.cos(angle),
+  y: cy + r * Math.sin(angle)
+})
+
+const usdFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' })
+
+const buildSlices = (data: { name: string; value: number }[], outerR: number, innerR: number): SliceData[] => {
+  const n = data.length
+  if (n === 0) return []
+
+  const total = data.reduce((s, d) => s + d.value, 0)
+  if (total === 0) return []
+
+  // Single item: full donut ring (two semicircular arcs to avoid SVG limitation)
+  if (n === 1) {
+    const t = polar(CX, CY, outerR, -Math.PI / 2)
+    const b = polar(CX, CY, outerR, Math.PI / 2)
+    const ti = polar(CX, CY, innerR, -Math.PI / 2)
+    const bi = polar(CX, CY, innerR, Math.PI / 2)
+    return [
+      {
+        startAngle: -Math.PI / 2,
+        endAngle: (3 * Math.PI) / 2,
+        midAngle: Math.PI / 2,
+        color: ChartColors[0],
+        name: data[0].name,
+        value: data[0].value,
+        path: [
+          `M${t.x},${t.y}`,
+          `A${outerR},${outerR} 0 1 1 ${b.x},${b.y}`,
+          `A${outerR},${outerR} 0 1 1 ${t.x},${t.y}`,
+          `L${ti.x},${ti.y}`,
+          `A${innerR},${innerR} 0 1 0 ${bi.x},${bi.y}`,
+          `A${innerR},${innerR} 0 1 0 ${ti.x},${ti.y}`,
+          'Z'
+        ].join(' ')
+      }
+    ]
+  }
+
+  // Calculate proportional angles with total padding removed
+  const available = Math.max(2 * Math.PI - PAD_ANGLE * n, 0)
+  const angles = data.map((d) => (d.value / total) * available)
+
+  // Clamp small slices to minAngle, redistribute deficit from larger slices
+  for (let iter = 0; iter < 10; iter++) {
+    let deficit = 0
+    let shrinkable = 0
+    let changed = false
+    for (let i = 0; i < n; i++) {
+      if (angles[i] < MIN_ANGLE) {
+        deficit += MIN_ANGLE - angles[i]
+        angles[i] = MIN_ANGLE
+        changed = true
+      } else {
+        shrinkable += angles[i]
+      }
+    }
+    if (!changed || shrinkable === 0) break
+    for (let i = 0; i < n; i++) {
+      if (angles[i] > MIN_ANGLE) angles[i] -= deficit * (angles[i] / shrinkable)
+    }
+  }
+
+  // Build slice paths starting from top (−π/2), going clockwise
+  let cur = -Math.PI / 2
+  return data.map((d, i) => {
+    const start = cur + PAD_ANGLE / 2
+    const end = start + angles[i]
+    cur = end + PAD_ANGLE / 2
+
+    const os = polar(CX, CY, outerR, start)
+    const oe = polar(CX, CY, outerR, end)
+    const ie = polar(CX, CY, innerR, end)
+    const is_ = polar(CX, CY, innerR, start)
+    const large = angles[i] > Math.PI ? 1 : 0
+
+    return {
+      startAngle: start,
+      endAngle: end,
+      midAngle: (start + end) / 2,
+      color: ChartColors[i % ChartColors.length],
+      name: d.name,
+      value: d.value,
+      path: [
+        `M${os.x},${os.y}`,
+        `A${outerR},${outerR} 0 ${large} 1 ${oe.x},${oe.y}`,
+        `L${ie.x},${ie.y}`,
+        `A${innerR},${innerR} 0 ${large} 0 ${is_.x},${is_.y}`,
+        'Z'
+      ].join(' ')
+    }
+  })
+}
+
 export const PieChart = ({
   isLegendHidden = false,
   showLabelLine = false,
@@ -23,71 +133,139 @@ export const PieChart = ({
   chartData
 }: ChartProps) => {
   const { isLight: isLightTheme } = useTheme()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [hovered, setHovered] = useState<number | null>(null)
+  const [mousePos, setMousePos] = useState({ x: 0, y: 0 })
 
-  // text-text2 dark:text-text2d
   const textColor = useMemo(() => (isLightTheme ? 'rgb(97, 107, 117)' : 'rgb(209, 213, 218)'), [isLightTheme])
+  const tooltipBg = isLightTheme ? '#fff' : '#101921'
+  const tooltipBorder = isLightTheme ? '#e0e0e0' : '#2a3a4a'
+
+  const innerR = isLegendHidden ? 40 : 50
+  const outerR = isLegendHidden ? 70 : 80
+
+  const slices = useMemo(() => buildSlices(chartData, outerR, innerR), [chartData, outerR, innerR])
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    const rect = containerRef.current?.getBoundingClientRect()
+    if (rect) {
+      setMousePos({ x: e.clientX - rect.left + 14, y: e.clientY - rect.top - 14 })
+    }
+  }, [])
+
+  const viewBox = showLabelLine ? '-80 -20 360 240' : '0 0 200 200'
 
   return (
-    <ReactECharts
-      className="w-full"
-      option={{
-        tooltip: {
-          trigger: 'item',
-          backgroundColor: isLightTheme ? '#fff' : '#101921',
-          valueFormatter: (value: number) =>
-            isPrivate
-              ? hiddenString
-              : new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value),
-          textStyle: {
-            color: textColor
-          }
-        },
-        legend: isLegendHidden
-          ? { show: false }
-          : {
-              type: 'scroll',
-              bottom: '0%',
-              itemWidth: 20,
-              itemHeight: 12,
-              pageIconColor: textColor,
-              pageTextStyle: {
-                color: textColor
-              },
-              textStyle: {
-                color: textColor,
-                fontWeight: 'lighter'
-              }
-            },
-        color: ChartColors,
-        series: [
-          {
-            top: '0%',
-            bottom: isLegendHidden ? '0%' : '20%',
-            type: 'pie',
-            radius: isLegendHidden ? ['40%', '70%'] : ['50%', '80%'],
-            padAngle: 3,
-            minAngle: 5,
-            itemStyle: {
-              borderRadius: 'full'
-            },
-            label: showLabelLine
-              ? { color: textColor, formatter: isPrivate ? `{b}: ${hiddenString}` : '{b}: ${c}' }
-              : { show: false },
-            emphasis: showLabelLine ? {} : { label: { show: false } },
-            labelLine: showLabelLine
-              ? {
-                  lineStyle: {
-                    color: textColor
-                  },
-                  smooth: 0.2,
-                  length: 10,
-                  length2: 40
-                }
-              : { show: false },
-            data: chartData
-          }
-        ]
-      }}
-    />
+    <div ref={containerRef} className="w-full" style={{ position: 'relative' }}>
+      <svg viewBox={viewBox} preserveAspectRatio="xMidYMid meet" style={{ width: '100%', maxHeight: 280 }}>
+        {slices.map((s, i) => (
+          <path
+            key={i}
+            d={s.path}
+            fill={s.color}
+            style={{
+              opacity: hovered !== null && hovered !== i ? 0.6 : 1,
+              transition: 'opacity 0.2s',
+              cursor: 'pointer'
+            }}
+            onMouseEnter={() => setHovered(i)}
+            onMouseMove={handleMouseMove}
+            onMouseLeave={() => setHovered(null)}
+          />
+        ))}
+
+        {showLabelLine &&
+          slices.map((s, i) => {
+            const outerPt = polar(CX, CY, outerR + 2, s.midAngle)
+            const elbow = polar(CX, CY, outerR + 12, s.midAngle)
+            const isRight = Math.cos(s.midAngle) >= 0
+            const endX = elbow.x + (isRight ? 40 : -40)
+            return (
+              <g key={`label-${i}`}>
+                <polyline
+                  points={`${outerPt.x},${outerPt.y} ${elbow.x},${elbow.y} ${endX},${elbow.y}`}
+                  fill="none"
+                  stroke={textColor}
+                  strokeWidth={0.8}
+                />
+                <text
+                  x={endX + (isRight ? 3 : -3)}
+                  y={elbow.y}
+                  fill={textColor}
+                  fontSize={9}
+                  textAnchor={isRight ? 'start' : 'end'}
+                  dominantBaseline="central">
+                  {s.name}: {isPrivate ? hiddenString : usdFormatter.format(s.value)}
+                </text>
+              </g>
+            )
+          })}
+      </svg>
+
+      {hovered !== null && slices[hovered] && (
+        <div
+          style={{
+            position: 'absolute',
+            left: mousePos.x,
+            top: mousePos.y,
+            backgroundColor: tooltipBg,
+            border: `1px solid ${tooltipBorder}`,
+            borderRadius: 4,
+            padding: '6px 10px',
+            pointerEvents: 'none',
+            zIndex: 10,
+            fontSize: 13,
+            color: textColor,
+            whiteSpace: 'nowrap',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.15)'
+          }}>
+          <span
+            style={{
+              display: 'inline-block',
+              width: 10,
+              height: 10,
+              borderRadius: '50%',
+              backgroundColor: slices[hovered].color,
+              marginRight: 6,
+              verticalAlign: 'middle'
+            }}
+          />
+          <span style={{ verticalAlign: 'middle' }}>
+            {slices[hovered].name}: {isPrivate ? hiddenString : usdFormatter.format(slices[hovered].value)}
+          </span>
+        </div>
+      )}
+
+      {!isLegendHidden && (
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            gap: '4px 12px',
+            padding: '8px 0',
+            overflowX: 'auto',
+            fontSize: 12,
+            color: textColor,
+            fontWeight: 300
+          }}>
+          {slices.map((s, i) => (
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span
+                style={{
+                  display: 'inline-block',
+                  width: 20,
+                  height: 12,
+                  backgroundColor: s.color,
+                  borderRadius: 2,
+                  flexShrink: 0
+                }}
+              />
+              <span>{s.name}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   )
 }

--- a/src/renderer/components/uielements/charts/utils.ts
+++ b/src/renderer/components/uielements/charts/utils.ts
@@ -20,26 +20,3 @@ export const ChartColors = [
   '#F5CBA7', // Light Brown
   '#CCD1D1' // Iron Gray
 ]
-
-export const ChartColorClassnames = [
-  'text-[#0088FE]', // Vivid Blue
-  'text-[#00C49F]', // Aqua Green
-  'text-[#FFBB28]', // Vibrant Yellow
-  'text-[#FF8042]', // Bright Orange
-  'text-[#A569BD]', // Purple
-  'text-[#F4D03F]', // Sunflower Yellow
-  'text-[#5DADE2]', // Light Blue
-  'text-[#48C9B0]', // Medium Aquamarine
-  'text-[#EC7063]', // Soft Red
-  'text-[#AF7AC5]', // Lavender
-  'text-[#F7DC6F]', // Light Goldenrod Yellow
-  'text-[#82E0AA]', // Pastel Green
-  'text-[#F5B041]', // Tangerine Yellow
-  'text-[#85C1E9]', // Sky Blue
-  'text-[#D7DBDD]', // Light Gray
-  'text-[#AED6F1]', // Pale Blue
-  'text-[#A3E4D7]', // Pale Aqua Green
-  'text-[#FAD7A0]', // Peach Orange
-  'text-[#F5CBA7]', // Light Brown
-  'text-[#CCD1D1]' // Iron Gray
-]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7030,8 +7030,6 @@ __metadata:
     cross-env: "npm:^7.0.3"
     crypto-browserify: "npm:^3.12.0"
     dotenv: "npm:16.4.5"
-    echarts: "npm:^5.5.1"
-    echarts-for-react: "npm:^3.0.2"
     electron: "npm:^35"
     electron-builder: "npm:^24.13.3"
     electron-debug: "npm:^3.2.0"
@@ -9029,29 +9027,6 @@ __metadata:
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 10/9b1d3e1baefeaf7d70799db8774149cef33b97183a6addceeba0cf6b85ba23ee2686f302f14482006df32df75d32b17c509c143a3689627929e4a8efaf483952
-  languageName: node
-  linkType: hard
-
-"echarts-for-react@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "echarts-for-react@npm:3.0.2"
-  dependencies:
-    fast-deep-equal: "npm:^3.1.3"
-    size-sensor: "npm:^1.0.1"
-  peerDependencies:
-    echarts: ^3.0.0 || ^4.0.0 || ^5.0.0
-    react: ^15.0.0 || >=16.0.0
-  checksum: 10/be9107e7c174fd8105d12e15c1ae4bbb828c4ca9a66ef99eec1660fc0c5db92e652f69a81c5c11c2b7b826b13ae79260569a6d74aea965ae4f31f0b4d18462e9
-  languageName: node
-  linkType: hard
-
-"echarts@npm:^5.5.1":
-  version: 5.5.1
-  resolution: "echarts@npm:5.5.1"
-  dependencies:
-    tslib: "npm:2.3.0"
-    zrender: "npm:5.6.0"
-  checksum: 10/573ebfd6795a8976c2320225b3de49daca518e41192bf86d7afb53ce793b072932ae913a027b8de613fda319dacccb53fb23a73d5f128bfed6de808fe2d476c5
   languageName: node
   linkType: hard
 
@@ -15136,13 +15111,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"size-sensor@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "size-sensor@npm:1.0.2"
-  checksum: 10/de7050178ae9afee3388eb9191af0902b30ef83c26e8c9d9c203e1b560e270b947d978e4f56d211802112d09ef296931fa612f69155a483900f3b4717a0750d7
-  languageName: node
-  linkType: hard
-
 "slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -15951,13 +15919,6 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
-  languageName: node
-  linkType: hard
-
-"tslib@npm:2.3.0":
-  version: 2.3.0
-  resolution: "tslib@npm:2.3.0"
-  checksum: 10/9c55c9abd5ecd94e5fd37573db27e26933fb6c33506431403fb4627dcb8aa9a45b772afa6d05dd2c25dc1de22a213193251e6303742f3bcdc179e523a9295bfd
   languageName: node
   linkType: hard
 
@@ -17115,14 +17076,5 @@ __metadata:
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10/f0c963ec40cd96858451d1690404d603d36507c1fc9682f2dae59ab38b578687d542708a7fdbf645f77926f78c9ed558f57c3d3aa226c285f798df0c4da16995
-  languageName: node
-  linkType: hard
-
-"zrender@npm:5.6.0":
-  version: 5.6.0
-  resolution: "zrender@npm:5.6.0"
-  dependencies:
-    tslib: "npm:2.3.0"
-  checksum: 10/7904bb17818fcf3c4a2729712991d8e29776404d8dc7aa58bc69cd853bdbb4cf8c8b302aaf10c1392a63bffbe07aad82ffef1d037537aab3d8a2f564940dd78d
   languageName: node
   linkType: hard


### PR DESCRIPTION
Remove echarts (~1.5MB) and echarts-for-react dependencies, replacing the single PieChart consumer with a zero-dependency SVG/CSS implementation. Same ChartProps interface, same export — zero consumer changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pie charts now render as interactive SVGs with hover effects, improved tooltips (including privacy masking), optional label lines, and a dynamic legend.

* **Chores**
  * Removed unused charting libraries from dependencies to streamline the app (echarts and echarts-for-react).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->