### PR TITLE
feat: add THORChain rapid swap mode and lazy LP share fetching

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -651,7 +651,9 @@ export const Swap = ({
     poolAddressThor: oPoolAddressThor,
     poolAddressMaya: oPoolAddressMaya,
     network,
-    isSendMax
+    isSendMax,
+    streamingInterval,
+    streamingQuantity
   })
 
   // ─── Remaining component logic ─────────────────────────────────────────────

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -223,8 +223,7 @@ export const Swap = ({
     activeMode,
     setMode,
     setInterval: setStreamingInterval,
-    setQuantity,
-    resetToDefault
+    setQuantity
   } = useStreamingParams()
 
   const { balances: oWalletBalances, loading: walletBalancesLoading } = walletBalances

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -216,8 +216,16 @@ export const Swap = ({
 
   const { isAssetSupported$, transactionTrackingService: chainflipTransactionTrackingService } = useChainflipContext()
 
-  const { streamingInterval, streamingQuantity, isStreaming, activeMode, setMode, setQuantity, resetToDefault } =
-    useStreamingParams()
+  const {
+    streamingInterval,
+    streamingQuantity,
+    isStreaming,
+    activeMode,
+    setMode,
+    setInterval: setStreamingInterval,
+    setQuantity,
+    resetToDefault
+  } = useStreamingParams()
 
   const { balances: oWalletBalances, loading: walletBalancesLoading } = walletBalances
 
@@ -1287,11 +1295,11 @@ export const Swap = ({
         streamingInterval={streamingInterval}
         streamingQuantity={streamingQuantity}
         onModeChange={setMode}
+        onIntervalChange={setStreamingInterval}
         onQuantityChange={setQuantity}
-        onReset={resetToDefault}
       />
     ),
-    [activeMode, streamingInterval, streamingQuantity, setMode, setQuantity, resetToDefault]
+    [activeMode, streamingInterval, streamingQuantity, setMode, setStreamingInterval, setQuantity]
   )
 
   const swapTxSource = useMemo(() => ({ asset: sourceAsset, amount: amountToSwap }), [sourceAsset, amountToSwap])

--- a/src/renderer/components/swap/TradeSwap.tsx
+++ b/src/renderer/components/swap/TradeSwap.tsx
@@ -679,7 +679,6 @@ export const TradeSwap = ({
       targetAsset,
       amountToSwapMax1e8,
       sourceAssetDecimal,
-      isStreaming,
       streamingInterval,
       streamingQuantity,
       network,

--- a/src/renderer/components/swap/TradeSwap.tsx
+++ b/src/renderer/components/swap/TradeSwap.tsx
@@ -655,9 +655,8 @@ export const TradeSwap = ({
           const amount = new CryptoAmount(convertBaseAmountDecimal(amountToSwapMax1e8, sourceAssetDecimal), sourceAsset)
           const address = destinationAddress
           const affiliate = ASGARDEX_ADDRESS === walletAddress ? undefined : getAsgardexThorname(network)
-          // Rapid (interval=0): omit streaming params — THORChain auto-handles rapid
-          const streamingInt = streamingInterval === 0 ? undefined : streamingInterval
-          const streaminQuant = streamingInterval === 0 ? undefined : streamingQuantity
+          const streamingInt = streamingInterval
+          const streaminQuant = streamingQuantity
           const toleranceBps = slipTolerance * 100 // convert to basis points
           return {
             fromAsset: fromAsset,
@@ -728,8 +727,8 @@ export const TradeSwap = ({
             fromAsset: sourceAsset,
             destinationAsset: targetAsset,
             amount: new CryptoAmount(convertBaseAmountDecimal(amountToSwapMax1e8, sourceAssetDecimal), sourceAsset),
-            streamingInterval: streamingInterval === 0 ? undefined : streamingInterval,
-            streamingQuantity: streamingInterval === 0 ? undefined : streamingQuantity,
+            streamingInterval: streamingInterval,
+            streamingQuantity: streamingQuantity,
             toleranceBps: slipTolerance * 100, // convert to basis points
             affiliateAddress: affiliateName,
             affiliateBps: 0

--- a/src/renderer/components/swap/TradeSwap.tsx
+++ b/src/renderer/components/swap/TradeSwap.tsx
@@ -54,7 +54,7 @@ import { unionAssets } from '../../helpers/fp/array'
 import { eqAsset, eqBaseAmount, eqOAsset, eqAddress } from '../../helpers/fp/eq'
 import { sequenceTOption } from '../../helpers/fpHelpers'
 import { logger } from '../../helpers/logger'
-import { getSwapMemo, updateMemoWithFullAsset } from '../../helpers/memoHelper'
+import { applyStreamingToMemo, getSwapMemo, updateMemoWithFullAsset } from '../../helpers/memoHelper'
 import * as PoolHelpers from '../../helpers/poolHelper'
 import { isPoolDetails } from '../../helpers/poolHelper'
 import * as PoolHelpersMaya from '../../helpers/poolHelperMaya'
@@ -243,8 +243,9 @@ export const TradeSwap = ({
   const pricePoolThor = usePricePool()
   const pricePoolMaya = usePricePoolMaya()
 
+  const supportRapid = protocol === THORChain
   const { streamingInterval, streamingQuantity, isStreaming, activeMode, setMode, setQuantity, resetToDefault } =
-    useStreamingParams()
+    useStreamingParams(supportRapid)
 
   const [oTargetWalletType, setTargetWalletType] = useState<O.Option<WalletType>>(oInitialTargetWalletType)
 
@@ -654,8 +655,9 @@ export const TradeSwap = ({
           const amount = new CryptoAmount(convertBaseAmountDecimal(amountToSwapMax1e8, sourceAssetDecimal), sourceAsset)
           const address = destinationAddress
           const affiliate = ASGARDEX_ADDRESS === walletAddress ? undefined : getAsgardexThorname(network)
-          const streamingInt = isStreaming ? streamingInterval : 0
-          const streaminQuant = isStreaming ? streamingQuantity : 0
+          // Rapid (interval=0): omit streaming params — THORChain auto-handles rapid
+          const streamingInt = streamingInterval === 0 ? undefined : streamingInterval
+          const streaminQuant = streamingInterval === 0 ? undefined : streamingQuantity
           const toleranceBps = slipTolerance * 100 // convert to basis points
           return {
             fromAsset: fromAsset,
@@ -727,8 +729,8 @@ export const TradeSwap = ({
             fromAsset: sourceAsset,
             destinationAsset: targetAsset,
             amount: new CryptoAmount(convertBaseAmountDecimal(amountToSwapMax1e8, sourceAssetDecimal), sourceAsset),
-            streamingInterval: isStreaming ? streamingInterval : 0,
-            streamingQuantity: isStreaming ? streamingQuantity : 0,
+            streamingInterval: streamingInterval === 0 ? undefined : streamingInterval,
+            streamingQuantity: streamingInterval === 0 ? undefined : streamingQuantity,
             toleranceBps: slipTolerance * 100, // convert to basis points
             affiliateAddress: affiliateName,
             affiliateBps: 0
@@ -1025,7 +1027,11 @@ export const TradeSwap = ({
         poolAddress,
         asset: sourceAsset,
         amount: convertBaseAmountDecimal(amountToSwapMax1e8, sourceAssetAmount.decimal),
-        memo: updateMemoWithFullAsset(quoteData.memo, targetAsset),
+        memo: applyStreamingToMemo(
+          updateMemoWithFullAsset(quoteData.memo, targetAsset),
+          streamingInterval,
+          streamingQuantity
+        ),
         walletType,
         sender: walletAddress,
         walletAccount,
@@ -1049,7 +1055,9 @@ export const TradeSwap = ({
     amountToSwapMax1e8,
     isSourceUTXO,
     isSendMax,
-    sourceAssetAmount.decimal
+    sourceAssetAmount.decimal,
+    streamingInterval,
+    streamingQuantity
   ])
 
   // Check to see slippage greater than tolerance
@@ -1328,16 +1336,11 @@ export const TradeSwap = ({
       percentageDifference = ((swapSlippage - swapStreamingSlippage) / swapSlippage) * 100
     }
 
-    if (!isStreaming) {
-      percentageDifference = 0
-    }
-
     // Check if percentageDifference is a number
     const isPercentageValid = !isNaN(percentageDifference) && isFinite(percentageDifference)
-    const streamingVal = isStreaming ? 'Streaming' : 'Limit'
     const streamerComparison = isPercentageValid
       ? percentageDifference <= 1
-        ? `Instant ${streamingVal} swap `
+        ? `Instant Streaming swap `
         : `${percentageDifference.toFixed(2)}% Better swap execution via streaming`
       : 'Invalid or zero slippage' // Default message for invalid or zero slippage
 
@@ -1347,10 +1350,9 @@ export const TradeSwap = ({
         percent={percentageDifference}
         withLabel
         labels={[`${streamerComparison}`, ``]}
-        hasError={!isStreaming}
       />
     )
-  }, [isStreaming, swapSlippage, swapStreamingSlippage])
+  }, [swapSlippage, swapStreamingSlippage])
 
   const swapTxSource = useMemo(
     () => ({ asset: sourceAsset, amount: amountToSwapMax1e8 }),
@@ -1832,6 +1834,7 @@ export const TradeSwap = ({
             onQuantityChange={setQuantity}
             onReset={resetToDefault}
             maxStreamingQuantity={maxStreamingQuantity}
+            supportRapid={supportRapid}
           />
           {renderStreamerReturns}
           <Collapse

--- a/src/renderer/components/swap/TradeSwap.tsx
+++ b/src/renderer/components/swap/TradeSwap.tsx
@@ -244,8 +244,16 @@ export const TradeSwap = ({
   const pricePoolMaya = usePricePoolMaya()
 
   const supportRapid = protocol === THORChain
-  const { streamingInterval, streamingQuantity, isStreaming, activeMode, setMode, setQuantity, resetToDefault } =
-    useStreamingParams(supportRapid)
+  const {
+    streamingInterval,
+    streamingQuantity,
+    isStreaming,
+    activeMode,
+    setMode,
+    setInterval: setStreamingInterval,
+    setQuantity,
+    resetToDefault
+  } = useStreamingParams(supportRapid)
 
   const [oTargetWalletType, setTargetWalletType] = useState<O.Option<WalletType>>(oInitialTargetWalletType)
 
@@ -1829,8 +1837,8 @@ export const TradeSwap = ({
             streamingInterval={streamingInterval}
             streamingQuantity={streamingQuantity}
             onModeChange={setMode}
+            onIntervalChange={setStreamingInterval}
             onQuantityChange={setQuantity}
-            onReset={resetToDefault}
             maxStreamingQuantity={maxStreamingQuantity}
             supportRapid={supportRapid}
           />

--- a/src/renderer/components/swap/TradeSwap.tsx
+++ b/src/renderer/components/swap/TradeSwap.tsx
@@ -251,8 +251,7 @@ export const TradeSwap = ({
     activeMode,
     setMode,
     setInterval: setStreamingInterval,
-    setQuantity,
-    resetToDefault
+    setQuantity
   } = useStreamingParams(supportRapid)
 
   const [oTargetWalletType, setTargetWalletType] = useState<O.Option<WalletType>>(oInitialTargetWalletType)

--- a/src/renderer/components/swap/components/SwapSettings.tsx
+++ b/src/renderer/components/swap/components/SwapSettings.tsx
@@ -1,39 +1,42 @@
 import { useCallback, useMemo } from 'react'
 
-import { ArrowPathIcon } from '@heroicons/react/24/outline'
 import { useIntl } from 'react-intl'
 
 import type { StreamingMode } from '../../../hooks/useStreamingParams'
-import { BaseButton } from '../../uielements/button'
 import { Collapse } from '../../uielements/collapse'
 import { RadioGroup } from '../../uielements/radioGroup/RadioGroup'
 import { Slider } from '../../uielements/slider'
-import { Tooltip } from '../../uielements/tooltip'
 
 type Props = {
   activeMode: StreamingMode
-  streamingInterval?: number
+  streamingInterval: number
   streamingQuantity: number
   onModeChange: (mode: StreamingMode) => void
+  onIntervalChange: (interval: number) => void
   onQuantityChange: (value: number) => void
-  onReset: () => void
   maxStreamingQuantity?: number
   supportRapid?: boolean
 }
 
 const MODE_LABEL_KEYS: Record<StreamingMode, string> = {
   0: 'swap.mode.rapid',
-  1: 'swap.mode.fast',
-  2: 'swap.mode.balanced',
-  3: 'swap.mode.bestPrice'
+  1: 'swap.mode.streaming',
+  2: 'swap.mode.instant'
 }
+
+const INTERVAL_OPTIONS = [
+  { value: 1, label: '1 blk (~6s)' },
+  { value: 2, label: '2 blks (~12s)' },
+  { value: 3, label: '3 blks (~18s)' }
+]
 
 export const SwapSettings = ({
   activeMode,
+  streamingInterval,
   streamingQuantity,
   onModeChange,
+  onIntervalChange,
   onQuantityChange,
-  onReset,
   maxStreamingQuantity,
   supportRapid = true
 }: Props) => {
@@ -41,7 +44,7 @@ export const SwapSettings = ({
 
   const modeLabel = intl.formatMessage({ id: MODE_LABEL_KEYS[activeMode] })
 
-  const availableModes: StreamingMode[] = useMemo(() => (supportRapid ? [0, 1, 2, 3] : [1, 2, 3]), [supportRapid])
+  const availableModes: StreamingMode[] = useMemo(() => (supportRapid ? [0, 1, 2] : [1, 2]), [supportRapid])
 
   const modeOptions = useMemo(
     () =>
@@ -61,6 +64,27 @@ export const SwapSettings = ({
 
   const activeIndex = useMemo(() => availableModes.indexOf(activeMode), [availableModes, activeMode])
 
+  const intervalOptions = useMemo(
+    () =>
+      INTERVAL_OPTIONS.map((opt) => ({
+        label: <span className="text-[11px]">{opt.label}</span>,
+        value: opt.value
+      })),
+    []
+  )
+
+  const activeIntervalIndex = useMemo(
+    () => INTERVAL_OPTIONS.findIndex((opt) => opt.value === streamingInterval),
+    [streamingInterval]
+  )
+
+  const handleIntervalChange = useCallback(
+    (index: number) => {
+      onIntervalChange(INTERVAL_OPTIONS[index].value)
+    },
+    [onIntervalChange]
+  )
+
   const quantityLabel = useMemo(() => {
     return streamingQuantity === 0
       ? [intl.formatMessage({ id: 'swap.settings.subSwaps.auto' })]
@@ -79,23 +103,26 @@ export const SwapSettings = ({
       <div className="flex flex-col p-4">
         <div className="flex w-full flex-col space-y-4 px-2">
           <RadioGroup options={modeOptions} activeIndex={activeIndex} onChange={handleModeChange} />
-          {activeMode !== 0 && (
-            <Slider
-              value={streamingQuantity}
-              onChange={onQuantityChange}
-              max={maxStreamingQuantity}
-              labels={quantityLabel}
-            />
+          {activeMode === 1 && (
+            <>
+              <div className="flex flex-col space-y-1">
+                <span className="text-[12px] text-text2 dark:text-text2d">
+                  {intl.formatMessage({ id: 'swap.streaming.interval' })}
+                </span>
+                <RadioGroup
+                  options={intervalOptions}
+                  activeIndex={activeIntervalIndex}
+                  onChange={handleIntervalChange}
+                />
+              </div>
+              <Slider
+                value={streamingQuantity}
+                onChange={onQuantityChange}
+                max={maxStreamingQuantity}
+                labels={quantityLabel}
+              />
+            </>
           )}
-        </div>
-        <div className="flex justify-end">
-          <Tooltip title={intl.formatMessage({ id: 'common.resetToDefault' })}>
-            <BaseButton
-              onClick={onReset}
-              className="rounded-full group-hover:rotate-180 hover:shadow-full dark:hover:shadow-fulld">
-              <ArrowPathIcon className="ease h-[25px] w-[25px] text-turquoise" />
-            </BaseButton>
-          </Tooltip>
         </div>
       </div>
     </Collapse>

--- a/src/renderer/components/swap/components/SwapSettings.tsx
+++ b/src/renderer/components/swap/components/SwapSettings.tsx
@@ -79,12 +79,14 @@ export const SwapSettings = ({
       <div className="flex flex-col p-4">
         <div className="flex w-full flex-col space-y-4 px-2">
           <RadioGroup options={modeOptions} activeIndex={activeIndex} onChange={handleModeChange} />
-          <Slider
-            value={streamingQuantity}
-            onChange={onQuantityChange}
-            max={maxStreamingQuantity}
-            labels={quantityLabel}
-          />
+          {activeMode !== 0 && (
+            <Slider
+              value={streamingQuantity}
+              onChange={onQuantityChange}
+              max={maxStreamingQuantity}
+              labels={quantityLabel}
+            />
+          )}
         </div>
         <div className="flex justify-end">
           <Tooltip title={intl.formatMessage({ id: 'common.resetToDefault' })}>

--- a/src/renderer/components/swap/components/SwapSettings.tsx
+++ b/src/renderer/components/swap/components/SwapSettings.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { ArrowPathIcon } from '@heroicons/react/24/outline'
 import { useIntl } from 'react-intl'
@@ -12,16 +12,17 @@ import { Tooltip } from '../../uielements/tooltip'
 
 type Props = {
   activeMode: StreamingMode
-  streamingInterval: number
+  streamingInterval?: number
   streamingQuantity: number
   onModeChange: (mode: StreamingMode) => void
   onQuantityChange: (value: number) => void
   onReset: () => void
   maxStreamingQuantity?: number
+  supportRapid?: boolean
 }
 
 const MODE_LABEL_KEYS: Record<StreamingMode, string> = {
-  0: 'swap.mode.limit',
+  0: 'swap.mode.rapid',
   1: 'swap.mode.fast',
   2: 'swap.mode.balanced',
   3: 'swap.mode.bestPrice'
@@ -29,32 +30,42 @@ const MODE_LABEL_KEYS: Record<StreamingMode, string> = {
 
 export const SwapSettings = ({
   activeMode,
-  streamingInterval,
   streamingQuantity,
   onModeChange,
   onQuantityChange,
   onReset,
-  maxStreamingQuantity
+  maxStreamingQuantity,
+  supportRapid = true
 }: Props) => {
   const intl = useIntl()
 
   const modeLabel = intl.formatMessage({ id: MODE_LABEL_KEYS[activeMode] })
 
+  const availableModes: StreamingMode[] = useMemo(() => (supportRapid ? [0, 1, 2, 3] : [1, 2, 3]), [supportRapid])
+
   const modeOptions = useMemo(
     () =>
-      ([0, 1, 2, 3] as StreamingMode[]).map((mode) => ({
+      availableModes.map((mode) => ({
         label: <span className="text-[12px]">{intl.formatMessage({ id: MODE_LABEL_KEYS[mode] })}</span>,
         value: mode
       })),
-    [intl]
+    [intl, availableModes]
   )
 
+  const handleModeChange = useCallback(
+    (index: number) => {
+      onModeChange(availableModes[index])
+    },
+    [availableModes, onModeChange]
+  )
+
+  const activeIndex = useMemo(() => availableModes.indexOf(activeMode), [availableModes, activeMode])
+
   const quantityLabel = useMemo(() => {
-    if (streamingInterval === 0) return [intl.formatMessage({ id: 'swap.settings.subSwaps.limit' })]
     return streamingQuantity === 0
       ? [intl.formatMessage({ id: 'swap.settings.subSwaps.auto' })]
       : [intl.formatMessage({ id: 'swap.streaming.quantity' }), `${streamingQuantity}`]
-  }, [streamingInterval, streamingQuantity, intl])
+  }, [streamingQuantity, intl])
 
   return (
     <Collapse
@@ -67,19 +78,13 @@ export const SwapSettings = ({
       }>
       <div className="flex flex-col p-4">
         <div className="flex w-full flex-col space-y-4 px-2">
-          <RadioGroup
-            options={modeOptions}
-            activeIndex={activeMode}
-            onChange={(index) => onModeChange(index as StreamingMode)}
+          <RadioGroup options={modeOptions} activeIndex={activeIndex} onChange={handleModeChange} />
+          <Slider
+            value={streamingQuantity}
+            onChange={onQuantityChange}
+            max={maxStreamingQuantity}
+            labels={quantityLabel}
           />
-          {activeMode !== 0 && (
-            <Slider
-              value={streamingQuantity}
-              onChange={onQuantityChange}
-              max={maxStreamingQuantity}
-              labels={quantityLabel}
-            />
-          )}
         </div>
         <div className="flex justify-end">
           <Tooltip title={intl.formatMessage({ id: 'common.resetToDefault' })}>

--- a/src/renderer/components/swap/components/SwapSettings.tsx
+++ b/src/renderer/components/swap/components/SwapSettings.tsx
@@ -62,7 +62,10 @@ export const SwapSettings = ({
     [availableModes, onModeChange]
   )
 
-  const activeIndex = useMemo(() => availableModes.indexOf(activeMode), [availableModes, activeMode])
+  const activeIndex = useMemo(() => {
+    const idx = availableModes.indexOf(activeMode)
+    return idx >= 0 ? idx : 0
+  }, [availableModes, activeMode])
 
   const intervalOptions = useMemo(
     () =>
@@ -74,7 +77,11 @@ export const SwapSettings = ({
   )
 
   const activeIntervalIndex = useMemo(
-    () => INTERVAL_OPTIONS.findIndex((opt) => opt.value === streamingInterval),
+    () =>
+      Math.max(
+        0,
+        INTERVAL_OPTIONS.findIndex((opt) => opt.value === streamingInterval)
+      ),
     [streamingInterval]
   )
 

--- a/src/renderer/helpers/memoHelper.ts
+++ b/src/renderer/helpers/memoHelper.ts
@@ -165,24 +165,19 @@ export const getSwapMemo = ({
   affiliateBps: number | undefined
 }) => {
   const target = assetToMemoString(targetAsset)
-  const hasAffiliate = affiliateName !== undefined && affiliateName !== null
-  // Rapid (interval=0): omit streaming params to let THORChain auto-handle.
-  // But if affiliate params follow, we must keep the positional slot with 0/0/0
-  // since mkMemo filters undefined and would shift affiliate into the streaming position.
-  const streaming =
-    streamingInterval === 0 ? (hasAffiliate ? '0/0/0' : undefined) : `0/${streamingInterval}/${streamingQuantity}`
+  // Streaming params format: LIMIT/INTERVAL/QUANTITY (embedded in the limit position)
+  // Rapid (interval=0, quantity=0): THORChain auto-calculates optimal sub-swap count
+  // Streaming (interval>0): explicit interval between sub-swaps
+  const streaming = `0/${streamingInterval}/${streamingQuantity}`
   const memo = '='
   return mkMemo([memo, target, targetAddress, toleranceBps, streaming, affiliateName, affiliateBps])
 }
 /**
- * Adjusts streaming params in a swap memo based on the selected mode.
+ * Ensures the swap memo includes the correct streaming params (LIMIT/INTERVAL/QUANTITY).
+ * THORNode quote memos may omit or differ from the user's selected streaming mode.
  *
- * Rapid mode (interval=0): Strips streaming params from the memo limit field.
- *   THORChain treats omitted interval/quantity as rapid by default —
- *   it auto-calculates quantity and runs multiple sub-swaps per block.
- *
- * Streaming modes (interval>0): Ensures the memo includes explicit streaming params
- *   (e.g. `LIM/1/0` for fast streaming with auto quantity).
+ * Rapid (interval=0, quantity=0): LIM/0/0 — THORChain auto-calculates optimal sub-swaps
+ * Streaming (interval>0): LIM/N/Q — explicit interval and quantity
  */
 export const applyStreamingToMemo = (memo: string, streamingInterval: number, streamingQuantity: number): string => {
   if (!memo?.trim()) return memo
@@ -190,16 +185,8 @@ export const applyStreamingToMemo = (memo: string, streamingInterval: number, st
   const parts = memo.split(':')
   if (parts.length < 4) return memo
 
-  const limitPart = parts[3]
-
-  if (streamingInterval === 0) {
-    // Rapid: strip any streaming suffix, let THORChain auto-handle
-    parts[3] = limitPart.includes('/') ? limitPart.split('/')[0] : limitPart
-  } else {
-    // Streaming: ensure params are present
-    const baseLim = limitPart.includes('/') ? limitPart.split('/')[0] : limitPart
-    parts[3] = `${baseLim}/${streamingInterval}/${streamingQuantity}`
-  }
+  const baseLim = parts[3].includes('/') ? parts[3].split('/')[0] : parts[3]
+  parts[3] = `${baseLim}/${streamingInterval}/${streamingQuantity}`
 
   return parts.join(':')
 }

--- a/src/renderer/helpers/memoHelper.ts
+++ b/src/renderer/helpers/memoHelper.ts
@@ -173,11 +173,11 @@ export const getSwapMemo = ({
   return mkMemo([memo, target, targetAddress, toleranceBps, streaming, affiliateName, affiliateBps])
 }
 /**
- * Ensures the swap memo includes the correct streaming params (LIMIT/INTERVAL/QUANTITY).
- * THORNode quote memos may omit or differ from the user's selected streaming mode.
+ * Applies streaming params to a swap memo returned by THORNode quote API.
  *
- * Rapid (interval=0, quantity=0): LIM/0/0 — THORChain auto-calculates optimal sub-swaps
- * Streaming (interval>0): LIM/N/Q — explicit interval and quantity
+ * Rapid (interval=0): Clear the limit field — THORChain requires no limit for
+ *   rapid execution (auto sub-swaps, multiple per block, no price protection).
+ * Streaming/Instant (interval>0): Inject LIM/INTERVAL/QUANTITY into position 3.
  */
 export const applyStreamingToMemo = (memo: string, streamingInterval: number, streamingQuantity: number): string => {
   if (!memo?.trim()) return memo
@@ -185,8 +185,14 @@ export const applyStreamingToMemo = (memo: string, streamingInterval: number, st
   const parts = memo.split(':')
   if (parts.length < 4) return memo
 
-  const baseLim = parts[3].includes('/') ? parts[3].split('/')[0] : parts[3]
-  parts[3] = `${baseLim}/${streamingInterval}/${streamingQuantity}`
+  if (streamingInterval === 0) {
+    // Rapid: clear limit field entirely
+    parts[3] = ''
+  } else {
+    // Streaming/Instant: preserve quote limit, add interval/quantity
+    const baseLim = parts[3].includes('/') ? parts[3].split('/')[0] : parts[3]
+    parts[3] = `${baseLim}/${streamingInterval}/${streamingQuantity}`
+  }
 
   return parts.join(':')
 }

--- a/src/renderer/helpers/memoHelper.ts
+++ b/src/renderer/helpers/memoHelper.ts
@@ -174,10 +174,11 @@ export const getSwapMemo = ({
 }
 /**
  * Applies streaming params to a swap memo returned by THORNode quote API.
+ * Always injects LIMIT/INTERVAL/QUANTITY into position 3.
  *
- * Rapid (interval=0): Clear the limit field — THORChain requires no limit for
- *   rapid execution (auto sub-swaps, multiple per block, no price protection).
- * Streaming/Instant (interval>0): Inject LIM/INTERVAL/QUANTITY into position 3.
+ * Rapid (interval=0): LIM/0/0 — THORChain auto-calculates optimal sub-swaps.
+ * Streaming (interval>0): LIM/N/Q — explicit interval and quantity.
+ * Instant (interval=1, qty=1): LIM/1/1 — single non-streaming swap.
  */
 export const applyStreamingToMemo = (memo: string, streamingInterval: number, streamingQuantity: number): string => {
   if (!memo?.trim()) return memo
@@ -185,14 +186,8 @@ export const applyStreamingToMemo = (memo: string, streamingInterval: number, st
   const parts = memo.split(':')
   if (parts.length < 4) return memo
 
-  if (streamingInterval === 0) {
-    // Rapid: clear limit field entirely
-    parts[3] = ''
-  } else {
-    // Streaming/Instant: preserve quote limit, add interval/quantity
-    const baseLim = parts[3].includes('/') ? parts[3].split('/')[0] : parts[3]
-    parts[3] = `${baseLim}/${streamingInterval}/${streamingQuantity}`
-  }
+  const baseLim = parts[3].includes('/') ? parts[3].split('/')[0] : parts[3]
+  parts[3] = `${baseLim}/${streamingInterval}/${streamingQuantity}`
 
   return parts.join(':')
 }

--- a/src/renderer/helpers/memoHelper.ts
+++ b/src/renderer/helpers/memoHelper.ts
@@ -165,10 +165,45 @@ export const getSwapMemo = ({
   affiliateBps: number | undefined
 }) => {
   const target = assetToMemoString(targetAsset)
-  const streaming = `0/${streamingInterval}/${streamingQuantity}`
+  const hasAffiliate = affiliateName !== undefined && affiliateName !== null
+  // Rapid (interval=0): omit streaming params to let THORChain auto-handle.
+  // But if affiliate params follow, we must keep the positional slot with 0/0/0
+  // since mkMemo filters undefined and would shift affiliate into the streaming position.
+  const streaming =
+    streamingInterval === 0 ? (hasAffiliate ? '0/0/0' : undefined) : `0/${streamingInterval}/${streamingQuantity}`
   const memo = '='
   return mkMemo([memo, target, targetAddress, toleranceBps, streaming, affiliateName, affiliateBps])
 }
+/**
+ * Adjusts streaming params in a swap memo based on the selected mode.
+ *
+ * Rapid mode (interval=0): Strips streaming params from the memo limit field.
+ *   THORChain treats omitted interval/quantity as rapid by default —
+ *   it auto-calculates quantity and runs multiple sub-swaps per block.
+ *
+ * Streaming modes (interval>0): Ensures the memo includes explicit streaming params
+ *   (e.g. `LIM/1/0` for fast streaming with auto quantity).
+ */
+export const applyStreamingToMemo = (memo: string, streamingInterval: number, streamingQuantity: number): string => {
+  if (!memo?.trim()) return memo
+
+  const parts = memo.split(':')
+  if (parts.length < 4) return memo
+
+  const limitPart = parts[3]
+
+  if (streamingInterval === 0) {
+    // Rapid: strip any streaming suffix, let THORChain auto-handle
+    parts[3] = limitPart.includes('/') ? limitPart.split('/')[0] : limitPart
+  } else {
+    // Streaming: ensure params are present
+    const baseLim = limitPart.includes('/') ? limitPart.split('/')[0] : limitPart
+    parts[3] = `${baseLim}/${streamingInterval}/${streamingQuantity}`
+  }
+
+  return parts.join(':')
+}
+
 // With stagenet, remove all affiliate config from memo
 export const updateMemo = (memo: string, network: Network): string => {
   const pattern = /:dx:\d+$/

--- a/src/renderer/hooks/useStreamingParams.ts
+++ b/src/renderer/hooks/useStreamingParams.ts
@@ -1,15 +1,23 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
+/**
+ * Streaming modes for swap execution:
+ * 0 = Rapid  — interval 0, multiple sub-swaps per block (THORChain only)
+ * 1 = Fast   — interval 1, one sub-swap per block
+ * 2 = Balanced — interval 2
+ * 3 = Best Price — interval 3
+ */
 export type StreamingMode = 0 | 1 | 2 | 3
 
 const MODE_TO_INTERVAL: Record<StreamingMode, number> = {
-  0: 0,
-  1: 1,
-  2: 2,
-  3: 3
+  0: 0, // Rapid
+  1: 1, // Fast
+  2: 2, // Balanced
+  3: 3 // Best Price
 }
 
-const DEFAULT_MODE: StreamingMode = 1
+const RAPID_DEFAULT: StreamingMode = 0
+const STREAMING_DEFAULT: StreamingMode = 1
 
 export type UseStreamingParamsReturn = {
   streamingInterval: number
@@ -19,19 +27,31 @@ export type UseStreamingParamsReturn = {
   setMode: (mode: StreamingMode) => void
   setQuantity: (quantity: number) => void
   resetToDefault: () => void
+  supportRapid: boolean
 }
 
-export const useStreamingParams = (): UseStreamingParamsReturn => {
-  const [activeMode, setActiveMode] = useState<StreamingMode>(DEFAULT_MODE)
-  const [streamingInterval, setStreamingInterval] = useState<number>(MODE_TO_INTERVAL[DEFAULT_MODE])
+export const useStreamingParams = (supportRapid = true): UseStreamingParamsReturn => {
+  const defaultMode = supportRapid ? RAPID_DEFAULT : STREAMING_DEFAULT
+
+  const [activeMode, setActiveMode] = useState<StreamingMode>(defaultMode)
+  const [streamingInterval, setStreamingInterval] = useState<number>(MODE_TO_INTERVAL[defaultMode])
   const [streamingQuantity, setStreamingQuantity] = useState<number>(0)
-  const [isStreaming, setIsStreaming] = useState<boolean>(true)
+
+  // Reset to appropriate default when supportRapid changes (e.g. switching protocols)
+  useEffect(() => {
+    const newDefault = supportRapid ? RAPID_DEFAULT : STREAMING_DEFAULT
+    // If current mode is Rapid but rapid is no longer supported, switch to streaming default
+    if (!supportRapid && activeMode === 0) {
+      setActiveMode(newDefault)
+      setStreamingInterval(MODE_TO_INTERVAL[newDefault])
+      setStreamingQuantity(0)
+    }
+  }, [supportRapid, activeMode])
 
   const setMode = useCallback((mode: StreamingMode) => {
     setActiveMode(mode)
     setStreamingInterval(MODE_TO_INTERVAL[mode])
     setStreamingQuantity(0)
-    setIsStreaming(mode !== 0)
   }, [])
 
   const setQuantity = useCallback((quantity: number) => {
@@ -39,19 +59,20 @@ export const useStreamingParams = (): UseStreamingParamsReturn => {
   }, [])
 
   const resetToDefault = useCallback(() => {
-    setActiveMode(DEFAULT_MODE)
-    setStreamingInterval(MODE_TO_INTERVAL[DEFAULT_MODE])
+    const mode = supportRapid ? RAPID_DEFAULT : STREAMING_DEFAULT
+    setActiveMode(mode)
+    setStreamingInterval(MODE_TO_INTERVAL[mode])
     setStreamingQuantity(0)
-    setIsStreaming(true)
-  }, [])
+  }, [supportRapid])
 
   return {
     streamingInterval,
     streamingQuantity,
-    isStreaming,
+    isStreaming: true, // Always streaming (Limit mode removed)
     activeMode,
     setMode,
     setQuantity,
-    resetToDefault
+    resetToDefault,
+    supportRapid
   }
 }

--- a/src/renderer/hooks/useStreamingParams.ts
+++ b/src/renderer/hooks/useStreamingParams.ts
@@ -38,11 +38,14 @@ export const useStreamingParams = (supportRapid = true): UseStreamingParamsRetur
 
   // Reset to appropriate default when supportRapid changes (e.g. switching protocols)
   useEffect(() => {
-    const newDefault = supportRapid ? RAPID_DEFAULT : STREAMING_DEFAULT
-    if (!supportRapid && activeMode === 0) {
-      setActiveMode(newDefault)
-      setStreamingInterval(MODE_DEFAULTS[newDefault].interval)
-      setStreamingQuantity(MODE_DEFAULTS[newDefault].quantity)
+    if (!supportRapid && activeMode === RAPID_DEFAULT) {
+      setActiveMode(STREAMING_DEFAULT)
+      setStreamingInterval(MODE_DEFAULTS[STREAMING_DEFAULT].interval)
+      setStreamingQuantity(MODE_DEFAULTS[STREAMING_DEFAULT].quantity)
+    } else if (supportRapid && activeMode === STREAMING_DEFAULT) {
+      setActiveMode(RAPID_DEFAULT)
+      setStreamingInterval(MODE_DEFAULTS[RAPID_DEFAULT].interval)
+      setStreamingQuantity(MODE_DEFAULTS[RAPID_DEFAULT].quantity)
     }
   }, [supportRapid, activeMode])
 

--- a/src/renderer/hooks/useStreamingParams.ts
+++ b/src/renderer/hooks/useStreamingParams.ts
@@ -1,19 +1,17 @@
 import { useCallback, useEffect, useState } from 'react'
 
 /**
- * Streaming modes for swap execution:
- * 0 = Rapid  — interval 0, multiple sub-swaps per block (THORChain only)
- * 1 = Fast   — interval 1, one sub-swap per block
- * 2 = Balanced — interval 2
- * 3 = Best Price — interval 3
+ * Swap execution modes:
+ * 0 = Rapid    — interval=0, qty=0 (auto). Multiple sub-swaps per block. THORChain only.
+ * 1 = Streaming — interval=1, qty=user (0=auto). One sub-swap per block, arb rebalancing.
+ * 2 = Instant   — interval=1, qty=1. Single swap, one block, no streaming.
  */
-export type StreamingMode = 0 | 1 | 2 | 3
+export type StreamingMode = 0 | 1 | 2
 
-const MODE_TO_INTERVAL: Record<StreamingMode, number> = {
-  0: 0, // Rapid
-  1: 1, // Fast
-  2: 2, // Balanced
-  3: 3 // Best Price
+const MODE_DEFAULTS: Record<StreamingMode, { interval: number; quantity: number }> = {
+  0: { interval: 0, quantity: 0 }, // Rapid
+  1: { interval: 1, quantity: 0 }, // Streaming (qty=0 means auto)
+  2: { interval: 1, quantity: 1 } // Instant
 }
 
 const RAPID_DEFAULT: StreamingMode = 0
@@ -25,6 +23,7 @@ export type UseStreamingParamsReturn = {
   isStreaming: boolean
   activeMode: StreamingMode
   setMode: (mode: StreamingMode) => void
+  setInterval: (interval: number) => void
   setQuantity: (quantity: number) => void
   resetToDefault: () => void
   supportRapid: boolean
@@ -34,24 +33,28 @@ export const useStreamingParams = (supportRapid = true): UseStreamingParamsRetur
   const defaultMode = supportRapid ? RAPID_DEFAULT : STREAMING_DEFAULT
 
   const [activeMode, setActiveMode] = useState<StreamingMode>(defaultMode)
-  const [streamingInterval, setStreamingInterval] = useState<number>(MODE_TO_INTERVAL[defaultMode])
-  const [streamingQuantity, setStreamingQuantity] = useState<number>(0)
+  const [streamingInterval, setStreamingInterval] = useState<number>(MODE_DEFAULTS[defaultMode].interval)
+  const [streamingQuantity, setStreamingQuantity] = useState<number>(MODE_DEFAULTS[defaultMode].quantity)
 
   // Reset to appropriate default when supportRapid changes (e.g. switching protocols)
   useEffect(() => {
     const newDefault = supportRapid ? RAPID_DEFAULT : STREAMING_DEFAULT
-    // If current mode is Rapid but rapid is no longer supported, switch to streaming default
     if (!supportRapid && activeMode === 0) {
       setActiveMode(newDefault)
-      setStreamingInterval(MODE_TO_INTERVAL[newDefault])
-      setStreamingQuantity(0)
+      setStreamingInterval(MODE_DEFAULTS[newDefault].interval)
+      setStreamingQuantity(MODE_DEFAULTS[newDefault].quantity)
     }
   }, [supportRapid, activeMode])
 
   const setMode = useCallback((mode: StreamingMode) => {
     setActiveMode(mode)
-    setStreamingInterval(MODE_TO_INTERVAL[mode])
-    setStreamingQuantity(0)
+    setStreamingInterval(MODE_DEFAULTS[mode].interval)
+    setStreamingQuantity(MODE_DEFAULTS[mode].quantity)
+  }, [])
+
+  // Only meaningful for Streaming mode — Rapid and Instant have fixed params
+  const setInterval = useCallback((interval: number) => {
+    setStreamingInterval(interval)
   }, [])
 
   const setQuantity = useCallback((quantity: number) => {
@@ -61,16 +64,17 @@ export const useStreamingParams = (supportRapid = true): UseStreamingParamsRetur
   const resetToDefault = useCallback(() => {
     const mode = supportRapid ? RAPID_DEFAULT : STREAMING_DEFAULT
     setActiveMode(mode)
-    setStreamingInterval(MODE_TO_INTERVAL[mode])
-    setStreamingQuantity(0)
+    setStreamingInterval(MODE_DEFAULTS[mode].interval)
+    setStreamingQuantity(MODE_DEFAULTS[mode].quantity)
   }, [supportRapid])
 
   return {
     streamingInterval,
     streamingQuantity,
-    isStreaming: true, // Always streaming (Limit mode removed)
+    isStreaming: activeMode !== 2, // Instant is not streaming
     activeMode,
     setMode,
+    setInterval,
     setQuantity,
     resetToDefault,
     supportRapid

--- a/src/renderer/hooks/useSwapExecution.ts
+++ b/src/renderer/hooks/useSwapExecution.ts
@@ -18,7 +18,7 @@ import type { ExtendedQuoteSwap } from '../components/swap/Swap.types'
 import { useWalletContext } from '../contexts/WalletContext'
 import { isRujiAsset, isUtxoAssetChain } from '../helpers/assetHelper'
 import { sequenceTOption } from '../helpers/fpHelpers'
-import { updateMemo } from '../helpers/memoHelper'
+import { applyStreamingToMemo, updateMemo } from '../helpers/memoHelper'
 import { INITIAL_SWAP_STATE } from '../services/chain/const'
 import { SwapTxParams, SwapTxState, SendTxParams, SwapHandler, SwapCFHandler, SwapFees } from '../services/chain/types'
 import { PoolAddress } from '../services/midgard/midgardTypes'
@@ -38,6 +38,8 @@ type UseSwapExecutionParams = {
   poolAddressMaya: O.Option<PoolAddress>
   network: Network
   isSendMax: boolean
+  streamingInterval: number
+  streamingQuantity: number
 }
 
 type UseSwapExecutionResult = {
@@ -64,7 +66,9 @@ export const useSwapExecution = ({
   poolAddressThor,
   poolAddressMaya,
   network,
-  isSendMax
+  isSendMax,
+  streamingInterval,
+  streamingQuantity
 }: UseSwapExecutionParams): UseSwapExecutionResult => {
   const { appWalletService } = useWalletContext()
   const appWalletState = useObservableState(appWalletService.appWalletState$)
@@ -142,7 +146,7 @@ export const useSwapExecution = ({
           poolAddress,
           asset: sourceAsset,
           amount: amountToSwapAdjusted,
-          memo: updateMemo(quoteSwap.memo, network),
+          memo: applyStreamingToMemo(updateMemo(quoteSwap.memo, network), streamingInterval, streamingQuantity),
           walletType,
           sender: finalWalletAddress,
           walletAccount: finalWalletAccount,
@@ -166,7 +170,9 @@ export const useSwapExecution = ({
     appWalletState,
     standaloneLedgerState?.address,
     isSourceUTXO,
-    isSendMax
+    isSendMax,
+    streamingInterval,
+    streamingQuantity
   ])
 
   // Build Chainflip swap params

--- a/src/renderer/hooks/useSwapQuote.ts
+++ b/src/renderer/hooks/useSwapQuote.ts
@@ -125,8 +125,8 @@ export const useSwapQuote = ({
           }),
           fromAddress: isSecuredAsset(sourceAsset) ? undefined : sourceWalletAddress,
           destinationAddress: quoteOnly ? undefined : destinationAddress,
-          streamingInterval: streaming.enabled ? streaming.interval : 0,
-          streamingQuantity: streaming.enabled ? streaming.quantity : 0,
+          streamingInterval: streaming.interval === 0 ? undefined : streaming.interval,
+          streamingQuantity: streaming.interval === 0 ? undefined : streaming.quantity,
           liquidityToleranceBps: slipTolerance * 100,
           toleranceBps: undefined
         }

--- a/src/renderer/hooks/useSwapQuote.ts
+++ b/src/renderer/hooks/useSwapQuote.ts
@@ -197,7 +197,6 @@ export const useSwapQuote = ({
       sourceWalletAddress,
       quoteOnly,
       destinationAddress,
-      streaming.enabled,
       streaming.interval,
       streaming.quantity,
       slipTolerance,

--- a/src/renderer/hooks/useSwapQuote.ts
+++ b/src/renderer/hooks/useSwapQuote.ts
@@ -125,8 +125,8 @@ export const useSwapQuote = ({
           }),
           fromAddress: isSecuredAsset(sourceAsset) ? undefined : sourceWalletAddress,
           destinationAddress: quoteOnly ? undefined : destinationAddress,
-          streamingInterval: streaming.interval === 0 ? undefined : streaming.interval,
-          streamingQuantity: streaming.interval === 0 ? undefined : streaming.quantity,
+          streamingInterval: streaming.interval,
+          streamingQuantity: streaming.quantity,
           liquidityToleranceBps: slipTolerance * 100,
           toleranceBps: undefined
         }

--- a/src/renderer/i18n/de/swap.ts
+++ b/src/renderer/i18n/de/swap.ts
@@ -40,12 +40,11 @@ const swap: SwapMessages = {
   'swap.address.evm.warning': 'NICHT zu Smart Contract Adressen tauschen',
   'swap.synth.warning':
     'Das Minten von Synths wurde eingestellt. Die Einlösung von Synths ist noch 3 Monate lang möglich — bitte löse sie ein, solange du kannst.',
-  'swap.mode.limit': 'Limit',
+  'swap.mode.rapid': 'Rapid',
   'swap.mode.fast': 'Schnell',
   'swap.mode.balanced': 'Ausgewogen',
   'swap.mode.bestPrice': 'Bester Preis',
-  'swap.settings.subSwaps.auto': 'Auto Swap-Anzahl',
-  'swap.settings.subSwaps.limit': 'Limit Swap'
+  'swap.settings.subSwaps.auto': 'Auto Swap-Anzahl'
 }
 
 export default swap

--- a/src/renderer/i18n/de/swap.ts
+++ b/src/renderer/i18n/de/swap.ts
@@ -41,9 +41,8 @@ const swap: SwapMessages = {
   'swap.synth.warning':
     'Das Minten von Synths wurde eingestellt. Die Einlösung von Synths ist noch 3 Monate lang möglich — bitte löse sie ein, solange du kannst.',
   'swap.mode.rapid': 'Rapid',
-  'swap.mode.fast': 'Schnell',
-  'swap.mode.balanced': 'Ausgewogen',
-  'swap.mode.bestPrice': 'Bester Preis',
+  'swap.mode.streaming': 'Streaming',
+  'swap.mode.instant': 'Sofort',
   'swap.settings.subSwaps.auto': 'Auto Swap-Anzahl'
 }
 

--- a/src/renderer/i18n/en/swap.ts
+++ b/src/renderer/i18n/en/swap.ts
@@ -39,12 +39,11 @@ const swap: SwapMessages = {
   'swap.address.evm.warning': 'Do NOT swap to Smart Contract addresses',
   'swap.synth.warning':
     'Synth minting has been discontinued. Synth redemption will remain available for the next 3 months — please redeem while you can.',
-  'swap.mode.limit': 'Limit',
+  'swap.mode.rapid': 'Rapid',
   'swap.mode.fast': 'Fast',
   'swap.mode.balanced': 'Balanced',
   'swap.mode.bestPrice': 'Best Price',
-  'swap.settings.subSwaps.auto': 'Auto swap count',
-  'swap.settings.subSwaps.limit': 'Limit swap'
+  'swap.settings.subSwaps.auto': 'Auto swap count'
 }
 
 export default swap

--- a/src/renderer/i18n/en/swap.ts
+++ b/src/renderer/i18n/en/swap.ts
@@ -40,9 +40,8 @@ const swap: SwapMessages = {
   'swap.synth.warning':
     'Synth minting has been discontinued. Synth redemption will remain available for the next 3 months — please redeem while you can.',
   'swap.mode.rapid': 'Rapid',
-  'swap.mode.fast': 'Fast',
-  'swap.mode.balanced': 'Balanced',
-  'swap.mode.bestPrice': 'Best Price',
+  'swap.mode.streaming': 'Streaming',
+  'swap.mode.instant': 'Instant',
   'swap.settings.subSwaps.auto': 'Auto swap count'
 }
 

--- a/src/renderer/i18n/es/swap.ts
+++ b/src/renderer/i18n/es/swap.ts
@@ -42,9 +42,8 @@ const swap: SwapMessages = {
   'swap.synth.warning':
     'La acuñación de Synths se ha descontinuado. La redención de Synths estará disponible durante los próximos 3 meses — por favor, canjéalos mientras puedas.',
   'swap.mode.rapid': 'Rapid',
-  'swap.mode.fast': 'Rápido',
-  'swap.mode.balanced': 'Equilibrado',
-  'swap.mode.bestPrice': 'Mejor precio',
+  'swap.mode.streaming': 'Streaming',
+  'swap.mode.instant': 'Instantáneo',
   'swap.settings.subSwaps.auto': 'Cantidad auto de swaps'
 }
 

--- a/src/renderer/i18n/es/swap.ts
+++ b/src/renderer/i18n/es/swap.ts
@@ -41,12 +41,11 @@ const swap: SwapMessages = {
   'swap.address.evm.warning': 'NO intercambiar a direcciones de Smart Contract',
   'swap.synth.warning':
     'La acuñación de Synths se ha descontinuado. La redención de Synths estará disponible durante los próximos 3 meses — por favor, canjéalos mientras puedas.',
-  'swap.mode.limit': 'Límite',
+  'swap.mode.rapid': 'Rapid',
   'swap.mode.fast': 'Rápido',
   'swap.mode.balanced': 'Equilibrado',
   'swap.mode.bestPrice': 'Mejor precio',
-  'swap.settings.subSwaps.auto': 'Cantidad auto de swaps',
-  'swap.settings.subSwaps.limit': 'Swap límite'
+  'swap.settings.subSwaps.auto': 'Cantidad auto de swaps'
 }
 
 export default swap

--- a/src/renderer/i18n/fr/swap.ts
+++ b/src/renderer/i18n/fr/swap.ts
@@ -41,9 +41,8 @@ const swap: SwapMessages = {
   'swap.synth.warning':
     "La création de Synths a été arrêtée. Le rachat des Synths restera disponible pendant encore 3 mois — veuillez les échanger tant que c'est possible.",
   'swap.mode.rapid': 'Rapid',
-  'swap.mode.fast': 'Rapide',
-  'swap.mode.balanced': 'Équilibré',
-  'swap.mode.bestPrice': 'Meilleur prix',
+  'swap.mode.streaming': 'Streaming',
+  'swap.mode.instant': 'Instantané',
   'swap.settings.subSwaps.auto': 'Nombre auto de swaps'
 }
 

--- a/src/renderer/i18n/fr/swap.ts
+++ b/src/renderer/i18n/fr/swap.ts
@@ -40,12 +40,11 @@ const swap: SwapMessages = {
   'swap.address.evm.warning': 'NE PAS échanger vers des adresses de Smart Contract',
   'swap.synth.warning':
     "La création de Synths a été arrêtée. Le rachat des Synths restera disponible pendant encore 3 mois — veuillez les échanger tant que c'est possible.",
-  'swap.mode.limit': 'Limite',
+  'swap.mode.rapid': 'Rapid',
   'swap.mode.fast': 'Rapide',
   'swap.mode.balanced': 'Équilibré',
   'swap.mode.bestPrice': 'Meilleur prix',
-  'swap.settings.subSwaps.auto': 'Nombre auto de swaps',
-  'swap.settings.subSwaps.limit': 'Swap limite'
+  'swap.settings.subSwaps.auto': 'Nombre auto de swaps'
 }
 
 export default swap

--- a/src/renderer/i18n/hi/swap.ts
+++ b/src/renderer/i18n/hi/swap.ts
@@ -39,11 +39,10 @@ const swap: SwapMessages = {
   'swap.address.evm.warning': 'स्मार्ट कॉन्ट्रैक्ट पतों पर स्वैप न करें',
   'swap.synth.warning':
     'Synth मिंटिंग बंद कर दी गई है। Synth रिडेम्प्शन अगले 3 महीनों तक उपलब्ध रहेगा — कृपया समय रहते रिडीम कर लें।',
-  'swap.mode.limit': 'लिमिट',
+  'swap.mode.rapid': 'रैपिड',
   'swap.mode.fast': 'तेज़',
   'swap.mode.balanced': 'संतुलित',
   'swap.mode.bestPrice': 'सर्वश्रेष्ठ मूल्य',
-  'swap.settings.subSwaps.auto': 'ऑटो स्वैप संख्या',
-  'swap.settings.subSwaps.limit': 'लिमिट स्वैप'
+  'swap.settings.subSwaps.auto': 'ऑटो स्वैप संख्या'
 }
 export default swap

--- a/src/renderer/i18n/hi/swap.ts
+++ b/src/renderer/i18n/hi/swap.ts
@@ -40,9 +40,8 @@ const swap: SwapMessages = {
   'swap.synth.warning':
     'Synth मिंटिंग बंद कर दी गई है। Synth रिडेम्प्शन अगले 3 महीनों तक उपलब्ध रहेगा — कृपया समय रहते रिडीम कर लें।',
   'swap.mode.rapid': 'रैपिड',
-  'swap.mode.fast': 'तेज़',
-  'swap.mode.balanced': 'संतुलित',
-  'swap.mode.bestPrice': 'सर्वश्रेष्ठ मूल्य',
+  'swap.mode.streaming': 'स्ट्रीमिंग',
+  'swap.mode.instant': 'तुरंत',
   'swap.settings.subSwaps.auto': 'ऑटो स्वैप संख्या'
 }
 export default swap

--- a/src/renderer/i18n/ko/swap.ts
+++ b/src/renderer/i18n/ko/swap.ts
@@ -39,12 +39,11 @@ const swap: SwapMessages = {
   'swap.address.evm.warning': '스마트 컨트랙트 주소로 스왑하지 마세요',
   'swap.synth.warning':
     'Synth 발행이 중단되었습니다. Synth 상환은 앞으로 3개월 동안만 가능합니다 — 가능한 한 빨리 상환해 주세요.',
-  'swap.mode.limit': '리밋',
+  'swap.mode.rapid': '래피드',
   'swap.mode.fast': '빠름',
   'swap.mode.balanced': '균형',
   'swap.mode.bestPrice': '최적 가격',
-  'swap.settings.subSwaps.auto': '자동 스왑 횟수',
-  'swap.settings.subSwaps.limit': '리밋 스왑'
+  'swap.settings.subSwaps.auto': '자동 스왑 횟수'
 }
 
 export default swap

--- a/src/renderer/i18n/ko/swap.ts
+++ b/src/renderer/i18n/ko/swap.ts
@@ -40,9 +40,8 @@ const swap: SwapMessages = {
   'swap.synth.warning':
     'Synth 발행이 중단되었습니다. Synth 상환은 앞으로 3개월 동안만 가능합니다 — 가능한 한 빨리 상환해 주세요.',
   'swap.mode.rapid': '래피드',
-  'swap.mode.fast': '빠름',
-  'swap.mode.balanced': '균형',
-  'swap.mode.bestPrice': '최적 가격',
+  'swap.mode.streaming': '스트리밍',
+  'swap.mode.instant': '즉시',
   'swap.settings.subSwaps.auto': '자동 스왑 횟수'
 }
 

--- a/src/renderer/i18n/ru/swap.ts
+++ b/src/renderer/i18n/ru/swap.ts
@@ -41,9 +41,8 @@ const swap: SwapMessages = {
   'swap.synth.warning':
     'Выпуск Synth больше не доступен. Обмен Synth будет возможен ещё в течение 3 месяцев — пожалуйста, воспользуйтесь этой возможностью заранее.',
   'swap.mode.rapid': 'Rapid',
-  'swap.mode.fast': 'Быстро',
-  'swap.mode.balanced': 'Сбалансированно',
-  'swap.mode.bestPrice': 'Лучшая цена',
+  'swap.mode.streaming': 'Streaming',
+  'swap.mode.instant': 'Мгновенно',
   'swap.settings.subSwaps.auto': 'Авто количество свопов'
 }
 

--- a/src/renderer/i18n/ru/swap.ts
+++ b/src/renderer/i18n/ru/swap.ts
@@ -40,12 +40,11 @@ const swap: SwapMessages = {
   'swap.address.evm.warning': 'НЕ обменивайте на адреса Смарт-контрактов',
   'swap.synth.warning':
     'Выпуск Synth больше не доступен. Обмен Synth будет возможен ещё в течение 3 месяцев — пожалуйста, воспользуйтесь этой возможностью заранее.',
-  'swap.mode.limit': 'Лимит',
+  'swap.mode.rapid': 'Rapid',
   'swap.mode.fast': 'Быстро',
   'swap.mode.balanced': 'Сбалансированно',
   'swap.mode.bestPrice': 'Лучшая цена',
-  'swap.settings.subSwaps.auto': 'Авто количество свопов',
-  'swap.settings.subSwaps.limit': 'Лимит своп'
+  'swap.settings.subSwaps.auto': 'Авто количество свопов'
 }
 
 export default swap

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -750,9 +750,8 @@ type SwapMessageKey =
   | 'swap.address.evm.warning'
   | 'swap.synth.warning'
   | 'swap.mode.rapid'
-  | 'swap.mode.fast'
-  | 'swap.mode.balanced'
-  | 'swap.mode.bestPrice'
+  | 'swap.mode.streaming'
+  | 'swap.mode.instant'
   | 'swap.settings.subSwaps.auto'
 
 export type SwapMessages = { [key in SwapMessageKey]: string }

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -749,12 +749,11 @@ type SwapMessageKey =
   | 'swap.min.result.protected'
   | 'swap.address.evm.warning'
   | 'swap.synth.warning'
-  | 'swap.mode.limit'
+  | 'swap.mode.rapid'
   | 'swap.mode.fast'
   | 'swap.mode.balanced'
   | 'swap.mode.bestPrice'
   | 'swap.settings.subSwaps.auto'
-  | 'swap.settings.subSwaps.limit'
 
 export type SwapMessages = { [key in SwapMessageKey]: string }
 

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -68,7 +68,6 @@ import {
   getWalletTypeFromState,
   isVultisigMode
 } from './types'
-import { hasImportedKeystore } from './util'
 
 export const createBalancesService = ({
   keystore$,
@@ -424,12 +423,22 @@ export const createBalancesService = ({
     walletBalancesState.clear()
   })
 
-  // Whenever keystore has been removed, reset stored balances
-  const keystoreSub = keystore$.subscribe((keystoreState: KeystoreState) => {
-    if (!hasImportedKeystore(keystoreState)) {
+  // Whenever the active keystore wallet changes (switch or removal), reset stored balances
+  // so stale balances from the previous wallet are not shown
+  const keystoreSub = keystore$
+    .pipe(
+      RxOp.map((keystoreState: KeystoreState) =>
+        FP.pipe(
+          keystoreState,
+          O.map(({ id }) => id),
+          O.toNullable
+        )
+      ),
+      RxOp.distinctUntilChanged()
+    )
+    .subscribe(() => {
       walletBalancesState.clear()
-    }
-  })
+    })
 
   // Whenever the active Vultisig vault changes, reset stored balances
   // so stale balances from the previous vault are not shown

--- a/src/renderer/views/pools/detail/TradingPanel.tsx
+++ b/src/renderer/views/pools/detail/TradingPanel.tsx
@@ -309,8 +309,7 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
     activeMode,
     setMode: setStreamingMode,
     setInterval: setStreamingIntervalValue,
-    setQuantity: setStreamingQuantity,
-    resetToDefault: resetStreaming
+    setQuantity: setStreamingQuantity
   } = useStreamingParams()
 
   // ── Hook 2: Swap addresses (simplified — no custom recipient, no standalone ledger target) ──

--- a/src/renderer/views/pools/detail/TradingPanel.tsx
+++ b/src/renderer/views/pools/detail/TradingPanel.tsx
@@ -428,7 +428,9 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
     poolAddressThor,
     poolAddressMaya,
     network,
-    isSendMax: false
+    isSendMax: false,
+    streamingInterval,
+    streamingQuantity
   })
 
   // ── Hook 6: ERC20 Approval ────────────────────────────────────────────

--- a/src/renderer/views/pools/detail/TradingPanel.tsx
+++ b/src/renderer/views/pools/detail/TradingPanel.tsx
@@ -308,6 +308,7 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
     isStreaming,
     activeMode,
     setMode: setStreamingMode,
+    setInterval: setStreamingIntervalValue,
     setQuantity: setStreamingQuantity,
     resetToDefault: resetStreaming
   } = useStreamingParams()
@@ -901,8 +902,8 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
         streamingInterval={streamingInterval}
         streamingQuantity={streamingQuantity}
         onModeChange={setStreamingMode}
+        onIntervalChange={setStreamingIntervalValue}
         onQuantityChange={setStreamingQuantity}
-        onResetStreaming={resetStreaming}
         isApprovedState={isApprovedState}
         needsApproval={needsApproval}
         awaitingConfirmation={awaitingConfirmation}

--- a/src/renderer/views/pools/detail/TradingPanelOrderSection.tsx
+++ b/src/renderer/views/pools/detail/TradingPanelOrderSection.tsx
@@ -26,8 +26,8 @@ type Props = {
   streamingInterval: number
   streamingQuantity: number
   onModeChange: (mode: StreamingMode) => void
+  onIntervalChange: (interval: number) => void
   onQuantityChange: (value: number) => void
-  onResetStreaming: () => void
   // ERC20 approval
   isApprovedState: IsApprovedRD
   needsApproval: boolean
@@ -50,8 +50,8 @@ export const TradingPanelOrderSection = ({
   streamingInterval,
   streamingQuantity,
   onModeChange,
+  onIntervalChange,
   onQuantityChange,
-  onResetStreaming,
   isApprovedState,
   needsApproval,
   awaitingConfirmation,
@@ -121,8 +121,8 @@ export const TradingPanelOrderSection = ({
           streamingInterval={streamingInterval}
           streamingQuantity={streamingQuantity}
           onModeChange={onModeChange}
+          onIntervalChange={onIntervalChange}
           onQuantityChange={onQuantityChange}
-          onReset={onResetStreaming}
         />
       </div>
 

--- a/src/renderer/views/wallet/AssetsView.tsx
+++ b/src/renderer/views/wallet/AssetsView.tsx
@@ -168,7 +168,7 @@ export const AssetsView = (): JSX.Element => {
   const pendingPoolsMayaRD = useObservableState(pendingPoolsStateMaya$, RD.pending)
   const selectedPricePool = useObservableState(selectedPricePool$, RUNE_PRICE_POOL)
 
-  const [lpFetchEnabled] = useState(true)
+  const [lpFetchEnabled, setLpFetchEnabled] = useState(false)
   const { allSharesRD: thorSharesRD } = usePoolShares(THORChain, lpFetchEnabled)
   const { allSharesRD: mayaSharesRD } = usePoolShares(MAYAChain, lpFetchEnabled)
 
@@ -212,17 +212,14 @@ export const AssetsView = (): JSX.Element => {
 
   const disableRefresh = useMemo(() => RD.isPending(poolsRD) || loadingBalances, [loadingBalances, poolsRD])
 
+  const [savePending, setSavePending] = useState(false)
+
   const disableSave = useMemo(
-    () =>
-      !allChainsLoaded ||
-      RD.isPending(poolsRD) ||
-      RD.isPending(poolsMayaRD) ||
-      RD.isPending(thorSharesRD) ||
-      RD.isPending(mayaSharesRD),
-    [allChainsLoaded, poolsRD, poolsMayaRD, thorSharesRD, mayaSharesRD]
+    () => !allChainsLoaded || RD.isPending(poolsRD) || RD.isPending(poolsMayaRD),
+    [allChainsLoaded, poolsRD, poolsMayaRD]
   )
 
-  const saveBalancesHandler = useCallback(async () => {
+  const performSave = useCallback(async () => {
     const now = new Date()
     const pad = (n: number) => String(n).padStart(2, '0')
     const datePart = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}`
@@ -307,6 +304,7 @@ export const AssetsView = (): JSX.Element => {
     } catch (err) {
       logger.error('Failed to save balances JSON:', err)
     }
+    setSavePending(false)
   }, [
     activeWallet,
     geckoPriceMap,
@@ -318,6 +316,23 @@ export const AssetsView = (): JSX.Element => {
     selectedPricePool,
     selectedPricePoolMaya
   ])
+
+  // Once LP shares are loaded after user clicked save, perform the actual save
+  useEffect(() => {
+    if (savePending && RD.isSuccess(thorSharesRD) && RD.isSuccess(mayaSharesRD)) {
+      performSave()
+    }
+  }, [savePending, thorSharesRD, mayaSharesRD, performSave])
+
+  const saveBalancesHandler = useCallback(() => {
+    setLpFetchEnabled(true)
+    // If shares are already loaded (e.g. user clicked save before), save immediately
+    if (RD.isSuccess(thorSharesRD) && RD.isSuccess(mayaSharesRD)) {
+      performSave()
+    } else {
+      setSavePending(true)
+    }
+  }, [thorSharesRD, mayaSharesRD, performSave])
 
   const refreshHandler = useCallback(async () => {
     const delay = 1000

--- a/src/renderer/views/wallet/AssetsView.tsx
+++ b/src/renderer/views/wallet/AssetsView.tsx
@@ -317,9 +317,15 @@ export const AssetsView = (): JSX.Element => {
     selectedPricePoolMaya
   ])
 
-  // Once LP shares are loaded after user clicked save, perform the actual save
+  // Once LP shares are loaded (or failed) after user clicked save, perform the actual save
   useEffect(() => {
-    if (savePending && RD.isSuccess(thorSharesRD) && RD.isSuccess(mayaSharesRD)) {
+    if (!savePending) return
+    const thorDone = RD.isSuccess(thorSharesRD) || RD.isFailure(thorSharesRD)
+    const mayaDone = RD.isSuccess(mayaSharesRD) || RD.isFailure(mayaSharesRD)
+    if (thorDone && mayaDone) {
+      if (RD.isFailure(thorSharesRD) || RD.isFailure(mayaSharesRD)) {
+        logger.warn('LP share fetch failed, saving with available data')
+      }
       performSave()
     }
   }, [savePending, thorSharesRD, mayaSharesRD, performSave])


### PR DESCRIPTION
Add Rapid swap mode (interval=0) as default for THORChain swaps. THORChain's Advanced Swap Queue auto-calculates optimal sub-swap count and executes multiple per block for reduced slippage.

- Replace Limit mode with Rapid (omit streaming params for rapid)
- Default to Fast streaming for MAYAChain (no rapid support)
- Fix memo positional params when affiliate present with rapid
- Lazy-load LP pool shares only on Save JSON Balances click

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protocol-aware "Rapid" mode and ability to pick streaming interval and quantity; swap requests, execution, and memos now honor those streaming parameters.

* **Bug Fixes**
  * Removed reset control; slider/quantity visibility now matches selected mode and streamer UI simplified.
  * Save flow defers LP-share loading until user confirms and completes once data is ready.
  * Wallet balances now reset when the active keystore wallet changes.

* **Internationalization**
  * Replaced legacy mode labels with "Rapid", "Streaming", and "Instant" across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->