### PR TITLE
Fix/sdk disposal error recovery

### DIFF
--- a/src/renderer/hooks/useSymDepositAddresses.ts
+++ b/src/renderer/hooks/useSymDepositAddresses.ts
@@ -65,6 +65,8 @@ export const useSymDepositAddresses = ({
     O.none
   )
 
+  // Ledger uses dedicated ledger address resolution; Keystore and Vultisig both resolve
+  // through the unified addressByChain$ (which handles Vultisig via getAddressForChain$)
   const symDepositAddresses = {
     asset: isLedgerWallet(assetWalletType) ? oAssetLedgerWalletAddress : oAssetWalletAddress,
     dex: isLedgerWallet(dexWalletType) ? runeLedgerAddress : oDexWalletAddress

--- a/src/renderer/hooks/useTradeDepositAddresses.ts
+++ b/src/renderer/hooks/useTradeDepositAddresses.ts
@@ -22,7 +22,7 @@ export const useTradeDepositAddresses = ({ protocol, walletType }: { protocol: C
 
   const [oProtocolAddress, setOProtocolAddress] = useState<O.Option<WalletAddress>>(O.none)
 
-  // Get keystore address
+  // Get address for Keystore or Vultisig (unified addressByChain$ handles both)
   useEffect(() => {
     if (!isLedgerWallet(walletType)) {
       const subscription = addressByChain$(protocol).subscribe(setOProtocolAddress)

--- a/src/renderer/services/clients/address.ts
+++ b/src/renderer/services/clients/address.ts
@@ -7,6 +7,7 @@ import { WalletAddress, WalletType } from '../../../shared/wallet/types'
 import { removeAddressPrefix } from '../../helpers/addressHelper'
 import { WalletAddress$, XChainClient$ } from '../clients/types'
 import { appWalletService } from '../wallet/appWallet'
+import { isStandaloneLedgerMode } from '../wallet/types'
 
 /**
  * Unified address resolution (Phase 5C)
@@ -19,11 +20,18 @@ import { appWalletService } from '../wallet/appWallet'
  * 2. If O.none (Keystore mode), fall back to xchainjs client
  */
 export const addressUI$: (client$: XChainClient$, chain: Chain) => WalletAddress$ = (client$, chain) =>
-  Rx.combineLatest([client$, appWalletService.getAddressForChain$(chain)]).pipe(
-    RxOp.switchMap(([oClient, unifiedAddress]) => {
+  Rx.combineLatest([client$, appWalletService.getAddressForChain$(chain), appWalletService.appWalletState$]).pipe(
+    RxOp.switchMap(([oClient, unifiedAddress, appState]) => {
       // If unified method returned an address (Vultisig or Ledger mode)
       if (O.isSome(unifiedAddress)) {
         const walletType = appWalletService.getCurrentWalletType()
+
+        // In Ledger standalone mode, preserve the full WalletAddress metadata
+        // (walletAccount, walletIndex, hdMode) from the state
+        if (isStandaloneLedgerMode(appState) && appState.address) {
+          return Rx.of<O.Option<WalletAddress>>(O.some(appState.address))
+        }
+
         return Rx.of<O.Option<WalletAddress>>(
           O.some({
             address: unifiedAddress.value,

--- a/src/renderer/services/wallet/appWallet.ts
+++ b/src/renderer/services/wallet/appWallet.ts
@@ -155,20 +155,26 @@ export const createAppWalletService = (): AppWalletService => {
    * Switch to keystore mode - clears standalone states
    */
   const switchToKeystoreMode = async () => {
-    // Exit standalone modes first
-    standaloneLedgerService.exitStandaloneMode()
-    vaultManager.exitStandaloneMode()
+    try {
+      // Exit standalone modes first
+      standaloneLedgerService.exitStandaloneMode()
+      vaultManager.exitStandaloneMode()
 
-    // Set app state to current keystore state
-    const keystoreState = await keystoreService.keystoreState$
-      .pipe(RxOp.take(1), RxOp.timeout(10_000))
-      .toPromise()
-      .catch((err) => {
-        logger.error('switchToKeystoreMode: timed out waiting for keystore state', err)
-        return undefined
-      })
-    if (keystoreState !== undefined) {
-      setAppWalletState(keystoreState)
+      // Set app state to current keystore state
+      const keystoreState = await keystoreService.keystoreState$
+        .pipe(RxOp.take(1), RxOp.timeout(10_000))
+        .toPromise()
+        .catch((err) => {
+          logger.error('switchToKeystoreMode: timed out waiting for keystore state', err)
+          return undefined
+        })
+      if (keystoreState !== undefined) {
+        setAppWalletState(keystoreState)
+      }
+    } catch (error) {
+      // Recover to a safe state — set app state to None (no keystore loaded)
+      logger.error('switchToKeystoreMode failed, resetting to initial state', error)
+      setAppWalletState(INITIAL_APP_WALLET_STATE)
     }
   }
 


### PR DESCRIPTION

  1. switchToKeystoreMode error recovery — try/catch with safe state reset on failure
  2. addressUI$ Ledger metadata — preserves full WalletAddress (walletAccount,
  walletIndex, hdMode) from standalone Ledger state instead of hardcoding 0/0/default
  3. Deposit hook comments — clarified that binary Ledger check works correctly for
  Vultisig via unified addressByChain$

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery when switching to Keystore mode, with automatic fallback to a stable initial state.

* **Refactor**
  * Enhanced address resolution for Ledger standalone mode, preserving wallet configuration from app state.
  * Added clarifications to address resolution comments for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->