### PR TITLE
fix: Various Vultisig fixes

### DIFF
--- a/src/renderer/components/modal/confirmation/VultisigConfirmationModal.tsx
+++ b/src/renderer/components/modal/confirmation/VultisigConfirmationModal.tsx
@@ -30,6 +30,7 @@ type Props = {
   isEncrypted: boolean
   onSuccess: FP.Lazy<void>
   onClose: FP.Lazy<void>
+  onCancel?: FP.Lazy<void>
   validatePassword$: (password: string) => Promise<boolean>
   txState: RD.RemoteData<ApiError, TxHash>
   getActiveVaultId: () => string | undefined
@@ -38,6 +39,7 @@ type Props = {
 export const VultisigConfirmationModal = ({
   visible,
   onClose,
+  onCancel,
   onSuccess,
   chain,
   network,
@@ -215,6 +217,7 @@ export const VultisigConfirmationModal = ({
   const handleCancel = useCallback(async () => {
     if (phase === 'password') {
       // Password phase - just close
+      onCancel?.()
       onClose()
       return
     }
@@ -233,8 +236,9 @@ export const VultisigConfirmationModal = ({
         setIsCancelling(false)
       }
     }
+    onCancel?.()
     onClose()
-  }, [onClose, phase, getActiveVaultId])
+  }, [onClose, onCancel, phase, getActiveVaultId])
 
   const handlePasswordChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(e.target.value)

--- a/src/renderer/components/modal/confirmation/VultisigConfirmationModal.tsx
+++ b/src/renderer/components/modal/confirmation/VultisigConfirmationModal.tsx
@@ -27,6 +27,7 @@ type Props = {
   network: Network
   chain: Chain
   vaultType: VaultType
+  isEncrypted: boolean
   onSuccess: FP.Lazy<void>
   onClose: FP.Lazy<void>
   validatePassword$: (password: string) => Promise<boolean>
@@ -41,6 +42,7 @@ export const VultisigConfirmationModal = ({
   chain,
   network,
   vaultType,
+  isEncrypted,
   validatePassword$,
   txState,
   getActiveVaultId
@@ -84,7 +86,6 @@ export const VultisigConfirmationModal = ({
   // Reset state when modal opens
   useEffect(() => {
     if (visible) {
-      setPhase('password')
       setPassword('')
       setPasswordError(null)
       setQrPayload(null)
@@ -93,8 +94,18 @@ export const VultisigConfirmationModal = ({
       setIsCancelling(false)
       signingStartedRef.current = false
       closedRef.current = false
+
+      if (!isEncrypted) {
+        // No password needed — skip straight to signing
+        // Secure: modal stays open for QR/device flow
+        // Fast: parent closes modal immediately via onSuccess callback
+        setPhase(vaultType === 'secure' ? 'waiting-qr' : 'signing')
+        onSuccess()
+      } else {
+        setPhase('password')
+      }
     }
-  }, [visible])
+  }, [visible]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Set up signing event listeners for SecureVault
   // These listeners receive IPC events from main process during MPC signing ceremony

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -1217,12 +1217,19 @@ export const Swap = ({
     [isAssetSupported$, poolAssets, poolDetailsMaya, poolDetailsThor, sourceAsset]
   )
 
-  // Get vault type for Vultisig wallets
+  // Get vault type and encryption status for Vultisig wallets
   const vaultType: VaultType = useMemo(() => {
     if (appWalletState && isVultisigMode(appWalletState) && appWalletState.activeVault) {
       return appWalletState.activeVault.type
     }
     return 'fast'
+  }, [appWalletState])
+
+  const isVaultEncrypted: boolean = useMemo(() => {
+    if (appWalletState && isVultisigMode(appWalletState) && appWalletState.activeVault) {
+      return appWalletState.activeVault.isEncrypted
+    }
+    return true // Default to encrypted (safe fallback — will show password prompt)
   }, [appWalletState])
 
   // Password validation for Vultisig
@@ -1265,9 +1272,11 @@ export const Swap = ({
     validatePassword$,
     validatePasswordForVultisig,
     vaultType,
+    isVaultEncrypted,
     approveState,
     swapState,
-    getActiveVaultId: appWalletService.getActiveVaultId
+    getActiveVaultId: appWalletService.getActiveVaultId,
+    resetSwapState
   })
 
   const setAmountToSwapFromPercentValue = useCallback(

--- a/src/renderer/components/swap/SwapRoute.tsx
+++ b/src/renderer/components/swap/SwapRoute.tsx
@@ -104,7 +104,11 @@ const Route = memo(function Route({
           {isFastest && <span className="rounded bg-turquoise px-1 text-11 text-white">FASTEST</span>}
         </div>
         {isBoostable && isChainflip && onToggleBoost && isBoostEnabled !== undefined && (
-          <div className="flex items-center space-x-2">
+          <div
+            className="flex items-center space-x-2"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+            role="group">
             <div className="flex items-center">
               <img src={BoostIcon} alt="Boost" className="h-5 w-5" />
               <span className="text-11 text-boost">Boost</span>

--- a/src/renderer/components/swap/TradeSwap.tsx
+++ b/src/renderer/components/swap/TradeSwap.tsx
@@ -1266,6 +1266,7 @@ export const TradeSwap = ({
     validatePassword$,
     validatePasswordForVultisig: async () => false,
     vaultType: 'fast',
+    isVaultEncrypted: true,
     approveState: RD.initial,
     swapState,
     getActiveVaultId: () => undefined

--- a/src/renderer/components/swap/components/SwapConfirmationModals.tsx
+++ b/src/renderer/components/swap/components/SwapConfirmationModals.tsx
@@ -221,12 +221,8 @@ export const useSwapConfirmationModals = ({
       vaultType={vaultType}
       isEncrypted={isVaultEncrypted}
       onSuccess={onVultisigSuccess}
-      onClose={() => {
-        setShowVultisigModal(ModalState.None)
-        // Reset swap state immediately so TxModal doesn't flash while
-        // the cancel propagates through the Observable chain
-        resetSwapState?.()
-      }}
+      onClose={() => setShowVultisigModal(ModalState.None)}
+      onCancel={() => resetSwapState?.()}
       validatePassword$={validatePasswordForVultisig}
       txState={showVultisigModal === ModalState.Approve ? approveState : swapState.swapTx}
       getActiveVaultId={getActiveVaultId}

--- a/src/renderer/components/swap/components/SwapConfirmationModals.tsx
+++ b/src/renderer/components/swap/components/SwapConfirmationModals.tsx
@@ -39,9 +39,11 @@ type SwapConfirmationModalsProps = {
   validatePasswordForVultisig: (password: string) => Promise<boolean>
   // Vultisig-specific
   vaultType: VaultType
+  isVaultEncrypted: boolean
   approveState: TxHashRD
   swapState: SwapTxState
   getActiveVaultId: () => string | undefined
+  resetSwapState?: () => void
 }
 
 type SwapConfirmationModalsResult = {
@@ -72,9 +74,11 @@ export const useSwapConfirmationModals = ({
   validatePassword$,
   validatePasswordForVultisig,
   vaultType,
+  isVaultEncrypted,
   approveState,
   swapState,
-  getActiveVaultId
+  getActiveVaultId,
+  resetSwapState
 }: SwapConfirmationModalsProps): SwapConfirmationModalsResult => {
   const intl = useIntl()
 
@@ -215,8 +219,14 @@ export const useSwapConfirmationModals = ({
       network={network}
       chain={sourceChain}
       vaultType={vaultType}
+      isEncrypted={isVaultEncrypted}
       onSuccess={onVultisigSuccess}
-      onClose={() => setShowVultisigModal(ModalState.None)}
+      onClose={() => {
+        setShowVultisigModal(ModalState.None)
+        // Reset swap state immediately so TxModal doesn't flash while
+        // the cancel propagates through the Observable chain
+        resetSwapState?.()
+      }}
       validatePassword$={validatePasswordForVultisig}
       txState={showVultisigModal === ModalState.Approve ? approveState : swapState.swapTx}
       getActiveVaultId={getActiveVaultId}

--- a/src/renderer/components/uielements/button/SwitchButton.tsx
+++ b/src/renderer/components/uielements/button/SwitchButton.tsx
@@ -29,11 +29,12 @@ export const SwitchButton = (props: Props): JSX.Element => {
 
   return (
     <Switch
+      as="div"
       disabled={disabled}
       checked={active}
       onChange={onChangeHandler}
       className={clsx(
-        'relative inline-flex h-6 w-11 items-center rounded-full',
+        'relative inline-flex h-6 w-11 cursor-pointer items-center rounded-full',
         active ? 'bg-turquoise' : 'bg-gray1 dark:bg-gray1d',
         className
       )}>

--- a/src/renderer/components/wallet/txs/send/SendForm.tsx
+++ b/src/renderer/components/wallet/txs/send/SendForm.tsx
@@ -161,12 +161,19 @@ export const SendForm = (props: Props): JSX.Element => {
   const { appWalletService } = useWalletContext()
   const appWalletState = useObservableState(appWalletService.appWalletState$, null)
 
-  // Get vault type for Vultisig wallets (defaults to 'fast' if not available)
+  // Get vault type and encryption status for Vultisig wallets
   const vaultType: VaultType = useMemo(() => {
     if (appWalletState && isVultisigMode(appWalletState) && appWalletState.activeVault) {
       return appWalletState.activeVault.type
     }
     return 'fast'
+  }, [appWalletState])
+
+  const isVaultEncrypted: boolean = useMemo(() => {
+    if (appWalletState && isVultisigMode(appWalletState) && appWalletState.activeVault) {
+      return appWalletState.activeVault.isEncrypted
+    }
+    return true
   }, [appWalletState])
 
   const { asset } = balance
@@ -1255,6 +1262,7 @@ export const SendForm = (props: Props): JSX.Element => {
       network={network}
       chain={asset.chain}
       vaultType={vaultType}
+      isEncrypted={isVaultEncrypted}
       onSuccess={onVultisigSuccess}
       onClose={onConfirmationModalClose}
       validatePassword$={validatePasswordAsync}

--- a/src/renderer/services/cosmos/vultisigTx.ts
+++ b/src/renderer/services/cosmos/vultisigTx.ts
@@ -54,11 +54,12 @@ export const createVultisigCosmosTx = (
     const denom = getDenom(asset)
     const id = denom && denom !== nativeDenom ? denom : undefined
 
-    // Native chain deposits (RUNE on THOR, CACAO on MAYA) use MsgDeposit, not MsgSend.
-    // These have no receiver (pool address is empty). The SDK uses the sender as signer.
-    // Only THOR and MAYA support native deposits — other Cosmos chains (GAIA etc.) should never set isDeposit.
-    const isNativeAsset = denom === nativeDenom || !denom
-    const isDeposit = !recipient && isNativeAsset && (chainName === 'THOR' || chainName === 'MAYA')
+    // THORChain/MAYAChain pool interactions (swaps, deposits, bonds, etc.) are always
+    // MsgDeposit — the memo contains the instruction and recipient, not the tx itself.
+    // This applies to ALL assets on these chains (RUNE, RUJI, TCY, synths, etc.),
+    // matching how keystore and Ledger handle deposits.
+    // Other Cosmos chains (GAIA) use MsgSend and should never set isDeposit.
+    const isDeposit = !recipient && (chainName === 'THOR' || chainName === 'MAYA')
 
     const txParams: SendTransactionParams = {
       vaultId,

--- a/src/renderer/views/pools/detail/TradingPanel.tsx
+++ b/src/renderer/views/pools/detail/TradingPanel.tsx
@@ -498,6 +498,13 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
     return 'fast'
   }, [appWalletState])
 
+  const isVaultEncrypted: boolean = useMemo(() => {
+    if (appWalletState && isVultisigMode(appWalletState) && appWalletState.activeVault) {
+      return appWalletState.activeVault.isEncrypted
+    }
+    return true
+  }, [appWalletState])
+
   const validatePasswordForVultisig = useCallback(
     async (password: string): Promise<boolean> => {
       if (isVultisigWallet(sourceWalletType)) {
@@ -533,9 +540,11 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
     validatePassword$,
     validatePasswordForVultisig,
     vaultType,
+    isVaultEncrypted,
     approveState: RD.initial,
     swapState,
-    getActiveVaultId
+    getActiveVaultId,
+    resetSwapState
   })
 
   // ── Explorer URL for tx modal ─────────────────────────────────────────


### PR DESCRIPTION
- Skip password for unencrypted vaults: VultisigConfirmationModal now checks isEncrypted and skips the password phase for vaults imported without a password. Secure vaults go straight to QR flow, fast vaults fire immediately.
  - Reset swap state on cancel: Added onCancel callback to VultisigConfirmationModal, called only when user explicitly cancels (not on success close). Prevents TxModal from flashing stale pending state after cancelling a signing session.
  - Fix RUJI/TCY MsgDeposit: Removed isNativeAsset gate from isDeposit check in cosmos/vultisigTx.ts. All THORChain/MAYAChain pool interactions are MsgDeposit regardless of asset type — matching how keystore and Ledger already work.
  - Fix nested button DOM warning: Changed headlessui Switch to render as div (as="div") in SwitchButton.tsx and added stopPropagation on boost toggle wrapper in  SwapRoute.tsx. Fixes <button> inside <button> warning when Chainflip boost is
  available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced confirmation modal flow to differentiate between encrypted and non-encrypted vault states.

* **Bug Fixes**
  * Improved transaction classification logic for deposit detection.
  * Fixed event propagation on swap route boost toggle to prevent unintended interactions.

* **Improvements**
  * Enhanced cursor feedback on switch button interactions.
  * Refined vault encryption state handling across swap and send flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->