### PR TITLE
fix: correct XRD LP share value and clean up sidebar footer

### DIFF
--- a/src/renderer/components/header/Header.tsx
+++ b/src/renderer/components/header/Header.tsx
@@ -6,6 +6,7 @@ import { useMidgardContext } from '../../contexts/MidgardContext'
 import { useMidgardMayaContext } from '../../contexts/MidgardMayaContext'
 import { useThorchainContext } from '../../contexts/ThorchainContext'
 import { useWalletContext } from '../../contexts/WalletContext'
+import { useFlipPrice } from '../../hooks/useFlipPrice'
 import { useKeystoreState } from '../../hooks/useKeystoreState'
 import { useMayachainClientUrl } from '../../hooks/useMayachainClientUrl'
 import { useMayaPrice } from '../../hooks/useMayaPrice'
@@ -50,6 +51,7 @@ export const Header = (): JSX.Element => {
 
   const { runePriceRD, reloadRunePrice } = useRunePrice()
   const { tcyPriceRD, reloadTcyPrice } = useTcyPrice()
+  const { flipPriceRD, reloadFlipPrice } = useFlipPrice()
   const { mayaPriceRD, reloadMayaPrice } = useMayaPrice()
   const { volume24PriceRD, reloadVolume24Price } = useVolume24Price()
   const { volume24PriceRD: volume24PriceMayaRD, reloadVolume24Price: reloadVolume24PriceMaya } = useVolume24PriceMaya()
@@ -81,6 +83,8 @@ export const Header = (): JSX.Element => {
       reloadRunePrice={reloadRunePrice}
       tcyPrice={tcyPriceRD}
       reloadTcyPrice={reloadTcyPrice}
+      flipPrice={flipPriceRD}
+      reloadFlipPrice={reloadFlipPrice}
       mayaPrice={mayaPriceRD}
       reloadMayaPrice={reloadMayaPrice}
       volume24PriceRune={volume24PriceRD}

--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -67,6 +67,8 @@ export type Props = {
   reloadRunePrice: FP.Lazy<void>
   tcyPrice: RD.RemoteData<Error, string>
   reloadTcyPrice: FP.Lazy<void>
+  flipPrice: RD.RemoteData<Error, string>
+  reloadFlipPrice: FP.Lazy<void>
   mayaPrice: PriceRD
   reloadMayaPrice: FP.Lazy<void>
   volume24PriceRune: PriceRD
@@ -91,12 +93,14 @@ export const HeaderComponent = (props: Props): JSX.Element => {
     pricePools: oPricePools,
     runePrice: runePriceRD,
     tcyPrice: tcyPriceRD,
+    flipPrice: flipPriceRD,
     mayaPrice: mayaPriceRD,
     midgardStatus: midgardStatusRD,
     midgardMayaStatus: midgardMayaStatusRD,
     mimir: mimirRD,
     reloadRunePrice,
     reloadTcyPrice,
+    reloadFlipPrice,
     reloadMayaPrice,
     volume24PriceRune: volume24PriceRD,
     volume24PriceMaya: volume24PriceMayaRD,
@@ -286,9 +290,11 @@ export const HeaderComponent = (props: Props): JSX.Element => {
         <HeaderStats
           runePrice={runePriceRD}
           tcyPrice={tcyPriceRD}
+          flipPrice={flipPriceRD}
           mayaPrice={mayaPriceRD}
           reloadRunePrice={reloadRunePrice}
           reloadTcyPrice={reloadTcyPrice}
+          reloadFlipPrice={reloadFlipPrice}
           reloadMayaPrice={reloadMayaPrice}
           volume24PriceRune={volume24PriceRD}
           volume24PriceMaya={volume24PriceMayaRD}

--- a/src/renderer/components/header/stats/HeaderStats.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useRef } from 'react'
 import * as RD from '@devexperts/remote-data-ts'
 import { AssetCacao, MAYAChain } from '@xchainjs/xchain-mayachain'
 import { AssetRuneNative, AssetTCY, THORChain } from '@xchainjs/xchain-thorchain'
-import { baseToAsset, formatAssetAmountCurrency, currencySymbolByAsset } from '@xchainjs/xchain-util'
+import { assetFromStringEx, baseToAsset, formatAssetAmountCurrency, currencySymbolByAsset } from '@xchainjs/xchain-util'
 import { function as FP } from 'fp-ts'
 
 import { abbreviateNumber } from '../../../helpers/numberHelper'
@@ -14,12 +14,16 @@ import { PriceRD } from '../../../services/midgard/midgardTypes'
 import { AssetIcon } from '../../uielements/assets/assetIcon'
 import { Label } from '../../uielements/label'
 
+const AssetFlip = assetFromStringEx('ETH.FLIP-0x826180541412D574cf1336d22c0C0a287822678A')
+
 export type Props = {
   runePrice: PriceRD
   tcyPrice: RD.RemoteData<Error, string>
+  flipPrice: RD.RemoteData<Error, string>
   mayaPrice: PriceRD
   reloadRunePrice: FP.Lazy<void>
   reloadTcyPrice: FP.Lazy<void>
+  reloadFlipPrice: FP.Lazy<void>
   reloadMayaPrice: FP.Lazy<void>
   volume24PriceRune: PriceRD
   volume24PriceMaya: PriceRD
@@ -31,9 +35,11 @@ export const HeaderStats = (props: Props): JSX.Element => {
   const {
     runePrice: runePriceRD,
     tcyPrice: tcyPriceRD,
+    flipPrice: flipPriceRD,
     mayaPrice: mayaPriceRD,
     reloadRunePrice,
     reloadTcyPrice,
+    reloadFlipPrice,
     reloadMayaPrice,
     volume24PriceRune: volume24PriceRuneRD,
     volume24PriceMaya: volume24PriceMayaRD,
@@ -49,6 +55,7 @@ export const HeaderStats = (props: Props): JSX.Element => {
 
   const prevRunePriceLabel = useRef<string>(loadingString)
   const prevTcyPriceLabel = useRef<string>(loadingString)
+  const prevFlipPriceLabel = useRef<string>(loadingString)
   const prevMayaPriceLabel = useRef<string>(loadingString)
   const runePriceLabel = useMemo(
     () =>
@@ -95,6 +102,24 @@ export const HeaderStats = (props: Props): JSX.Element => {
         )
       ),
     [tcyPriceRD]
+  )
+
+  const flipPriceLabel = useMemo(
+    () =>
+      FP.pipe(
+        flipPriceRD,
+        RD.fold(
+          () => prevFlipPriceLabel.current,
+          () => prevFlipPriceLabel.current,
+          () => '--',
+          (price) => {
+            const label = price ?? '--'
+            prevFlipPriceLabel.current = label
+            return label
+          }
+        )
+      ),
+    [flipPriceRD]
   )
 
   const mayaPriceLabel = useMemo(
@@ -187,13 +212,16 @@ export const HeaderStats = (props: Props): JSX.Element => {
   }, [reloadRunePrice, reloadVolume24PriceRune, runePriceRD, volume24PriceRuneRD])
 
   const reloadTcyStats = useCallback(() => {
-    if (!RD.isPending(volume24PriceRuneRD)) {
-      reloadVolume24PriceRune()
-    }
     if (!RD.isPending(tcyPriceRD)) {
       reloadTcyPrice()
     }
-  }, [reloadTcyPrice, reloadVolume24PriceRune, tcyPriceRD, volume24PriceRuneRD])
+  }, [reloadTcyPrice, tcyPriceRD])
+
+  const reloadFlipStats = useCallback(() => {
+    if (!RD.isPending(flipPriceRD)) {
+      reloadFlipPrice()
+    }
+  }, [reloadFlipPrice, flipPriceRD])
 
   const reloadMayaStats = useCallback(() => {
     if (!RD.isPending(volume24PriceMayaRD)) {
@@ -229,17 +257,30 @@ export const HeaderStats = (props: Props): JSX.Element => {
 
       {isSmallMobileView ||
         (!(isLargeMobileView && !isXLargeMobileView) && (
-          <div
-            className="flex cursor-pointer items-center space-x-2 rounded-xl bg-bg0 py-1 pr-2 pl-1 drop-shadow dark:bg-gray0d"
-            onClick={reloadTcyStats}>
-            <AssetIcon size="xsmall" asset={AssetTCY} network={network} />
-            <Label className="!w-auto" color="primary" textTransform="uppercase" weight="bold">
-              TCY
-            </Label>
-            <Label className="!w-auto" color="gray" textTransform="uppercase">
-              {tcyPriceLabel}
-            </Label>
-          </div>
+          <>
+            <div
+              className="flex cursor-pointer items-center space-x-2 rounded-xl bg-bg0 py-1 pr-2 pl-1 drop-shadow dark:bg-gray0d"
+              onClick={reloadTcyStats}>
+              <AssetIcon size="xsmall" asset={AssetTCY} network={network} />
+              <Label className="!w-auto" color="primary" textTransform="uppercase" weight="bold">
+                TCY
+              </Label>
+              <Label className="!w-auto" color="gray" textTransform="uppercase">
+                {tcyPriceLabel}
+              </Label>
+            </div>
+            <div
+              className="flex cursor-pointer items-center space-x-2 rounded-xl bg-bg0 py-1 pr-2 pl-1 drop-shadow dark:bg-gray0d"
+              onClick={reloadFlipStats}>
+              <AssetIcon size="xsmall" asset={AssetFlip} network={network} />
+              <Label className="!w-auto" color="primary" textTransform="uppercase" weight="bold">
+                FLIP
+              </Label>
+              <Label className="!w-auto" color="gray" textTransform="uppercase">
+                {flipPriceLabel}
+              </Label>
+            </div>
+          </>
         ))}
 
       <div

--- a/src/renderer/components/sidebar/Sidebar.tsx
+++ b/src/renderer/components/sidebar/Sidebar.tsx
@@ -4,13 +4,12 @@ import { SidebarComponent } from './SidebarComponent'
 type Props = {
   commitHash?: string
   isDev: boolean
-  publicIP: string
 }
 
 export const Sidebar = (props: Props): JSX.Element => {
-  const { commitHash, isDev, publicIP } = props
+  const { commitHash, isDev } = props
 
   const { network } = useNetwork()
 
-  return <SidebarComponent network={network} commitHash={commitHash} isDev={isDev} publicIP={publicIP} />
+  return <SidebarComponent network={network} commitHash={commitHash} isDev={isDev} />
 }

--- a/src/renderer/components/sidebar/SidebarComponent.stories.tsx
+++ b/src/renderer/components/sidebar/SidebarComponent.stories.tsx
@@ -104,8 +104,7 @@ export const Default = Template.bind({})
 export const WithActiveTransactions = Template.bind({})
 WithActiveTransactions.args = {
   network: Network.Mainnet,
-  isDev: false,
-  publicIP: '127.0.0.1'
+  isDev: false
 }
 
 const meta: Meta<typeof Component> = {
@@ -116,8 +115,7 @@ const meta: Meta<typeof Component> = {
   },
   args: {
     network: Network.Mainnet,
-    isDev: false,
-    publicIP: '127.0.0.1'
+    isDev: false
   },
   decorators: [
     (Story) => (

--- a/src/renderer/components/sidebar/SidebarComponent.tsx
+++ b/src/renderer/components/sidebar/SidebarComponent.tsx
@@ -25,7 +25,6 @@ import SwapIcon from '../../assets/svg/icon-swap.svg?react'
 import TwitterIcon from '../../assets/svg/icon-twitter.svg?react'
 import WalletIcon from '../../assets/svg/icon-wallet.svg?react'
 import AsgardexLogo from '../../assets/svg/logo-asgardex.svg?react'
-import ThorChainIcon from '../../assets/svg/logo-thorchain.svg?react'
 import { useChainflipContext } from '../../contexts/ChainflipContext'
 import { useMayachainContext } from '../../contexts/MayachainContext'
 import { useThorchainContext } from '../../contexts/ThorchainContext'
@@ -37,7 +36,6 @@ import * as playgroundRoutes from '../../routes/playground'
 import * as poolsRoutes from '../../routes/pools'
 import * as portfolioRoutes from '../../routes/portfolio'
 import * as walletRoutes from '../../routes/wallet'
-import { mayaIconT } from '../icons'
 import { Label } from '../uielements/label'
 import { Tooltip } from '../uielements/tooltip'
 import { TransactionSlideshow } from '../uielements/transactionProgress/TransactionSlideshow'
@@ -90,11 +88,10 @@ export type Props = {
   network: Network
   commitHash?: string
   isDev: boolean
-  publicIP: string
 }
 
 export const SidebarComponent = memo(function SidebarComponent(props: Props): JSX.Element {
-  const { network, commitHash, isDev, publicIP } = props
+  const { network, commitHash, isDev } = props
 
   const intl = useIntl()
   const { transactionTrackingService } = useThorchainContext()
@@ -264,25 +261,7 @@ export const SidebarComponent = memo(function SidebarComponent(props: Props): JS
           <div className="flex-1" />
         </div>
         <div className="flex flex-col items-center justify-center">
-          <FooterIcon url={ExternalUrl.DOCSTHOR} onClick={clickIconHandler}>
-            <div className="flex h-12 flex-row items-center">
-              <ThorChainIcon className="[&>*:not(:first-child)]:fill-text1 [&>*:not(:first-child)]:dark:fill-text1d" />
-            </div>
-          </FooterIcon>
-          <FooterIcon className="!ml-0" url={ExternalUrl.DOCSMAYA} onClick={clickIconHandler}>
-            <div className="flex h-12 flex-row items-center space-x-2">
-              <img className="h-8 w-8 rounded-full" src={mayaIconT} />
-              <Label size="big" textTransform="uppercase">
-                MAYACHAIN
-              </Label>
-            </div>
-          </FooterIcon>
-          {publicIP && (
-            <div className="h-8 items-center px-20px text-[14px] text-text2 dark:text-text2d">
-              Public IP: {publicIP}
-            </div>
-          )}
-          <div className="mt-6 flex items-center justify-center">
+          <div className="flex items-center justify-center">
             <FooterIcon url={ExternalUrl.ASGARDEX} onClick={clickIconHandler}>
               <Tooltip title={intl.formatMessage({ id: 'sidebar.tooltip.website' })}>
                 <GlobeIcon className="h-5 w-5" />

--- a/src/renderer/hooks/useFlipPrice.ts
+++ b/src/renderer/hooks/useFlipPrice.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import * as RD from '@devexperts/remote-data-ts'
+import axios from 'axios'
+
+const COINGECKO_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=chainflip&vs_currencies=usd'
+const CACHE_DURATION_MS = 10 * 60 * 1000 // 10 minutes
+
+export const useFlipPrice = () => {
+  const [flipPriceRD, setFlipPriceRD] = useState<RD.RemoteData<Error, string>>(RD.pending)
+  const lastFetchedAt = useRef<number>(0)
+  const cachedPrice = useRef<string | null>(null)
+
+  const fetchFlipPrice = useCallback(async () => {
+    const now = Date.now()
+    if (cachedPrice.current && now - lastFetchedAt.current < CACHE_DURATION_MS) {
+      setFlipPriceRD(RD.success(cachedPrice.current))
+      return
+    }
+
+    try {
+      setFlipPriceRD((prev) => (RD.isSuccess(prev) ? prev : RD.pending))
+      const { data } = await axios.get(COINGECKO_URL)
+      const price = data?.chainflip?.usd ?? 0
+      const label = `$${price.toFixed(2)}`
+      cachedPrice.current = label
+      lastFetchedAt.current = now
+      setFlipPriceRD(RD.success(label))
+    } catch (error) {
+      if (!cachedPrice.current) {
+        setFlipPriceRD(RD.failure(error instanceof Error ? error : new Error('Failed to fetch FLIP price')))
+      }
+      // Keep showing cached price on error
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchFlipPrice()
+  }, [fetchFlipPrice])
+
+  const reloadFlipPrice = useCallback(() => {
+    lastFetchedAt.current = 0 // force refresh
+    fetchFlipPrice()
+  }, [fetchFlipPrice])
+
+  return { flipPriceRD, reloadFlipPrice }
+}

--- a/src/renderer/views/app/AppHaltedChains.tsx
+++ b/src/renderer/views/app/AppHaltedChains.tsx
@@ -5,6 +5,7 @@ import { ExclamationTriangleIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { Chain } from '@xchainjs/xchain-util'
 import { function as FP, array as A } from 'fp-ts'
 import { useIntl } from 'react-intl'
+import { useLocation } from 'react-router-dom'
 
 import { chainToString, DEFAULT_ENABLED_CHAINS } from '../../../shared/utils/chain'
 import { Alert } from '../../components/uielements/alert'
@@ -29,8 +30,14 @@ type HaltedChainsState = {
 
 const HaltedChainsWarning = ({ haltedChainsRD, mimirHaltRD, protocol, midgardStatusRD }: HaltedChainsWarningProps) => {
   const intl = useIntl()
+  const location = useLocation()
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [hasRendered, setHasRendered] = useState(false)
+
+  // Determine current page context for filtering warnings
+  const isSwapPage = location.pathname.includes('/swap')
+  const isPoolPage = location.pathname.includes('/pools')
+  const isDepositPage = location.pathname.includes('/deposit') || location.pathname.includes('/liquidity')
 
   // Small delay to prevent flashing on data updates
   const RENDER_DELAY_MS = 200
@@ -81,11 +88,15 @@ const HaltedChainsWarning = ({ haltedChainsRD, mimirHaltRD, protocol, midgardSta
     }
   }, [haltedChainsRD, mimirHaltRD, midgardStatusRD])
 
-  // Memoize warning message calculation to prevent flashing on lastblock updates
+  // Memoize warning message calculation — route-aware filtering
   const warningMessage = useMemo(() => {
     let msg = ''
-    msg = mimirHalt.haltGlobalTrading ? intl.formatMessage({ id: 'halt.trading' }) : msg
-    msg = mimirHalt.HALTTHORCHAIN ? intl.formatMessage({ id: 'halt.thorchain' }) : msg
+
+    // Global halts: show on swap and pool pages (critical warnings)
+    if (isSwapPage || isPoolPage) {
+      msg = mimirHalt.haltGlobalTrading ? intl.formatMessage({ id: 'halt.trading' }) : msg
+      msg = mimirHalt.HALTTHORCHAIN ? intl.formatMessage({ id: 'halt.thorchain' }) : msg
+    }
 
     if (!mimirHalt.HALTTHORCHAIN && !mimirHalt.haltGlobalTrading) {
       const haltedChainsState: HaltedChainsState[] = Object.keys(DEFAULT_ENABLED_CHAINS).map((chain) => ({
@@ -96,56 +107,67 @@ const HaltedChainsWarning = ({ haltedChainsRD, mimirHaltRD, protocol, midgardSta
         pausedLPDeposit: mimirHalt[`PAUSELPDEPOSIT-${chain}-${chain}`] || false
       }))
 
-      const haltedChains = FP.pipe(
-        haltedChainsState,
-        A.filter(({ haltedChain }) => haltedChain),
-        A.map(({ chain }) => chain),
-        unionChains(inboundHaltedChains)
-      )
+      // Chain halts: show on swap and pool pages
+      if (isSwapPage || isPoolPage) {
+        const haltedChains = FP.pipe(
+          haltedChainsState,
+          A.filter(({ haltedChain }) => haltedChain),
+          A.map(({ chain }) => chain),
+          unionChains(inboundHaltedChains)
+        )
 
-      msg =
-        haltedChains.length === 1
-          ? `${msg} ${intl.formatMessage({ id: 'halt.chain' }, { chain: haltedChains[0], dex: protocol })}`
-          : haltedChains.length > 1
-            ? `${msg} ${intl.formatMessage(
-                { id: 'halt.chains' },
-                { chains: haltedChains.join(', '), protocol: protocol }
-              )}`
-            : msg
-
-      const haltedTradingChains = haltedChainsState
-        .filter(({ haltedTrading }) => haltedTrading)
-        .map(({ chain }) => chain)
-      msg =
-        haltedTradingChains.length > 0
-          ? `${msg} ${intl.formatMessage({ id: 'halt.chain.trading' }, { chains: haltedTradingChains.join(', ') })}`
-          : msg
-
-      const pausedLPs = haltedChainsState.filter(({ pausedLP }) => pausedLP).map(({ chain }) => chain)
-      const pausedLPsDeposits = haltedChainsState
-        .filter(({ pausedLPDeposit }) => pausedLPDeposit)
-        .map(({ chain }) => chain)
-
-      msg =
-        pausedLPs.length > 0
-          ? `${msg} ${intl.formatMessage({ id: 'halt.chain.pause' }, { chains: pausedLPs.join(', ') })}`
-          : mimirHalt.PAUSELP
-            ? `${msg} ${intl.formatMessage({ id: 'halt.chain.pauseall' })}`
-            : pausedLPsDeposits.length > 0
+        msg =
+          haltedChains.length === 1
+            ? `${msg} ${intl.formatMessage({ id: 'halt.chain' }, { chain: haltedChains[0], dex: protocol })}`
+            : haltedChains.length > 1
               ? `${msg} ${intl.formatMessage(
-                  { id: 'halt.chain.pauseDeposits' },
-                  { chains: pausedLPsDeposits.join(', '), protocol: chainToString(protocol) }
+                  { id: 'halt.chains' },
+                  { chains: haltedChains.join(', '), protocol: protocol }
                 )}`
               : msg
+      }
+
+      // Trading halts: show only on swap pages
+      if (isSwapPage) {
+        const haltedTradingChains = haltedChainsState
+          .filter(({ haltedTrading }) => haltedTrading)
+          .map(({ chain }) => chain)
+        msg =
+          haltedTradingChains.length > 0
+            ? `${msg} ${intl.formatMessage({ id: 'halt.chain.trading' }, { chains: haltedTradingChains.join(', ') })}`
+            : msg
+      }
+
+      // LP pause/deposit warnings: show only on pool/deposit/liquidity pages
+      if (isPoolPage || isDepositPage) {
+        const pausedLPs = haltedChainsState.filter(({ pausedLP }) => pausedLP).map(({ chain }) => chain)
+        const pausedLPsDeposits = haltedChainsState
+          .filter(({ pausedLPDeposit }) => pausedLPDeposit)
+          .map(({ chain }) => chain)
+
+        msg =
+          pausedLPs.length > 0
+            ? `${msg} ${intl.formatMessage({ id: 'halt.chain.pause' }, { chains: pausedLPs.join(', ') })}`
+            : mimirHalt.PAUSELP
+              ? `${msg} ${intl.formatMessage({ id: 'halt.chain.pauseall' })}`
+              : pausedLPsDeposits.length > 0
+                ? `${msg} ${intl.formatMessage(
+                    { id: 'halt.chain.pauseDeposits' },
+                    { chains: pausedLPsDeposits.join(', '), protocol: chainToString(protocol) }
+                  )}`
+                : msg
+      }
     }
 
-    // Append Midgard offline message if the endpoint is down
-    msg = !midgard
-      ? `${msg} ${intl.formatMessage({ id: 'midgard.status.offline' }, { protocol: protocol })}`.trim()
-      : msg
+    // Midgard offline: show on swap and pool pages
+    if (isSwapPage || isPoolPage) {
+      msg = !midgard
+        ? `${msg} ${intl.formatMessage({ id: 'midgard.status.offline' }, { protocol: protocol })}`.trim()
+        : msg
+    }
 
     return msg.trim()
-  }, [inboundHaltedChains, mimirHalt, midgard, intl, protocol])
+  }, [inboundHaltedChains, mimirHalt, midgard, intl, protocol, isSwapPage, isPoolPage, isDepositPage])
 
   // Don't show warnings until we have actual data from at least one source
   if (!hasRendered || !hasAnyData) {

--- a/src/renderer/views/app/AppView.tsx
+++ b/src/renderer/views/app/AppView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { MayaChain } from '@xchainjs/xchain-mayachain-query'
@@ -20,7 +20,6 @@ import { useMayachainContext } from '../../contexts/MayachainContext'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { useMidgardMayaContext } from '../../contexts/MidgardMayaContext'
 import { useThorchainContext } from '../../contexts/ThorchainContext'
-import { logger } from '../../helpers/logger'
 import { useBreakpoint } from '../../hooks/useBreakpoint'
 import { useKeystoreWallets } from '../../hooks/useKeystoreWallets'
 import { useLedgerAddresses } from '../../hooks/useLedgerAddresses'
@@ -158,20 +157,6 @@ export const AppView = (): JSX.Element => {
     )
   }, [ledgerAddressesPersistentRD, reloadPersistentLedgerAddresses, intl])
 
-  const getPublicIP = async () => {
-    const response = await fetch('https://api.ipify.org?format=json')
-    const data = await response.json()
-    return data.ip
-  }
-
-  const [publicIP, setPublicIP] = useState('')
-
-  useEffect(() => {
-    getPublicIP()
-      .then((ip) => setPublicIP(ip))
-      .catch((err) => logger.error(err))
-  }, [])
-
   return (
     <div className="h-screen bg-bg3 p-0 font-main dark:bg-bg3d">
       {shouldHideLayout ? (
@@ -179,9 +164,7 @@ export const AppView = (): JSX.Element => {
       ) : (
         <div className="flex h-full flex-col">
           <div className="flex h-full flex-row bg-bg3 dark:bg-bg3d">
-            {isDesktopView && (
-              <Sidebar commitHash={envOrDefault($COMMIT_HASH, '')} isDev={$IS_DEV} publicIP={publicIP} />
-            )}
+            {isDesktopView && <Sidebar commitHash={envOrDefault($COMMIT_HASH, '')} isDev={$IS_DEV} />}
             <div className="flex w-full flex-col overflow-auto p-4 lg:w-[calc(100vw-240px)] lg:px-12 lg:py-8">
               <AppUpdateView />
               <Header />

--- a/src/renderer/views/wallet/PoolShareView.helper.ts
+++ b/src/renderer/views/wallet/PoolShareView.helper.ts
@@ -5,7 +5,7 @@ import { array as A, function as FP, option as O } from 'fp-ts'
 
 import { PoolShareTableData } from '../../components/PoolShares/PoolShares.types'
 import { ZERO_BASE_AMOUNT } from '../../const'
-import { THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
+import { convertBaseAmountDecimal, THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
 import { isPoolDetails } from '../../helpers/poolHelper'
 import * as ShareHelpers from '../../helpers/poolShareHelper'
 import { PoolDetails as PoolDetailsMaya } from '../../services/midgard/mayaMidgard/types'
@@ -45,7 +45,10 @@ export const getSharesTotal = (
           })
           const poolData = protocol === THORChain ? toPoolData(poolDetail) : toPoolDataMaya(poolDetail)
           // 2. price asset + rune
-          const assetDepositPrice = getValueOfAsset1InAsset2(assetShare, poolData, pricePoolData)
+          // Convert assetShare back to dexDecimal for pricing — poolData balances are in dexDecimal,
+          // so the raw amounts must be in the same base for correct ratio calculations
+          const assetShareForPricing = convertBaseAmountDecimal(assetShare, dexDecimal)
+          const assetDepositPrice = getValueOfAsset1InAsset2(assetShareForPricing, poolData, pricePoolData)
           const runeDepositPrice = getValueOfRuneInAsset(runeShare, pricePoolData)
 
           // 3. sum rune + asset values
@@ -84,7 +87,9 @@ export const getPoolShareTableData = (
           })
           const sharePercent = ShareHelpers.getPoolShare(units, poolDetail)
           const poolData = protocol === THORChain ? toPoolData(poolDetail) : toPoolDataMaya(poolDetail)
-          const assetDepositPrice = getValueOfAsset1InAsset2(assetShare, poolData, pricePoolData)
+          // Convert assetShare back to dexDecimal for pricing — must match poolData's decimal base
+          const assetShareForPricing = convertBaseAmountDecimal(assetShare, dexDecimal)
+          const assetDepositPrice = getValueOfAsset1InAsset2(assetShareForPricing, poolData, pricePoolData)
           const runeDepositPrice = getValueOfRuneInAsset(runeShare, pricePoolData)
 
           return {


### PR DESCRIPTION
Fix wildly inflated XRD value on LP shares page by converting assetShare back to dexDecimal before pricing — the raw amounts must match poolData's decimal base for correct ratio calculations. Also remove THORChain/MAYAChain logos and public IP display from sidebar footer, keeping only social icons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FLIP price fetching from CoinGecko with 10-minute caching, displayed in header stats
  * Implemented route-aware halted chain warnings that only appear on relevant pages (swap, pool, deposits)

* **Bug Fixes**
  * Fixed decimal conversion in pool share pricing calculations to ensure accurate valuations

* **Removals**
  * Removed public IP display from sidebar
  * Simplified sidebar footer with external links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->