### PR TITLE
fix: default to Streaming mode, fix snap-back bug, add AVAX.SOL decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 <!-- markdownlint-disable MD024 MD025 -->
 
+# 1.43.0
+
+## Add
+
+- add THORChain rapid swap mode with 3 swap modes: Rapid, Streaming, Instant [#1027](https://github.com/asgardex/asgardex-desktop/pull/1027)
+- add compact trading panel with inline swap execution and limit orders [#1021](https://github.com/asgardex/asgardex-desktop/pull/1021)
+- add Vultisig MPC wallet integration with 5 additional chains [#1012](https://github.com/asgardex/asgardex-desktop/pull/1012) [#1016](https://github.com/asgardex/asgardex-desktop/pull/1016)
+- add charting and wallet chart integration [#1013](https://github.com/asgardex/asgardex-desktop/pull/1013) [#1015](https://github.com/asgardex/asgardex-desktop/pull/1015)
+- add save JSON balances export with LP positions [#1019](https://github.com/asgardex/asgardex-desktop/pull/1019)
+
+## Update/Fixes
+
+- redesign TxModal with vertical step-based progress and pulse animation [#1024](https://github.com/asgardex/asgardex-desktop/pull/1024)
+- fix SDK disposal error recovery [#1022](https://github.com/asgardex/asgardex-desktop/pull/1022)
+- fix price level amount symbol display [#1020](https://github.com/asgardex/asgardex-desktop/pull/1020)
+- fix XRD LP share value and clean up sidebar footer [#1014](https://github.com/asgardex/asgardex-desktop/pull/1014)
+- fix deprecated MayaScan URLs, replace with explorer.mayachain.info [#1011](https://github.com/asgardex/asgardex-desktop/pull/1011)
+- fix memory leaks, error handling, and remove dead code [#1006](https://github.com/asgardex/asgardex-desktop/pull/1006) [#1008](https://github.com/asgardex/asgardex-desktop/pull/1008)
+- lazy-load LP pool shares only on Save JSON Balances click [#1027](https://github.com/asgardex/asgardex-desktop/pull/1027)
+
+## Refactors
+
+- extract reusable hooks and components from Swap.tsx [#1023](https://github.com/asgardex/asgardex-desktop/pull/1023)
+- refactor EVM chain service and Ledger transaction factories [#1007](https://github.com/asgardex/asgardex-desktop/pull/1007) [#1009](https://github.com/asgardex/asgardex-desktop/pull/1009)
+
+## Chores
+
+- upgrade xchain packages [#1017](https://github.com/asgardex/asgardex-desktop/pull/1017) [#1026](https://github.com/asgardex/asgardex-desktop/pull/1026)
+
 # 1.42.1
 
 ## Add

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "asgardex",
   "productName": "ASGARDEX",
-  "version": "1.42.1",
+  "version": "1.43.0",
   "description": "WALLET AND EXCHANGE CLIENT FOR THORCHAIN, MAYACHAIN, CHAINFLIP",
   "main": "build/main/electron.js",
   "scripts": {

--- a/src/renderer/hooks/useStreamingParams.ts
+++ b/src/renderer/hooks/useStreamingParams.ts
@@ -14,8 +14,7 @@ const MODE_DEFAULTS: Record<StreamingMode, { interval: number; quantity: number 
   2: { interval: 1, quantity: 1 } // Instant
 }
 
-const RAPID_DEFAULT: StreamingMode = 0
-const STREAMING_DEFAULT: StreamingMode = 1
+const DEFAULT_MODE: StreamingMode = 1 // Streaming
 
 export type UseStreamingParamsReturn = {
   streamingInterval: number
@@ -30,24 +29,19 @@ export type UseStreamingParamsReturn = {
 }
 
 export const useStreamingParams = (supportRapid = true): UseStreamingParamsReturn => {
-  const defaultMode = supportRapid ? RAPID_DEFAULT : STREAMING_DEFAULT
+  const [activeMode, setActiveMode] = useState<StreamingMode>(DEFAULT_MODE)
+  const [streamingInterval, setStreamingInterval] = useState<number>(MODE_DEFAULTS[DEFAULT_MODE].interval)
+  const [streamingQuantity, setStreamingQuantity] = useState<number>(MODE_DEFAULTS[DEFAULT_MODE].quantity)
 
-  const [activeMode, setActiveMode] = useState<StreamingMode>(defaultMode)
-  const [streamingInterval, setStreamingInterval] = useState<number>(MODE_DEFAULTS[defaultMode].interval)
-  const [streamingQuantity, setStreamingQuantity] = useState<number>(MODE_DEFAULTS[defaultMode].quantity)
-
-  // Reset to appropriate default when supportRapid changes (e.g. switching protocols)
+  // If rapid is not supported and user has it selected, fall back to streaming
   useEffect(() => {
-    if (!supportRapid && activeMode === RAPID_DEFAULT) {
-      setActiveMode(STREAMING_DEFAULT)
-      setStreamingInterval(MODE_DEFAULTS[STREAMING_DEFAULT].interval)
-      setStreamingQuantity(MODE_DEFAULTS[STREAMING_DEFAULT].quantity)
-    } else if (supportRapid && activeMode === STREAMING_DEFAULT) {
-      setActiveMode(RAPID_DEFAULT)
-      setStreamingInterval(MODE_DEFAULTS[RAPID_DEFAULT].interval)
-      setStreamingQuantity(MODE_DEFAULTS[RAPID_DEFAULT].quantity)
+    if (!supportRapid && activeMode === 0) {
+      setActiveMode(DEFAULT_MODE)
+      setStreamingInterval(MODE_DEFAULTS[DEFAULT_MODE].interval)
+      setStreamingQuantity(MODE_DEFAULTS[DEFAULT_MODE].quantity)
     }
-  }, [supportRapid, activeMode])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [supportRapid])
 
   const setMode = useCallback((mode: StreamingMode) => {
     setActiveMode(mode)
@@ -65,16 +59,15 @@ export const useStreamingParams = (supportRapid = true): UseStreamingParamsRetur
   }, [])
 
   const resetToDefault = useCallback(() => {
-    const mode = supportRapid ? RAPID_DEFAULT : STREAMING_DEFAULT
-    setActiveMode(mode)
-    setStreamingInterval(MODE_DEFAULTS[mode].interval)
-    setStreamingQuantity(MODE_DEFAULTS[mode].quantity)
-  }, [supportRapid])
+    setActiveMode(DEFAULT_MODE)
+    setStreamingInterval(MODE_DEFAULTS[DEFAULT_MODE].interval)
+    setStreamingQuantity(MODE_DEFAULTS[DEFAULT_MODE].quantity)
+  }, [])
 
   return {
     streamingInterval,
     streamingQuantity,
-    isStreaming: activeMode !== 2, // Instant is not streaming
+    isStreaming: activeMode !== 2,
     activeMode,
     setMode,
     setInterval,

--- a/src/renderer/services/chain/tokenDecimalMap.ts
+++ b/src/renderer/services/chain/tokenDecimalMap.ts
@@ -72,7 +72,10 @@ const AVAX_TOKENS: Record<string, number> = {
   '0x50b7545627a5162f82a992c33b87adc75187b218': 8, // WBTC.e
 
   // fUSDT (Frax bridged) - check if 6
-  '0x5b8470fbc6b31038aa07abd3010acffca6e36611': 6 // fUSDT
+  '0x5b8470fbc6b31038aa07abd3010acffca6e36611': 6, // fUSDT
+
+  // Bridged SOL (9 decimals)
+  '0xfe6b19286885a4f7f55adad09c3cd1f906d2478f': 9 // SOL
 }
 
 // ────────────────────────────────────────────────


### PR DESCRIPTION
- Default swap mode is Streaming (interval=1) instead of Rapid
- Fix useEffect that snapped mode back to Rapid on every change
- Add AVAX.SOL bridged token (9 decimals) to token decimal map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional bridged SOL token on AVAX with correct decimal precision.

* **Refactor**
  * Simplified streaming mode initialization and default/reset behavior.

* **Chores**
  * Added v1.43.0 release notes to the changelog and bumped package version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->