### PR TITLE
chore: clean up release pipeline workflows

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,22 +22,13 @@ jobs:
       - name: Checkout git repo
         uses: actions/checkout@v4
 
-      # Cache Yarn dependencies
-      - name: Cache Yarn dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'
 
       - name: Install missing dependencies
-        run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev libusb-1.0-0-dev
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -48,7 +39,7 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=7168
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: production
-          VITE_NODE_ENV: ${{ env.NODE_ENV }}
+          VITE_NODE_ENV: production
           VITE_BLOCKCYPHER_API_KEY: ${{ secrets.REACT_APP_BLOCKCYPHER_API_KEY }}
           VITE_ETHERSCAN_API_KEY: ${{ secrets.REACT_APP_ETHERSCAN_API_KEY }}
           VITE_ASGARDEX_THORNAME: ${{ secrets.REACT_APP_ASGARDEX_THORNAME }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,9 +15,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macOS-13
-            os-name: Ventura
-            os-version: 13
           - os: macOS-14
             os-name: Sonoma
             os-version: 14

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macOS-14
@@ -30,14 +31,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.9'
-
-      - name: Cache Yarn dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - uses: actions/setup-node@v4
         with:
@@ -63,7 +56,7 @@ jobs:
           SIGNING_APP_PASSWORD: ${{ secrets.SIGNING_APP_PASSWORD }}
           SIGNING_TEAM_ID: ${{ secrets.SIGNING_TEAM_ID }}
           NODE_ENV: production
-          VITE_NODE_ENV: ${{ env.NODE_ENV }}
+          VITE_NODE_ENV: production
           VITE_BLOCKCYPHER_API_KEY: ${{ secrets.REACT_APP_BLOCKCYPHER_API_KEY }}
           VITE_ETHERSCAN_API_KEY: ${{ secrets.REACT_APP_ETHERSCAN_API_KEY }}
           VITE_ASGARDEX_THORNAME: ${{ secrets.REACT_APP_ASGARDEX_THORNAME }}

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -22,15 +22,6 @@ jobs:
       - name: Checkout git repo
         uses: actions/checkout@v4
 
-        # Cache Yarn dependencies
-      - name: Cache Yarn dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/yarn
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
@@ -51,7 +42,7 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=7168
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: production
-          VITE_NODE_ENV: ${{ env.NODE_ENV }}
+          VITE_NODE_ENV: production
           VITE_BLOCKCYPHER_API_KEY: ${{ secrets.REACT_APP_BLOCKCYPHER_API_KEY }}
           VITE_ETHERSCAN_API_KEY: ${{ secrets.REACT_APP_ETHERSCAN_API_KEY }}
           VITE_ASGARDEX_THORNAME: ${{ secrets.REACT_APP_ASGARDEX_THORNAME }}

--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger website update
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PAT }}
           repository: asgardex/asgardex-website

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ stats.html
 CLAUDE.md
 .claude/
 /docs
+
+# Release signing (local only)
+scripts/sign_bin.sh
+/release-signing


### PR DESCRIPTION
## Summary
- **Drop Ventura (macOS-13)** from CI matrix — runner is deprecated and was being cancelled immediately
- **Fix `VITE_NODE_ENV` bug** — was silently empty in all 3 build workflows because `${{ env.NODE_ENV }}` can't reference step-level env vars
- **Remove redundant Yarn cache steps** — `actions/setup-node` with `cache: 'yarn'` already handles this, and the manual paths were wrong for macOS/Windows
- **Add `fail-fast: false`** to macOS matrix so one build failure doesn't cancel the other
- **Add `-y` flag** to Linux `apt-get install`
- **Bump `repository-dispatch`** to v3
- **Gitignore** local release signing script and download directory

## Test plan
- [ ] Verify CI passes on this branch (test workflow)
- [ ] Next release build should produce Sonoma + Sequoia DMGs only (no Ventura cancellation noise)
- [ ] Confirm `VITE_NODE_ENV` is correctly set to `production` in built artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined and unified build workflows across Linux, macOS, and Windows platforms.
  * Updated GitHub Actions dependencies to the latest versions for improved compatibility.
  * Enhanced build artifact management and release configuration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->