### PR TITLE
Feat/wire 5 chains vultisig

### DIFF
--- a/src/main/api/mpc/index.ts
+++ b/src/main/api/mpc/index.ts
@@ -779,11 +779,25 @@ export function registerMpcIpcHandlers(ipcMain: IpcMain): void {
 
       // Step 6: Broadcast via SDK
       log.info(`[MPC IPC] Step 5: broadcastTx`)
-      const txHash: string = await vault.broadcastTx({
-        chain: sdkChain,
-        keysignPayload,
-        signature
-      })
+      let txHash: string
+      try {
+        txHash = await vault.broadcastTx({
+          chain: sdkChain,
+          keysignPayload,
+          signature
+        })
+      } catch (broadcastError: unknown) {
+        // Some chains (e.g. Solana) may report "already been processed" if the SDK
+        // submitted the tx internally before the explicit broadcast call.
+        // The tx succeeded — treat this as success with a placeholder hash.
+        const broadcastMsg = errorMsg(broadcastError)
+        if (broadcastMsg.includes('already been processed') || broadcastMsg.includes('AlreadyProcessed')) {
+          log.warn(`[MPC IPC] Broadcast reported duplicate — tx already submitted`, { chain })
+          txHash = 'broadcast-duplicate-tx-already-processed'
+        } else {
+          throw broadcastError
+        }
+      }
       log.info(`[MPC IPC] Step 5: broadcastTx complete`, { txHash })
 
       return { txHash }

--- a/src/renderer/services/cardano/balances.ts
+++ b/src/renderer/services/cardano/balances.ts
@@ -1,7 +1,14 @@
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { client$ } from './common'
+import { createEnhancedClient$ } from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
+import { client$, readOnlyClient$ } from './common'
+
+/**
+ * Enhanced client that switches between keystore and read-only client for standalone ledger mode
+ */
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`
@@ -9,13 +16,22 @@ import { client$ } from './common'
  * e.g. @see src/renderer/services/wallet/balances.ts:getChainBalance$
  */
 const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolean>(false)
+const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
-const resetReloadBalances = () => {
-  setReloadBalances(false)
+const resetReloadBalances = (walletType: WalletType) => {
+  if (isKeystoreReloadTrigger(walletType)) {
+    setReloadBalances(false)
+  } else {
+    setReloadLedgerBalances(false)
+  }
 }
 
-const reloadBalances = () => {
-  setReloadBalances(true)
+const reloadBalances = (walletType: WalletType) => {
+  if (isKeystoreReloadTrigger(walletType)) {
+    setReloadBalances(true)
+  } else {
+    setReloadLedgerBalances(true)
+  }
 }
 
 // State of balances loaded by Client
@@ -29,18 +45,26 @@ const balances$ = ({
   walletAccount: number
   walletIndex: number
   hdMode: HDMode
-}): C.WalletBalancesLD =>
-  C.balances$({
-    client$,
-    trigger$: reloadBalances$,
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
+  return C.balances$({
+    client$: enhancedClient$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType: 'all'
   })
+}
 
 // State of balances loaded by Client and Address
-const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$, walletBalanceType: 'all' })
+const getBalanceByAddress$ = C.balancesByAddress$({
+  client$: enhancedClient$,
+  trigger$: reloadLedgerBalances$,
+  walletBalanceType: 'all'
+})
 
 export { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/cardano/common.ts
+++ b/src/renderer/services/cardano/common.ts
@@ -79,4 +79,34 @@ const addressUI$: C.WalletAddress$ = C.addressUI$(client$, ADAChain)
  */
 const explorerUrl$: C.ExplorerUrl$ = C.explorerUrl$(client$)
 
-export { client$, clientState$, address$, addressUI$, explorerUrl$ }
+/**
+ * Read-only ADA client for balance queries without requiring keystore
+ * This client can be used for standalone ledger/Vultisig mode to query balances
+ */
+const readOnlyClientState$: Rx.Observable<RD.RemoteData<Error, ADAClient>> = FP.pipe(
+  clientNetwork$,
+  RxOp.map((network) => {
+    try {
+      const client = new ADAClient({
+        ...defaultAdaParams,
+        network: network,
+        apiKeys: {
+          blockfrostApiKeys
+        }
+      })
+      return RD.success(client)
+    } catch (error) {
+      logger.error('Failed to create read-only ADA client', error)
+      return RD.failure<Error>(isError(error) ? error : new Error('Unknown error'))
+    }
+  }),
+  RxOp.startWith<RD.RemoteData<Error, ADAClient>>(RD.pending),
+  RxOp.shareReplay(1)
+)
+
+const readOnlyClient$: Rx.Observable<O.Option<ADAClient>> = readOnlyClientState$.pipe(
+  RxOp.map(RD.toOption),
+  RxOp.shareReplay(1)
+)
+
+export { client$, clientState$, readOnlyClient$, address$, addressUI$, explorerUrl$ }

--- a/src/renderer/services/cardano/transaction.ts
+++ b/src/renderer/services/cardano/transaction.ts
@@ -8,11 +8,12 @@ import * as RxOp from 'rxjs/operators'
 
 import { IPCLedgerSendTxParams, ipcLedgerSendTxParamsIO } from '../../../shared/api/io'
 import { LedgerError } from '../../../shared/api/types'
-import { isLedgerWallet } from '../../../shared/utils/guard'
+import { isLedgerWallet, isVultisigWallet } from '../../../shared/utils/guard'
 import { Network$ } from '../app/types'
 import * as C from '../clients'
 import { TxHashLD, ErrorId } from '../wallet/types'
 import { TransactionService, Client$, SendTxParams } from './types'
+import { createVultisigCardanoTx } from './vultisigTx'
 
 export const createTransactionService = (client$: Client$, network$: Network$): TransactionService => {
   const common = C.createTransactionService(client$)
@@ -62,11 +63,15 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
   }
 
+  // Vultisig transaction handler — SDK native pipeline
+  const sendVultisigTx = createVultisigCardanoTx()
+
   const sendTx = (params: SendTxParams) =>
     FP.pipe(
       Rx.combineLatest([network$]),
       RxOp.switchMap(([network]) => {
         if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
+        if (isVultisigWallet(params.walletType)) return sendVultisigTx({ network, params })
 
         return common.sendTx(params)
       })

--- a/src/renderer/services/cardano/vultisigTx.ts
+++ b/src/renderer/services/cardano/vultisigTx.ts
@@ -1,0 +1,3 @@
+import { createVultisigSdkNativeTx } from '../shared/vultisigSdkTx'
+
+export const createVultisigCardanoTx = () => createVultisigSdkNativeTx('ADA')

--- a/src/renderer/services/kuji/balances.ts
+++ b/src/renderer/services/kuji/balances.ts
@@ -1,7 +1,14 @@
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { client$ } from './common'
+import { createEnhancedClient$ } from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
+import { client$, readOnlyClient$ } from './common'
+
+/**
+ * Enhanced client that switches between keystore and read-only client for standalone ledger mode
+ */
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`
@@ -9,13 +16,22 @@ import { client$ } from './common'
  * e.g. @see src/renderer/services/wallet/balances.ts:getChainBalance$
  */
 const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolean>(false)
+const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
-const resetReloadBalances = () => {
-  setReloadBalances(false)
+const resetReloadBalances = (walletType: WalletType) => {
+  if (isKeystoreReloadTrigger(walletType)) {
+    setReloadBalances(false)
+  } else {
+    setReloadLedgerBalances(false)
+  }
 }
 
-const reloadBalances = () => {
-  setReloadBalances(true)
+const reloadBalances = (walletType: WalletType) => {
+  if (isKeystoreReloadTrigger(walletType)) {
+    setReloadBalances(true)
+  } else {
+    setReloadLedgerBalances(true)
+  }
 }
 
 // State of balances loaded by Client
@@ -29,18 +45,26 @@ const balances$ = ({
   walletAccount: number
   walletIndex: number
   hdMode: HDMode
-}): C.WalletBalancesLD =>
-  C.balances$({
-    client$,
-    trigger$: reloadBalances$,
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
+  return C.balances$({
+    client$: enhancedClient$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType: 'all'
   })
+}
 
 // State of balances loaded by Client and Address
-const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$, walletBalanceType: 'all' })
+const getBalanceByAddress$ = C.balancesByAddress$({
+  client$: enhancedClient$,
+  trigger$: reloadLedgerBalances$,
+  walletBalanceType: 'all'
+})
 
 export { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/kuji/common.ts
+++ b/src/renderer/services/kuji/common.ts
@@ -66,4 +66,31 @@ const addressUI$: C.WalletAddress$ = C.addressUI$(client$, KUJIChain)
  */
 const explorerUrl$: C.ExplorerUrl$ = C.explorerUrl$(client$)
 
-export { client$, clientState$, address$, addressUI$, explorerUrl$ }
+/**
+ * Read-only KUJI client for balance queries without requiring keystore
+ * This client can be used for standalone ledger/Vultisig mode to query balances
+ */
+const readOnlyClientState$: Rx.Observable<RD.RemoteData<Error, KujiClient>> = FP.pipe(
+  clientNetwork$,
+  RxOp.map((network) => {
+    try {
+      const client = new KujiClient({
+        ...defaultKujiParams,
+        network: network
+      })
+      return RD.success(client)
+    } catch (error) {
+      logger.error('Failed to create read-only KUJI client', error)
+      return RD.failure<Error>(isError(error) ? error : new Error('Unknown error'))
+    }
+  }),
+  RxOp.startWith<RD.RemoteData<Error, KujiClient>>(RD.pending),
+  RxOp.shareReplay(1)
+)
+
+const readOnlyClient$: Rx.Observable<O.Option<KujiClient>> = readOnlyClientState$.pipe(
+  RxOp.map(RD.toOption),
+  RxOp.shareReplay(1)
+)
+
+export { client$, clientState$, readOnlyClient$, address$, addressUI$, explorerUrl$ }

--- a/src/renderer/services/kuji/transaction.ts
+++ b/src/renderer/services/kuji/transaction.ts
@@ -7,9 +7,10 @@ import * as RxOp from 'rxjs/operators'
 
 import { IPCLedgerSendTxParams, ipcLedgerSendTxParamsIO } from '../../../shared/api/io'
 import { LedgerError } from '../../../shared/api/types'
-import { isLedgerWallet } from '../../../shared/utils/guard'
+import { isLedgerWallet, isVultisigWallet } from '../../../shared/utils/guard'
 import { Network$ } from '../app/types'
 import * as C from '../clients'
+import { createVultisigCosmosTx } from '../cosmos/vultisigTx'
 import { TxHashLD, ErrorId } from '../wallet/types'
 import { TransactionService, Client$, SendTxParams } from './types'
 
@@ -61,11 +62,19 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
   }
 
+  // Vultisig transaction handler — SDK native pipeline
+  // KUJI uses 'ukuji' as native denom
+  const getDenom = (asset: { symbol?: string } | null) => (asset?.symbol?.toLowerCase() === 'kuji' ? 'ukuji' : null)
+  const vultisigTx = createVultisigCosmosTx('KUJI', getDenom, 'ukuji')
+  const sendVultisigTx = ({ network, params }: { network: Network; params: SendTxParams }): TxHashLD =>
+    vultisigTx({ network, params })
+
   const sendTx = (params: SendTxParams) =>
     FP.pipe(
       Rx.combineLatest([network$]),
       RxOp.switchMap(([network]) => {
         if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
+        if (isVultisigWallet(params.walletType)) return sendVultisigTx({ network, params })
 
         return common.sendTx(params)
       })

--- a/src/renderer/services/radix/balances.ts
+++ b/src/renderer/services/radix/balances.ts
@@ -1,7 +1,14 @@
 import { HDMode, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
-import { client$ } from './common'
+import { createEnhancedClient$ } from '../clients'
+import { isKeystoreReloadTrigger } from '../wallet/types'
+import { client$, readOnlyClient$ } from './common'
+
+/**
+ * Enhanced client that switches between keystore and read-only client for standalone ledger mode
+ */
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`
@@ -9,13 +16,22 @@ import { client$ } from './common'
  * e.g. @see src/renderer/services/wallet/balances.ts:getChainBalance$
  */
 const { get$: reloadBalances$, set: setReloadBalances } = observableState<boolean>(false)
+const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observableState<boolean>(false)
 
-const resetReloadBalances = () => {
-  setReloadBalances(false)
+const resetReloadBalances = (walletType: WalletType) => {
+  if (isKeystoreReloadTrigger(walletType)) {
+    setReloadBalances(false)
+  } else {
+    setReloadLedgerBalances(false)
+  }
 }
 
-const reloadBalances = () => {
-  setReloadBalances(true)
+const reloadBalances = (walletType: WalletType) => {
+  if (isKeystoreReloadTrigger(walletType)) {
+    setReloadBalances(true)
+  } else {
+    setReloadLedgerBalances(true)
+  }
 }
 
 // State of balances loaded by Client
@@ -29,18 +45,26 @@ const balances$ = ({
   walletAccount: number
   walletIndex: number
   hdMode: HDMode
-}): C.WalletBalancesLD =>
-  C.balances$({
-    client$,
-    trigger$: reloadBalances$,
+}): C.WalletBalancesLD => {
+  // Select trigger based on wallet type
+  const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
+
+  return C.balances$({
+    client$: enhancedClient$,
+    trigger$,
     walletType,
     walletAccount,
     walletIndex,
     hdMode,
     walletBalanceType: 'all'
   })
+}
 
 // State of balances loaded by Client and Address
-const getBalanceByAddress$ = C.balancesByAddress$({ client$, trigger$: reloadBalances$, walletBalanceType: 'all' })
+const getBalanceByAddress$ = C.balancesByAddress$({
+  client$: enhancedClient$,
+  trigger$: reloadLedgerBalances$,
+  walletBalanceType: 'all'
+})
 
 export { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/radix/common.ts
+++ b/src/renderer/services/radix/common.ts
@@ -65,4 +65,30 @@ const addressUI$: C.WalletAddress$ = C.addressUI$(client$, RadixChain)
  */
 const explorerUrl$: C.ExplorerUrl$ = C.explorerUrl$(client$)
 
-export { client$, clientState$, address$, addressUI$, explorerUrl$ }
+/**
+ * Read-only XRD client for balance queries without requiring keystore
+ * This client can be used for standalone ledger/Vultisig mode to query balances
+ */
+const readOnlyClientState$: Rx.Observable<RD.RemoteData<Error, RADIXClient>> = FP.pipe(
+  clientNetwork$,
+  RxOp.map((network) => {
+    try {
+      const client = new RADIXClient({
+        network: network
+      })
+      return RD.success(client)
+    } catch (error) {
+      logger.error('Failed to create read-only XRD client', error)
+      return RD.failure<Error>(isError(error) ? error : new Error('Unknown error'))
+    }
+  }),
+  RxOp.startWith<RD.RemoteData<Error, RADIXClient>>(RD.pending),
+  RxOp.shareReplay(1)
+)
+
+const readOnlyClient$: Rx.Observable<O.Option<RADIXClient>> = readOnlyClientState$.pipe(
+  RxOp.map(RD.toOption),
+  RxOp.shareReplay(1)
+)
+
+export { client$, clientState$, readOnlyClient$, address$, addressUI$, explorerUrl$ }

--- a/src/renderer/services/radix/transaction.ts
+++ b/src/renderer/services/radix/transaction.ts
@@ -20,12 +20,13 @@ import {
   ipcLedgerSendTxParamsIO
 } from '../../../shared/api/io'
 import { LedgerError } from '../../../shared/api/types'
-import { isLedgerWallet } from '../../../shared/utils/guard'
+import { isLedgerWallet, isVultisigWallet } from '../../../shared/utils/guard'
 import { sequenceSOption } from '../../helpers/fpHelpers'
 import { Network$ } from '../app/types'
 import * as C from '../clients'
 import { TxHashLD, ErrorId, ApiError } from '../wallet/types'
 import { SendPoolTxParams, TransactionService, Client$, SendTxParams } from './types'
+import { createVultisigRadixTx, createVultisigRadixPoolTx } from './vultisigTx'
 
 export const createTransactionService = (client$: Client$, network$: Network$): TransactionService => {
   const common = C.createTransactionService(client$)
@@ -114,11 +115,21 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
   }
 
+  // Vultisig transaction handlers — SDK native pipeline
+  const sendVultisigTx = createVultisigRadixTx()
+  const sendVultisigPoolTx = createVultisigRadixPoolTx()
+
   const sendPoolTx$ = (params: SendPoolTxParams): TxHashLD => {
     if (isLedgerWallet(params.walletType))
       return FP.pipe(
         network$,
         RxOp.switchMap((network) => sendLedgerPoolTx({ network, params }))
+      )
+
+    if (isVultisigWallet(params.walletType))
+      return FP.pipe(
+        network$,
+        RxOp.switchMap((network) => sendVultisigPoolTx({ network, params }))
       )
 
     return FP.pipe(
@@ -185,6 +196,7 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       Rx.combineLatest([network$]),
       RxOp.switchMap(([network]) => {
         if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
+        if (isVultisigWallet(params.walletType)) return sendVultisigTx({ network, params })
 
         return common.sendTx(params)
       })

--- a/src/renderer/services/radix/vultisigTx.ts
+++ b/src/renderer/services/radix/vultisigTx.ts
@@ -1,0 +1,11 @@
+import { createVultisigSdkNativeTx } from '../shared/vultisigSdkTx'
+import { ErrorId } from '../wallet/types'
+
+export const createVultisigRadixTx = () => createVultisigSdkNativeTx('XRD')
+
+// Pool deposits via SDK native pipeline.
+// Note: The SDK sendTransaction does not take a router param. For Radix pool deposits
+// that require calling `user_deposit` on a router contract, the SDK must handle this
+// internally based on the memo. If the SDK does not support this, pool deposits will
+// need a dedicated handler similar to the keystore path.
+export const createVultisigRadixPoolTx = () => createVultisigSdkNativeTx('XRD', ErrorId.POOL_TX)

--- a/src/renderer/services/radix/vultisigTx.ts
+++ b/src/renderer/services/radix/vultisigTx.ts
@@ -4,8 +4,9 @@ import { ErrorId } from '../wallet/types'
 export const createVultisigRadixTx = () => createVultisigSdkNativeTx('XRD')
 
 // Pool deposits via SDK native pipeline.
-// Note: The SDK sendTransaction does not take a router param. For Radix pool deposits
-// that require calling `user_deposit` on a router contract, the SDK must handle this
-// internally based on the memo. If the SDK does not support this, pool deposits will
-// need a dedicated handler similar to the keystore path.
+// Limitation: SDK sendTransaction has no router param. Radix pool deposits require
+// calling `user_deposit` on a router contract (see keystore path in transaction.ts).
+// Currently guarded at UI level — pool features are not yet enabled for Vultisig.
+// When enabled, this will need a dedicated handler if the SDK cannot infer router
+// semantics from memo alone.
 export const createVultisigRadixPoolTx = () => createVultisigSdkNativeTx('XRD', ErrorId.POOL_TX)

--- a/src/renderer/services/shared/vultisigSdkTx.ts
+++ b/src/renderer/services/shared/vultisigSdkTx.ts
@@ -30,10 +30,12 @@ type GenericSendParams = {
  *
  * @param chainName - Chain identifier (e.g., 'TRON', 'ADA', 'XRD')
  * @param errorId - Error ID to use on failure (default: ErrorId.SEND_TX)
+ * @param resolveId - Optional resolver for token identifier (contract address, denom, etc.)
  */
 export const createVultisigSdkNativeTx = (
   chainName: string,
-  errorId: ErrorId = ErrorId.SEND_TX
+  errorId: ErrorId = ErrorId.SEND_TX,
+  resolveId?: (asset: AnyAsset) => string | undefined
 ): ((args: { network: Network; params: GenericSendParams }) => TxHashLD) => {
   return ({ params }): TxHashLD => {
     const { asset, recipient, amount, memo } = params
@@ -44,6 +46,8 @@ export const createVultisigSdkNativeTx = (
       return Rx.of(RD.failure({ errorId, msg: 'No active Vultisig vault' }))
     }
 
+    const id = resolveId?.(asset)
+
     const txParams: SendTransactionParams = {
       vaultId,
       chain: chainName,
@@ -51,7 +55,8 @@ export const createVultisigSdkNativeTx = (
       amount: amount.amount().toFixed(),
       memo,
       decimals: amount.decimal,
-      ticker: asset.ticker
+      ticker: asset.ticker,
+      id
     }
 
     logger.info(`${chainName} sendTransaction via SDK pipeline`, {

--- a/src/renderer/services/shared/vultisigSdkTx.ts
+++ b/src/renderer/services/shared/vultisigSdkTx.ts
@@ -1,0 +1,89 @@
+/**
+ * Generic Vultisig SEND handler using SDK native pipeline
+ *
+ * Used by chains that don't fit UTXO or Cosmos patterns (TRON, ADA, XRD, etc.)
+ * Uses SDK native pipeline: prepareSendTx → extractMessageHashes → sign → broadcastTx
+ */
+import * as RD from '@devexperts/remote-data-ts'
+import { Network } from '@xchainjs/xchain-client'
+import { AnyAsset, BaseAmount } from '@xchainjs/xchain-util'
+import * as Rx from 'rxjs'
+import * as RxOp from 'rxjs/operators'
+
+import { SendTransactionParams } from '../../../shared/api/mpcTypes'
+import { createScopedLogger } from '../../helpers/logger'
+import { appWalletService } from '../wallet/appWallet'
+import { ErrorId, TxHashLD } from '../wallet/types'
+
+const logger = createScopedLogger('Vultisig')
+
+/** Minimal params shape shared across chain-specific SendTxParams */
+type GenericSendParams = {
+  recipient: string
+  amount: BaseAmount
+  asset: AnyAsset
+  memo?: string
+}
+
+/**
+ * Creates a Vultisig send handler for any chain using the SDK native pipeline.
+ *
+ * @param chainName - Chain identifier (e.g., 'TRON', 'ADA', 'XRD')
+ * @param errorId - Error ID to use on failure (default: ErrorId.SEND_TX)
+ */
+export const createVultisigSdkNativeTx = (
+  chainName: string,
+  errorId: ErrorId = ErrorId.SEND_TX
+): ((args: { network: Network; params: GenericSendParams }) => TxHashLD) => {
+  return ({ params }): TxHashLD => {
+    const { asset, recipient, amount, memo } = params
+
+    const vaultId = appWalletService.getActiveVaultId()
+    if (!vaultId) {
+      logger.error(`${chainName} tx failed: no active vault`)
+      return Rx.of(RD.failure({ errorId, msg: 'No active Vultisig vault' }))
+    }
+
+    const txParams: SendTransactionParams = {
+      vaultId,
+      chain: chainName,
+      receiver: recipient,
+      amount: amount.amount().toFixed(),
+      memo,
+      decimals: amount.decimal,
+      ticker: asset.ticker
+    }
+
+    logger.info(`${chainName} sendTransaction via SDK pipeline`, {
+      receiver: recipient,
+      amount: amount.amount().toFixed(),
+      memo: memo || '(none)',
+      vaultId,
+      ticker: asset.ticker
+    })
+
+    return Rx.from(window.apiMpc.sendTransaction(txParams)).pipe(
+      RxOp.map(({ txHash }) => {
+        logger.info(`${chainName} tx success`, { txHash })
+        return RD.success(txHash)
+      }),
+      RxOp.catchError((error) => {
+        const errorMsg = error?.message ?? error.toString()
+
+        if (errorMsg.includes('Signing cancelled')) {
+          logger.info(`${chainName} tx cancelled by user`)
+          return Rx.of(RD.initial)
+        }
+
+        logger.error(`${chainName} tx failed`, { error: errorMsg })
+        return Rx.of(
+          RD.failure({
+            errorId,
+            msg: `Vultisig ${chainName} tx failed: ${errorMsg}`
+          })
+        )
+      }),
+      RxOp.startWith(RD.pending)
+    )
+  }
+}

--- a/src/renderer/services/thorchain/index.ts
+++ b/src/renderer/services/thorchain/index.ts
@@ -59,7 +59,7 @@ const {
 } = createThornodeService$(network$, clientUrl$)
 
 const { txs$, tx$, txStatus$, subscribeTx, resetTx, sendTx, txRD$, sendPoolTx$ } = createTransactionService(
-  client$,
+  enhancedClient$,
   network$,
   clientUrl$
 )

--- a/src/renderer/services/tron/transaction.ts
+++ b/src/renderer/services/tron/transaction.ts
@@ -7,7 +7,7 @@ import * as RxOp from 'rxjs/operators'
 
 import { IPCLedgerSendTxParams, ipcLedgerSendTxParamsIO } from '../../../shared/api/io'
 import { LedgerError } from '../../../shared/api/types'
-import { isLedgerWallet } from '../../../shared/utils/guard'
+import { isLedgerWallet, isVultisigWallet } from '../../../shared/utils/guard'
 import { addressInTRONTRC20Whitelist } from '../../helpers/assetHelper'
 import { LiveData } from '../../helpers/rx/liveData'
 import { Network$ } from '../app/types'
@@ -22,6 +22,7 @@ import {
   SendTxParams,
   TransactionService
 } from './types'
+import { createVultisigTronTx } from './vultisigTx'
 
 export const createTransactionService = (client$: Client$, network$: Network$): TransactionService => {
   const common = C.createTransactionService(client$)
@@ -173,12 +174,16 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       )
     )
 
+  // Vultisig transaction handler — SDK native pipeline
+  const sendVultisigTx = createVultisigTronTx()
+
   const sendTx = (params: SendTxParams): TxHashLD =>
     FP.pipe(
       network$,
       RxOp.take(1),
       RxOp.switchMap((network) => {
         if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
+        if (isVultisigWallet(params.walletType)) return sendVultisigTx({ network, params })
 
         return common.sendTx(params)
       })

--- a/src/renderer/services/tron/vultisigTx.ts
+++ b/src/renderer/services/tron/vultisigTx.ts
@@ -1,0 +1,3 @@
+import { createVultisigSdkNativeTx } from '../shared/vultisigSdkTx'
+
+export const createVultisigTronTx = () => createVultisigSdkNativeTx('TRON')

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -142,10 +142,10 @@ export const createBalancesService = ({
         if (enabledChainsSet.has(LTCChain)) reloadFunctions.push(() => LTC.reloadBalances(walletType))
         if (enabledChainsSet.has(DOGEChain)) reloadFunctions.push(() => DOGE.reloadBalances(walletType))
         if (enabledChainsSet.has(GAIAChain)) reloadFunctions.push(() => COSMOS.reloadBalances(walletType))
-        if (enabledChainsSet.has(KUJIChain)) reloadFunctions.push(() => KUJI.reloadBalances())
-        if (enabledChainsSet.has(ADAChain)) reloadFunctions.push(() => ADA.reloadBalances())
+        if (enabledChainsSet.has(KUJIChain)) reloadFunctions.push(() => KUJI.reloadBalances(walletType))
+        if (enabledChainsSet.has(ADAChain)) reloadFunctions.push(() => ADA.reloadBalances(walletType))
         if (enabledChainsSet.has(XRPChain)) reloadFunctions.push(() => XRP.reloadBalances(walletType))
-        if (enabledChainsSet.has(RadixChain)) reloadFunctions.push(() => XRD.reloadBalances())
+        if (enabledChainsSet.has(RadixChain)) reloadFunctions.push(() => XRD.reloadBalances(walletType))
         if (enabledChainsSet.has(SOLChain)) reloadFunctions.push(() => SOL.reloadBalances())
         if (enabledChainsSet.has(TRONChain)) reloadFunctions.push(() => TRON.reloadBalances(walletType))
         if (enabledChainsSet.has(ZECChain)) reloadFunctions.push(() => ZEC.reloadBalances(walletType))
@@ -335,15 +335,15 @@ export const createBalancesService = ({
           }
         case KUJIChain:
           return {
-            reloadBalances: KUJI.reloadBalances,
-            resetReloadBalances: KUJI.resetReloadBalances,
+            reloadBalances: () => KUJI.reloadBalances(walletType),
+            resetReloadBalances: () => KUJI.resetReloadBalances(walletType),
             balances$: KUJI.balances$({ walletType, walletAccount, walletIndex, hdMode }),
             reloadBalances$: KUJI.reloadBalances$
           }
         case ADAChain:
           return {
-            reloadBalances: ADA.reloadBalances,
-            resetReloadBalances: ADA.resetReloadBalances,
+            reloadBalances: () => ADA.reloadBalances(walletType),
+            resetReloadBalances: () => ADA.resetReloadBalances(walletType),
             balances$: ADA.balances$({ walletType, walletAccount, walletIndex, hdMode }),
             reloadBalances$: ADA.reloadBalances$
           }
@@ -356,8 +356,8 @@ export const createBalancesService = ({
           }
         case RadixChain:
           return {
-            reloadBalances: XRD.reloadBalances,
-            resetReloadBalances: XRD.resetReloadBalances,
+            reloadBalances: () => XRD.reloadBalances(walletType),
+            resetReloadBalances: () => XRD.resetReloadBalances(walletType),
             balances$: XRD.balances$({ walletType, walletAccount, walletIndex, hdMode }),
             reloadBalances$: XRD.reloadBalances$
           }

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -160,7 +160,7 @@ export const createBalancesService = ({
     [BTCChain]: BTC.reloadBalances,
     [DASHChain]: DASH.reloadBalances,
     [BCHChain]: BCH.reloadBalances,
-    [ETHChain]: (walletType) => ETH.reloadBalances(walletType), // Accept walletType
+    [ETHChain]: ETH.reloadBalances,
     [ARBChain]: ARB.reloadBalances,
     [AVAXChain]: AVAX.reloadBalances,
     [BSCChain]: BSC.reloadBalances,

--- a/src/renderer/services/zcash/balances.ts
+++ b/src/renderer/services/zcash/balances.ts
@@ -1,8 +1,14 @@
 import { HDMode, WalletBalanceType, WalletType } from '../../../shared/wallet/types'
 import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
+import { createEnhancedClient$ } from '../clients'
 import { isKeystoreReloadTrigger } from '../wallet/types'
-import { client$ } from './common'
+import { client$, readOnlyClient$ } from './common'
+
+/**
+ * Enhanced client that switches between keystore and read-only client for standalone ledger mode
+ */
+const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
 
 /**
  * `ObservableState` to reload `Balances`
@@ -45,7 +51,7 @@ const balances$ = ({
 
   // For ZEC, we'll always use 'all' balance type since it might not support confirmed/unconfirmed distinction
   return C.balances$({
-    client$,
+    client$: enhancedClient$,
     trigger$,
     walletType,
     walletAccount,
@@ -57,6 +63,6 @@ const balances$ = ({
 
 // State of balances loaded by Client and Address
 const getBalanceByAddress$ = (walletBalanceType: WalletBalanceType) =>
-  C.balancesByAddress$({ client$, trigger$: reloadLedgerBalances$, walletBalanceType })
+  C.balancesByAddress$({ client$: enhancedClient$, trigger$: reloadLedgerBalances$, walletBalanceType })
 
 export { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances }

--- a/src/renderer/services/zcash/transaction.ts
+++ b/src/renderer/services/zcash/transaction.ts
@@ -8,11 +8,12 @@ import * as RxOp from 'rxjs/operators'
 import { blockcypherApiKey } from '../../../shared/api/blockcypher'
 import { IPCLedgerSendTxParams, ipcLedgerSendTxParamsIO } from '../../../shared/api/io'
 import { LedgerError } from '../../../shared/api/types'
-import { isLedgerWallet } from '../../../shared/utils/guard'
+import { isLedgerWallet, isVultisigWallet } from '../../../shared/utils/guard'
 import { getUtxoErrorMessage } from '../../helpers/utxoErrorHelper'
 import { Network$ } from '../app/types'
 import * as C from '../clients'
 import { SendTxParams, TransactionService } from '../utxo/types'
+import { createVultisigUtxoTx } from '../utxo/vultisigTx'
 import { TxHashLD, ErrorId } from '../wallet/types'
 import { Client$ } from './types'
 
@@ -85,11 +86,16 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
       RxOp.startWith(RD.pending)
     )
   }
+
+  // Vultisig transaction handler - MPC signing for ZEC using PSBT
+  const sendVultisigTx = createVultisigUtxoTx(client$, 'ZEC')
+
   const sendTx = (params: SendTxParams): TxHashLD =>
     FP.pipe(
       network$,
       RxOp.switchMap((network) => {
         if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
+        if (isVultisigWallet(params.walletType)) return sendVultisigTx({ network, params })
 
         if (params.sendMax) return sendKeystoreMaxTx(params)
 

--- a/src/renderer/services/zcash/transaction.ts
+++ b/src/renderer/services/zcash/transaction.ts
@@ -87,7 +87,7 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
   }
 
-  // Vultisig transaction handler - MPC signing for ZEC using PSBT
+  // Vultisig transaction handler - MPC signing for ZEC via SDK native pipeline
   const sendVultisigTx = createVultisigUtxoTx(client$, 'ZEC')
 
   const sendTx = (params: SendTxParams): TxHashLD =>

--- a/src/shared/api/mpcTypes.test.ts
+++ b/src/shared/api/mpcTypes.test.ts
@@ -4,8 +4,8 @@ import { ASGARDEX_TO_SDK_CHAIN, SDK_TO_ASGARDEX_CHAIN, MpcIPCMessages } from './
 
 describe('shared/api/mpcTypes', () => {
   describe('ASGARDEX_TO_SDK_CHAIN', () => {
-    it('contains 15 chain mappings', () => {
-      expect(Object.keys(ASGARDEX_TO_SDK_CHAIN)).toHaveLength(15)
+    it('contains 20 chain mappings', () => {
+      expect(Object.keys(ASGARDEX_TO_SDK_CHAIN)).toHaveLength(20)
     })
 
     it('has no duplicate SDK chain values', () => {
@@ -74,7 +74,25 @@ describe('shared/api/mpcTypes', () => {
       expect(ASGARDEX_TO_SDK_CHAIN['SOL']).toBe('Solana')
     })
 
-    // ZEC, KUJI, ADA, TRON, XRD removed — re-add in follow-up PR
+    it('maps ZEC to Zcash', () => {
+      expect(ASGARDEX_TO_SDK_CHAIN['ZEC']).toBe('Zcash')
+    })
+
+    it('maps KUJI to Kujira', () => {
+      expect(ASGARDEX_TO_SDK_CHAIN['KUJI']).toBe('Kujira')
+    })
+
+    it('maps ADA to Cardano', () => {
+      expect(ASGARDEX_TO_SDK_CHAIN['ADA']).toBe('Cardano')
+    })
+
+    it('maps TRON to Tron', () => {
+      expect(ASGARDEX_TO_SDK_CHAIN['TRON']).toBe('Tron')
+    })
+
+    it('maps XRD to Radix', () => {
+      expect(ASGARDEX_TO_SDK_CHAIN['XRD']).toBe('Radix')
+    })
   })
 
   describe('SDK_TO_ASGARDEX_CHAIN', () => {

--- a/src/shared/api/mpcTypes.ts
+++ b/src/shared/api/mpcTypes.ts
@@ -152,7 +152,12 @@ export const ASGARDEX_TO_SDK_CHAIN: Record<string, string> = {
   BASE: 'Base',
   DASH: 'Dash',
   XRP: 'Ripple',
-  SOL: 'Solana'
+  SOL: 'Solana',
+  ZEC: 'Zcash',
+  KUJI: 'Kujira',
+  ADA: 'Cardano',
+  TRON: 'Tron',
+  XRD: 'Radix'
 }
 
 export const SDK_TO_ASGARDEX_CHAIN: Record<string, string> = Object.entries(ASGARDEX_TO_SDK_CHAIN).reduce(


### PR DESCRIPTION
Summary

  - Add Vultisig MPC wallet support (balance loading + send transactions) for 5 chains
  previously removed from ASGARDEX_TO_SDK_CHAIN: ZEC, KUJI, ADA, TRON, XRD
  - Add readOnlyClient$ + enhancedClient$ for KUJI, ADA, XRD (ZEC/TRON already had them)
  so balances load in standalone Vultisig/Ledger mode
  - Extract shared createVultisigSdkNativeTx factory for non-UTXO/non-Cosmos chains to
  avoid duplication
  - ZEC reuses createVultisigUtxoTx, KUJI reuses createVultisigCosmosTx, TRON/ADA/XRD use
  the new generic SDK native pipeline handler
  - XRD also wires Vultisig routing for sendPoolTx$


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vultisig wallet support added across multiple chains (Cardano, Kujira, Tron, Zcash, Radix).
  * Balance reloads now respect wallet type (ledger vs keystore), improving ledger-only and read-only workflows.

* **Bug Fixes**
  * Duplicate/previously-processed transaction broadcasts are now handled gracefully to avoid unnecessary failures.

* **Chores**
  * Expanded chain mappings and increased test coverage for new chain entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->