### PR TITLE
fix: migrate Nine Realms endpoints to Liquify and add provider selector

### DIFF
--- a/src/renderer/components/settings/AppExpertMode.tsx
+++ b/src/renderer/components/settings/AppExpertMode.tsx
@@ -263,7 +263,7 @@ export const AppExpertMode = (props: Props): JSX.Element => {
                   successMsg={intl.formatMessage({ id: 'settings.mayanode.node.valid' })}
                 />
               </SubSection>
-              <SubSection title="MAYANode RPC">
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.mayanodeRpc.title' })}>
                 <EditableUrl
                   className="w-full xl:w-3/4"
                   url={mayanodeRpcUrl}
@@ -281,7 +281,7 @@ export const AppExpertMode = (props: Props): JSX.Element => {
               <SubSection title={intl.formatMessage({ id: 'settings.expert.mayanodeApi.title' })}>
                 <ReadOnlyUrl url={mayanodeNodeUrl} />
               </SubSection>
-              <SubSection title="MAYANode RPC">
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.mayanodeRpc.title' })}>
                 <ReadOnlyUrl url={mayanodeRpcUrl} />
               </SubSection>
             </>

--- a/src/renderer/components/settings/AppExpertMode.tsx
+++ b/src/renderer/components/settings/AppExpertMode.tsx
@@ -7,6 +7,8 @@ import { function as FP } from 'fp-ts'
 import { useIntl } from 'react-intl'
 
 import { GasMultiplier } from '../../../shared/api/types'
+import { PROVIDER_REGISTRY } from '../../../shared/providers'
+import { ProviderId, ProviderSectionKey } from '../../../shared/providers/types'
 import { LiveData } from '../../helpers/rx/liveData'
 import { GAS_MULTIPLIER_OPTIONS } from '../../hooks/useEvmGasMultiplier'
 import { RpcHealthStatus } from '../../hooks/useEvmRpcUrl'
@@ -22,6 +24,7 @@ import { TextButton } from '../uielements/button'
 import { SwitchButton } from '../uielements/button/SwitchButton'
 import { RadioGroup } from '../uielements/radioGroup'
 import EditableUrl from './EditableUrl'
+import { ProviderSelector } from './ProviderSelector'
 
 export type CheckEvmRpcUrlHandler = (url: string) => LiveData<Error, string>
 
@@ -60,6 +63,10 @@ type Props = {
   // EVM Gas multiplier
   gasMultiplier: GasMultiplier
   onChangeGasMultiplier: (multiplier: GasMultiplier) => void
+  // Provider (derived from current URLs)
+  thorchainProvider: ProviderId
+  mayachainProvider: ProviderId
+  onChangeProvider: (section: ProviderSectionKey, providerId: ProviderId) => void
 }
 
 type SubSectionProps = {
@@ -70,9 +77,14 @@ type SubSectionProps = {
   warningTooltip?: string
 }
 
+/** Read-only URL display — no edit/test, just the URL text */
+const ReadOnlyUrl = ({ url }: { url: string }) => (
+  <div className="flex items-center">
+    <span className="font-main text-[14px] text-gray2 dark:text-gray2d">{url}</span>
+  </div>
+)
+
 const expertModeDefault: Record<string, boolean> = {
-  thorchain: false,
-  mayachain: false,
   evm: false
 }
 
@@ -135,7 +147,10 @@ export const AppExpertMode = (props: Props): JSX.Element => {
     avaxRpc,
     baseRpc,
     gasMultiplier,
-    onChangeGasMultiplier
+    onChangeGasMultiplier,
+    thorchainProvider,
+    mayachainProvider,
+    onChangeProvider
   } = props
 
   const intl = useIntl()
@@ -167,110 +182,110 @@ export const AppExpertMode = (props: Props): JSX.Element => {
 
   return (
     <div className="flex flex-col">
-      <Section
-        title={intl.formatMessage({ id: 'settings.expert.thorchain.title' })}
-        toggleHandler={
-          <div className="flex items-center justify-end px-4 py-6">
-            <TextButton
-              className={clsx(
-                'mb-0 !py-0 !pr-10px !pl-0 font-main !text-14 text-text0 uppercase dark:text-text0d',
-                advancedActive ? 'opacity-100' : 'opacity-60'
-              )}
-              onClick={() => setAdvancedActive((prev) => ({ ...prev, thorchain: !prev.thorchain }))}>
-              {intl.formatMessage({ id: 'common.advanced' })}
-            </TextButton>
-            <SwitchButton
-              active={advancedActive.thorchain}
-              onChange={(active) => setAdvancedActive({ ...advancedActive, thorchain: active })}
-            />
-          </div>
-        }>
-        <div
-          className={clsx(
-            'flex-col transition-all duration-300 ease-in-out',
-            advancedActive.thorchain ? 'flex' : 'hidden'
-          )}>
-          <SubSection title={intl.formatMessage({ id: 'settings.expert.midgard.title' })}>
-            <EditableUrl
-              className="w-full xl:w-3/4"
-              url={midgardUrl}
-              onChange={onChangeMidgardUrl}
-              loading={RD.isPending(midgardUrlRD)}
-              checkUrl$={checkMidgardUrl$}
-              successMsg={intl.formatMessage({ id: 'midgard.url.valid' })}
-            />
-          </SubSection>
-          <SubSection title={intl.formatMessage({ id: 'settings.expert.thornodeApi.title' })}>
-            <EditableUrl
-              className="w-full xl:w-3/4"
-              url={thornodeNodeUrl}
-              onChange={onChangeThornodeNodeUrl}
-              checkUrl$={checkThornodeNodeUrl$}
-              successMsg={intl.formatMessage({ id: 'settings.thornode.node.valid' })}
-            />
-          </SubSection>
-          <SubSection title={intl.formatMessage({ id: 'settings.expert.thornodeRpc.title' })}>
-            <EditableUrl
-              className="w-full xl:w-3/4"
-              url={thornodeRpcUrl}
-              onChange={onChangeThornodeRpcUrl}
-              checkUrl$={checkThornodeRpcUrl$}
-              successMsg={intl.formatMessage({ id: 'settings.thornode.rpc.valid' })}
-            />
-          </SubSection>
+      <Section title={intl.formatMessage({ id: 'settings.expert.thorchain.title' })}>
+        <div className="flex flex-col">
+          <ProviderSelector
+            config={PROVIDER_REGISTRY.thorchain}
+            selectedProviderId={thorchainProvider}
+            onSelectProvider={(id) => onChangeProvider('thorchain', id)}
+          />
+          {thorchainProvider === 'custom' ? (
+            <>
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.midgard.title' })}>
+                <EditableUrl
+                  className="w-full xl:w-3/4"
+                  url={midgardUrl}
+                  onChange={onChangeMidgardUrl}
+                  loading={RD.isPending(midgardUrlRD)}
+                  checkUrl$={checkMidgardUrl$}
+                  successMsg={intl.formatMessage({ id: 'midgard.url.valid' })}
+                />
+              </SubSection>
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.thornodeApi.title' })}>
+                <EditableUrl
+                  className="w-full xl:w-3/4"
+                  url={thornodeNodeUrl}
+                  onChange={onChangeThornodeNodeUrl}
+                  checkUrl$={checkThornodeNodeUrl$}
+                  successMsg={intl.formatMessage({ id: 'settings.thornode.node.valid' })}
+                />
+              </SubSection>
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.thornodeRpc.title' })}>
+                <EditableUrl
+                  className="w-full xl:w-3/4"
+                  url={thornodeRpcUrl}
+                  onChange={onChangeThornodeRpcUrl}
+                  checkUrl$={checkThornodeRpcUrl$}
+                  successMsg={intl.formatMessage({ id: 'settings.thornode.rpc.valid' })}
+                />
+              </SubSection>
+            </>
+          ) : (
+            <>
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.midgard.title' })}>
+                <ReadOnlyUrl url={midgardUrl} />
+              </SubSection>
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.thornodeApi.title' })}>
+                <ReadOnlyUrl url={thornodeNodeUrl} />
+              </SubSection>
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.thornodeRpc.title' })}>
+                <ReadOnlyUrl url={thornodeRpcUrl} />
+              </SubSection>
+            </>
+          )}
         </div>
       </Section>
-      <Section
-        title={intl.formatMessage({ id: 'settings.expert.mayachain.title' })}
-        toggleHandler={
-          <div className="flex items-center justify-end px-4 py-6">
-            <TextButton
-              className={clsx(
-                'mb-0 !py-0 !pr-10px !pl-0 font-main !text-14 text-text0 uppercase dark:text-text0d',
-                advancedActive ? 'opacity-100' : 'opacity-60'
-              )}
-              onClick={() => setAdvancedActive((prev) => ({ ...prev, mayachain: !prev.mayachain }))}>
-              {intl.formatMessage({ id: 'common.advanced' })}
-            </TextButton>
-            <SwitchButton
-              active={advancedActive.mayachain}
-              onChange={(active) => setAdvancedActive({ ...advancedActive, mayachain: active })}
-            />
-          </div>
-        }>
-        <div
-          className={clsx(
-            'flex-col transition-all duration-300 ease-in-out',
-            advancedActive.mayachain ? 'flex' : 'hidden'
-          )}>
-          <SubSection title={intl.formatMessage({ id: 'settings.expert.midgardMaya.title' })}>
-            <EditableUrl
-              className="w-full"
-              url={midgardMayaUrl}
-              onChange={onChangeMidgardMayaUrl}
-              loading={RD.isPending(midgardMayaUrlRD)}
-              checkUrl$={checkMidgardMayaUrl$}
-              successMsg={intl.formatMessage({ id: 'midgard.url.valid' })}
-            />
-          </SubSection>
-          <SubSection title={intl.formatMessage({ id: 'settings.expert.mayanodeApi.title' })}>
-            <EditableUrl
-              className="w-full xl:w-3/4"
-              url={mayanodeNodeUrl}
-              onChange={onChangeMayanodeNodeUrl}
-              checkUrl$={checkMayanodeNodeUrl$}
-              successMsg={intl.formatMessage({ id: 'settings.mayanode.node.valid' })}
-            />
-          </SubSection>
-          <SubSection title="MAYANode RPC">
-            <EditableUrl
-              className="w-full xl:w-3/4"
-              url={mayanodeRpcUrl}
-              onChange={onChangeMayanodeRpcUrl}
-              checkUrl$={checkMayanodeRpcUrl$}
-              successMsg={intl.formatMessage({ id: 'settings.mayanode.rpc.valid' })}
-            />
-          </SubSection>
+      <Section title={intl.formatMessage({ id: 'settings.expert.mayachain.title' })}>
+        <div className="flex flex-col">
+          <ProviderSelector
+            config={PROVIDER_REGISTRY.mayachain}
+            selectedProviderId={mayachainProvider}
+            onSelectProvider={(id) => onChangeProvider('mayachain', id)}
+          />
+          {mayachainProvider === 'custom' ? (
+            <>
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.midgardMaya.title' })}>
+                <EditableUrl
+                  className="w-full"
+                  url={midgardMayaUrl}
+                  onChange={onChangeMidgardMayaUrl}
+                  loading={RD.isPending(midgardMayaUrlRD)}
+                  checkUrl$={checkMidgardMayaUrl$}
+                  successMsg={intl.formatMessage({ id: 'midgard.url.valid' })}
+                />
+              </SubSection>
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.mayanodeApi.title' })}>
+                <EditableUrl
+                  className="w-full xl:w-3/4"
+                  url={mayanodeNodeUrl}
+                  onChange={onChangeMayanodeNodeUrl}
+                  checkUrl$={checkMayanodeNodeUrl$}
+                  successMsg={intl.formatMessage({ id: 'settings.mayanode.node.valid' })}
+                />
+              </SubSection>
+              <SubSection title="MAYANode RPC">
+                <EditableUrl
+                  className="w-full xl:w-3/4"
+                  url={mayanodeRpcUrl}
+                  onChange={onChangeMayanodeRpcUrl}
+                  checkUrl$={checkMayanodeRpcUrl$}
+                  successMsg={intl.formatMessage({ id: 'settings.mayanode.rpc.valid' })}
+                />
+              </SubSection>
+            </>
+          ) : (
+            <>
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.midgardMaya.title' })}>
+                <ReadOnlyUrl url={midgardMayaUrl} />
+              </SubSection>
+              <SubSection title={intl.formatMessage({ id: 'settings.expert.mayanodeApi.title' })}>
+                <ReadOnlyUrl url={mayanodeNodeUrl} />
+              </SubSection>
+              <SubSection title="MAYANode RPC">
+                <ReadOnlyUrl url={mayanodeRpcUrl} />
+              </SubSection>
+            </>
+          )}
         </div>
       </Section>
       <Section

--- a/src/renderer/components/settings/ProviderSelector.tsx
+++ b/src/renderer/components/settings/ProviderSelector.tsx
@@ -1,0 +1,193 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { ChevronDownIcon } from '@heroicons/react/24/outline'
+import clsx from 'clsx'
+import { useIntl } from 'react-intl'
+
+import { ChainProviderConfig, ProviderId, ProviderEntry } from '../../../shared/providers/types'
+
+type Props = {
+  config: ChainProviderConfig
+  selectedProviderId: ProviderId
+  onSelectProvider: (providerId: ProviderId) => void
+}
+
+const BadgeLabel = ({
+  badge,
+  intl
+}: {
+  badge?: 'recommended' | 'backup' | 'manual'
+  intl: ReturnType<typeof useIntl>
+}) => {
+  if (!badge) return null
+  const labels: Record<string, string> = {
+    recommended: intl.formatMessage({ id: 'settings.provider.badge.recommended' }),
+    backup: intl.formatMessage({ id: 'settings.provider.badge.backup' }),
+    manual: intl.formatMessage({ id: 'settings.provider.badge.manual' })
+  }
+  return (
+    <span
+      className={clsx(
+        'rounded px-1.5 py-px font-main text-[10px] font-bold tracking-wide uppercase',
+        badge === 'recommended'
+          ? 'border border-turquoise/30 bg-turquoise/15 text-turquoise'
+          : badge === 'backup'
+            ? 'border border-warning0/25 bg-warning0/12 text-warning0'
+            : 'border border-gray1/25 bg-gray1/12 text-gray2 dark:text-gray2d'
+      )}>
+      {labels[badge]}
+    </span>
+  )
+}
+
+export const ProviderSelector = ({ config, selectedProviderId, onSelectProvider }: Props): JSX.Element => {
+  const intl = useIntl()
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (!isOpen) return
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen])
+
+  const selectedProvider = useMemo(
+    () => config.providers.find((p) => p.id === selectedProviderId),
+    [config.providers, selectedProviderId]
+  )
+
+  const isCustom = selectedProviderId === 'custom'
+
+  const handleSelect = useCallback(
+    (providerId: ProviderId) => {
+      onSelectProvider(providerId)
+      setIsOpen(false)
+    },
+    [onSelectProvider]
+  )
+
+  return (
+    <div ref={containerRef} className="border-b border-gray0 px-4 py-3 dark:border-gray0d">
+      {/* Provider chip / trigger */}
+      <div className="flex items-center gap-3">
+        <span className="font-main text-[14px] text-gray1 uppercase dark:text-gray1d">
+          {intl.formatMessage({ id: 'settings.provider.label' })}
+        </span>
+        <button
+          className={clsx(
+            'flex items-center gap-2 rounded-md border px-3 py-1.5 transition-colors',
+            isOpen
+              ? 'border-turquoise/50 bg-turquoise/12'
+              : 'border-turquoise/25 bg-turquoise/8 hover:border-turquoise/40 hover:bg-turquoise/12'
+          )}
+          onClick={() => setIsOpen(!isOpen)}>
+          <span className="font-main text-[14px] font-semibold text-text0 dark:text-text0d">
+            {isCustom ? intl.formatMessage({ id: 'settings.provider.custom' }) : (selectedProvider?.name ?? 'Select')}
+          </span>
+          {isCustom ? (
+            <BadgeLabel badge="manual" intl={intl} />
+          ) : (
+            selectedProvider && <BadgeLabel badge={selectedProvider.badge} intl={intl} />
+          )}
+          {!isCustom && selectedProvider && (
+            <span className="font-main text-[12px] text-gray2 dark:text-gray2d">{selectedProvider.domain}</span>
+          )}
+          <ChevronDownIcon
+            className={clsx('h-4 w-4 text-gray2 transition-transform dark:text-gray2d', isOpen && 'rotate-180')}
+          />
+        </button>
+      </div>
+
+      {/* Dropdown */}
+      {isOpen && (
+        <div className="mt-2 overflow-hidden rounded-md border border-gray0 bg-bg0 dark:border-gray0d dark:bg-bg0d">
+          {config.providers.map((provider: ProviderEntry) => (
+            <ProviderOption
+              key={provider.id}
+              provider={provider}
+              isSelected={provider.id === selectedProviderId}
+              onSelect={() => handleSelect(provider.id)}
+              intl={intl}
+            />
+          ))}
+          {/* Custom option */}
+          <button
+            className={clsx(
+              'flex w-full items-center gap-3 border-t border-gray0/50 px-4 py-3 text-left transition-colors dark:border-gray0d/50',
+              isCustom ? 'border-l-[3px] border-l-turquoise bg-turquoise/8 pl-[13px]' : 'hover:bg-turquoise/6'
+            )}
+            onClick={() => handleSelect('custom')}>
+            <div
+              className={clsx(
+                'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border-2',
+                isCustom ? 'border-turquoise' : 'border-gray1 dark:border-gray1d'
+              )}>
+              {isCustom && <div className="h-2 w-2 rounded-full bg-turquoise" />}
+            </div>
+            <div className="flex flex-col gap-0.5">
+              <div className="flex items-center gap-2">
+                <span className="font-main text-[14px] font-semibold text-text0 dark:text-text0d">
+                  {intl.formatMessage({ id: 'settings.provider.custom' })}
+                </span>
+                <BadgeLabel badge="manual" intl={intl} />
+              </div>
+              <span className="font-main text-[12px] text-gray2 dark:text-gray2d">
+                {intl.formatMessage({ id: 'settings.provider.custom.description' })}
+              </span>
+            </div>
+          </button>
+        </div>
+      )}
+
+      {/* Managed hint when a preset provider is active */}
+      {!isCustom && !isOpen && (
+        <p className="mt-2 font-main text-[12px] text-gray1 italic dark:text-gray1d">
+          {intl.formatMessage({ id: 'settings.provider.hint' })}
+        </p>
+      )}
+    </div>
+  )
+}
+
+const ProviderOption = ({
+  provider,
+  isSelected,
+  onSelect,
+  intl
+}: {
+  provider: ProviderEntry
+  isSelected: boolean
+  onSelect: () => void
+  intl: ReturnType<typeof useIntl>
+}) => (
+  <button
+    className={clsx(
+      'flex w-full items-center gap-3 border-b border-gray0/50 px-4 py-3 text-left transition-colors last:border-b-0 dark:border-gray0d/50',
+      isSelected ? 'border-l-[3px] border-l-turquoise bg-turquoise/8 pl-[13px]' : 'hover:bg-turquoise/6'
+    )}
+    onClick={onSelect}>
+    <div
+      className={clsx(
+        'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border-2',
+        isSelected ? 'border-turquoise' : 'border-gray1 dark:border-gray1d'
+      )}>
+      {isSelected && <div className="h-2 w-2 rounded-full bg-turquoise" />}
+    </div>
+    <div className="flex flex-col gap-0.5">
+      <div className="flex items-center gap-2">
+        <span className="font-main text-[14px] font-semibold text-text0 dark:text-text0d">{provider.name}</span>
+        <BadgeLabel badge={provider.badge} intl={intl} />
+      </div>
+      <span className="font-main text-[12px] text-gray2 dark:text-gray2d">{provider.description}</span>
+      <span className="font-mono text-[12px] text-gray1 dark:text-gray1d">{provider.domain}</span>
+    </div>
+  </button>
+)
+
+export default ProviderSelector

--- a/src/renderer/i18n/de/settings.ts
+++ b/src/renderer/i18n/de/settings.ts
@@ -79,7 +79,14 @@ const settings: SettingMessages = {
     'RPC-Endpunkt antwortet nicht. Überprüfe deine Verbindung oder versuche eine andere URL.',
   'settings.ledgerMode.lockWalletWarning': 'Wallet zuerst sperren, um in den Ledger-Modus zu wechseln',
   'settings.wallet.whitelist': 'Whitelist',
-  'settings.wallet.customToken': 'Benutzerdefinierter Token'
+  'settings.wallet.customToken': 'Benutzerdefinierter Token',
+  'settings.provider.label': 'Provider',
+  'settings.provider.custom': 'Custom',
+  'settings.provider.custom.description': 'Enter your own endpoint URLs',
+  'settings.provider.badge.recommended': 'Recommended',
+  'settings.provider.badge.backup': 'Backup',
+  'settings.provider.badge.manual': 'Manual',
+  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
 }
 
 export default settings

--- a/src/renderer/i18n/de/settings.ts
+++ b/src/renderer/i18n/de/settings.ts
@@ -65,6 +65,7 @@ const settings: SettingMessages = {
   'settings.expert.mayachain.title': 'Mayachain-URLs',
   'settings.expert.midgardMaya.title': 'Midgard Mayachain',
   'settings.expert.mayanodeApi.title': 'MayaNode-API',
+  'settings.expert.mayanodeRpc.title': 'MayaNode-RPC',
   'settings.expert.evm.title': 'EVM-Ketten RPC-URLs',
   'settings.expert.evm.eth.title': 'Ethereum RPC',
   'settings.expert.evm.bsc.title': 'BSC RPC',
@@ -80,13 +81,14 @@ const settings: SettingMessages = {
   'settings.ledgerMode.lockWalletWarning': 'Wallet zuerst sperren, um in den Ledger-Modus zu wechseln',
   'settings.wallet.whitelist': 'Whitelist',
   'settings.wallet.customToken': 'Benutzerdefinierter Token',
-  'settings.provider.label': 'Provider',
-  'settings.provider.custom': 'Custom',
-  'settings.provider.custom.description': 'Enter your own endpoint URLs',
-  'settings.provider.badge.recommended': 'Recommended',
+  'settings.provider.label': 'Anbieter',
+  'settings.provider.custom': 'Benutzerdefiniert',
+  'settings.provider.custom.description': 'Eigene Endpunkt-URLs eingeben',
+  'settings.provider.badge.recommended': 'Empfohlen',
   'settings.provider.badge.backup': 'Backup',
-  'settings.provider.badge.manual': 'Manual',
-  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
+  'settings.provider.badge.manual': 'Manuell',
+  'settings.provider.hint':
+    'URLs werden vom ausgewählten Anbieter verwaltet. Wechsle zu "Benutzerdefiniert", um sie einzeln zu bearbeiten.'
 }
 
 export default settings

--- a/src/renderer/i18n/en/settings.ts
+++ b/src/renderer/i18n/en/settings.ts
@@ -62,6 +62,7 @@ const settings: SettingMessages = {
   'settings.expert.mayachain.title': 'Mayachain URLs',
   'settings.expert.midgardMaya.title': 'Midgard Mayachain',
   'settings.expert.mayanodeApi.title': 'MayaNode API',
+  'settings.expert.mayanodeRpc.title': 'MayaNode RPC',
   'settings.expert.evm.title': 'EVM Chain RPC URLs',
   'settings.expert.evm.eth.title': 'Ethereum RPC',
   'settings.expert.evm.bsc.title': 'BSC RPC',

--- a/src/renderer/i18n/en/settings.ts
+++ b/src/renderer/i18n/en/settings.ts
@@ -75,7 +75,14 @@ const settings: SettingMessages = {
   'settings.evm.rpc.unhealthy': 'RPC endpoint is not responding. Check your connection or try a different URL.',
   'settings.ledgerMode.lockWalletWarning': 'Lock wallet first to enter Ledger mode',
   'settings.wallet.whitelist': 'Whitelist',
-  'settings.wallet.customToken': 'Custom token'
+  'settings.wallet.customToken': 'Custom token',
+  'settings.provider.label': 'Provider',
+  'settings.provider.custom': 'Custom',
+  'settings.provider.custom.description': 'Enter your own endpoint URLs',
+  'settings.provider.badge.recommended': 'Recommended',
+  'settings.provider.badge.backup': 'Backup',
+  'settings.provider.badge.manual': 'Manual',
+  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
 }
 
 export default settings

--- a/src/renderer/i18n/es/settings.ts
+++ b/src/renderer/i18n/es/settings.ts
@@ -63,6 +63,7 @@ const settings: SettingMessages = {
   'settings.expert.mayachain.title': 'URLs de Mayachain',
   'settings.expert.midgardMaya.title': 'Midgard Mayachain',
   'settings.expert.mayanodeApi.title': 'API de MayaNode',
+  'settings.expert.mayanodeRpc.title': 'RPC de MayaNode',
   'settings.expert.evm.title': 'URLs RPC de cadenas EVM',
   'settings.expert.evm.eth.title': 'RPC de Ethereum',
   'settings.expert.evm.bsc.title': 'RPC de BSC',
@@ -77,13 +78,14 @@ const settings: SettingMessages = {
   'settings.ledgerMode.lockWalletWarning': 'Bloquea la cartera primero para entrar en el modo Ledger',
   'settings.wallet.whitelist': 'Lista blanca',
   'settings.wallet.customToken': 'Token personalizado',
-  'settings.provider.label': 'Provider',
-  'settings.provider.custom': 'Custom',
-  'settings.provider.custom.description': 'Enter your own endpoint URLs',
-  'settings.provider.badge.recommended': 'Recommended',
-  'settings.provider.badge.backup': 'Backup',
+  'settings.provider.label': 'Proveedor',
+  'settings.provider.custom': 'Personalizado',
+  'settings.provider.custom.description': 'Introduce tus propias URLs de endpoint',
+  'settings.provider.badge.recommended': 'Recomendado',
+  'settings.provider.badge.backup': 'Respaldo',
   'settings.provider.badge.manual': 'Manual',
-  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
+  'settings.provider.hint':
+    'Las URLs son gestionadas por el proveedor seleccionado. Cambia a Personalizado para editarlas individualmente.'
 }
 
 export default settings

--- a/src/renderer/i18n/es/settings.ts
+++ b/src/renderer/i18n/es/settings.ts
@@ -76,7 +76,14 @@ const settings: SettingMessages = {
   'settings.evm.rpc.unhealthy': 'El endpoint RPC no responde. Verifica tu conexión o prueba con otra URL.',
   'settings.ledgerMode.lockWalletWarning': 'Bloquea la cartera primero para entrar en el modo Ledger',
   'settings.wallet.whitelist': 'Lista blanca',
-  'settings.wallet.customToken': 'Token personalizado'
+  'settings.wallet.customToken': 'Token personalizado',
+  'settings.provider.label': 'Provider',
+  'settings.provider.custom': 'Custom',
+  'settings.provider.custom.description': 'Enter your own endpoint URLs',
+  'settings.provider.badge.recommended': 'Recommended',
+  'settings.provider.badge.backup': 'Backup',
+  'settings.provider.badge.manual': 'Manual',
+  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
 }
 
 export default settings

--- a/src/renderer/i18n/fr/settings.ts
+++ b/src/renderer/i18n/fr/settings.ts
@@ -62,6 +62,7 @@ const settings: SettingMessages = {
   'settings.expert.mayachain.title': 'URLs Mayachain',
   'settings.expert.midgardMaya.title': 'Midgard Mayachain',
   'settings.expert.mayanodeApi.title': 'API MayaNode',
+  'settings.expert.mayanodeRpc.title': 'RPC MayaNode',
   'settings.expert.evm.title': 'URLs RPC des chaînes EVM',
   'settings.expert.evm.eth.title': 'RPC Ethereum',
   'settings.expert.evm.bsc.title': 'RPC BSC',
@@ -77,13 +78,14 @@ const settings: SettingMessages = {
   'settings.ledgerMode.lockWalletWarning': "Verrouillez d'abord le portefeuille pour entrer en mode Ledger",
   'settings.wallet.whitelist': 'Liste blanche',
   'settings.wallet.customToken': 'Token personnalisé',
-  'settings.provider.label': 'Provider',
-  'settings.provider.custom': 'Custom',
-  'settings.provider.custom.description': 'Enter your own endpoint URLs',
-  'settings.provider.badge.recommended': 'Recommended',
-  'settings.provider.badge.backup': 'Backup',
-  'settings.provider.badge.manual': 'Manual',
-  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
+  'settings.provider.label': 'Fournisseur',
+  'settings.provider.custom': 'Personnalisé',
+  'settings.provider.custom.description': 'Saisissez vos propres URLs de point de terminaison',
+  'settings.provider.badge.recommended': 'Recommandé',
+  'settings.provider.badge.backup': 'Secours',
+  'settings.provider.badge.manual': 'Manuel',
+  'settings.provider.hint':
+    'Les URLs sont gérées par le fournisseur sélectionné. Passez à Personnalisé pour les modifier individuellement.'
 }
 
 export default settings

--- a/src/renderer/i18n/fr/settings.ts
+++ b/src/renderer/i18n/fr/settings.ts
@@ -76,7 +76,14 @@ const settings: SettingMessages = {
     "Le point d'accès RPC ne répond pas. Vérifiez votre connexion ou essayez une autre URL.",
   'settings.ledgerMode.lockWalletWarning': "Verrouillez d'abord le portefeuille pour entrer en mode Ledger",
   'settings.wallet.whitelist': 'Liste blanche',
-  'settings.wallet.customToken': 'Token personnalisé'
+  'settings.wallet.customToken': 'Token personnalisé',
+  'settings.provider.label': 'Provider',
+  'settings.provider.custom': 'Custom',
+  'settings.provider.custom.description': 'Enter your own endpoint URLs',
+  'settings.provider.badge.recommended': 'Recommended',
+  'settings.provider.badge.backup': 'Backup',
+  'settings.provider.badge.manual': 'Manual',
+  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
 }
 
 export default settings

--- a/src/renderer/i18n/hi/settings.ts
+++ b/src/renderer/i18n/hi/settings.ts
@@ -75,7 +75,14 @@ const settings: SettingMessages = {
   'settings.evm.rpc.unhealthy': 'RPC एंडपॉइंट प्रतिक्रिया नहीं दे रहा है। अपना कनेक्शन जांचें या कोई अलग URL आज़माएं।',
   'settings.ledgerMode.lockWalletWarning': 'Ledger मोड में प्रवेश करने के लिए पहले वॉलेट लॉक करें',
   'settings.wallet.whitelist': 'व्हाइटलिस्ट',
-  'settings.wallet.customToken': 'कस्टम टोकन'
+  'settings.wallet.customToken': 'कस्टम टोकन',
+  'settings.provider.label': 'Provider',
+  'settings.provider.custom': 'Custom',
+  'settings.provider.custom.description': 'Enter your own endpoint URLs',
+  'settings.provider.badge.recommended': 'Recommended',
+  'settings.provider.badge.backup': 'Backup',
+  'settings.provider.badge.manual': 'Manual',
+  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
 }
 
 export default settings

--- a/src/renderer/i18n/hi/settings.ts
+++ b/src/renderer/i18n/hi/settings.ts
@@ -62,6 +62,7 @@ const settings: SettingMessages = {
   'settings.expert.mayachain.title': 'Mayachain URL',
   'settings.expert.midgardMaya.title': 'Midgard Mayachain',
   'settings.expert.mayanodeApi.title': 'MayaNode API',
+  'settings.expert.mayanodeRpc.title': 'MayaNode RPC',
   'settings.expert.evm.title': 'EVM चेन RPC URLs',
   'settings.expert.evm.eth.title': 'Ethereum RPC',
   'settings.expert.evm.bsc.title': 'BSC RPC',
@@ -76,13 +77,14 @@ const settings: SettingMessages = {
   'settings.ledgerMode.lockWalletWarning': 'Ledger मोड में प्रवेश करने के लिए पहले वॉलेट लॉक करें',
   'settings.wallet.whitelist': 'व्हाइटलिस्ट',
   'settings.wallet.customToken': 'कस्टम टोकन',
-  'settings.provider.label': 'Provider',
-  'settings.provider.custom': 'Custom',
-  'settings.provider.custom.description': 'Enter your own endpoint URLs',
-  'settings.provider.badge.recommended': 'Recommended',
-  'settings.provider.badge.backup': 'Backup',
-  'settings.provider.badge.manual': 'Manual',
-  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
+  'settings.provider.label': 'प्रदाता',
+  'settings.provider.custom': 'कस्टम',
+  'settings.provider.custom.description': 'अपनी स्वयं की एंडपॉइंट URL दर्ज करें',
+  'settings.provider.badge.recommended': 'अनुशंसित',
+  'settings.provider.badge.backup': 'बैकअप',
+  'settings.provider.badge.manual': 'मैनुअल',
+  'settings.provider.hint':
+    'URL का प्रबंधन चयनित प्रदाता द्वारा किया जाता है। व्यक्तिगत रूप से संपादित करने के लिए कस्टम पर स्विच करें।'
 }
 
 export default settings

--- a/src/renderer/i18n/ko/settings.ts
+++ b/src/renderer/i18n/ko/settings.ts
@@ -63,6 +63,7 @@ const settings: SettingMessages = {
   'settings.expert.mayachain.title': 'Mayachain URL',
   'settings.expert.midgardMaya.title': 'Midgard Mayachain',
   'settings.expert.mayanodeApi.title': 'MayaNode API',
+  'settings.expert.mayanodeRpc.title': 'MayaNode RPC',
   'settings.expert.evm.title': 'EVM 체인 RPC URL',
   'settings.expert.evm.eth.title': 'Ethereum RPC',
   'settings.expert.evm.bsc.title': 'BSC RPC',
@@ -77,13 +78,13 @@ const settings: SettingMessages = {
   'settings.ledgerMode.lockWalletWarning': 'Ledger 모드로 진입하려면 먼저 지갑을 잠금하세요',
   'settings.wallet.whitelist': '화이트리스트',
   'settings.wallet.customToken': '사용자 정의 토큰',
-  'settings.provider.label': 'Provider',
-  'settings.provider.custom': 'Custom',
-  'settings.provider.custom.description': 'Enter your own endpoint URLs',
-  'settings.provider.badge.recommended': 'Recommended',
-  'settings.provider.badge.backup': 'Backup',
-  'settings.provider.badge.manual': 'Manual',
-  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
+  'settings.provider.label': '제공자',
+  'settings.provider.custom': '사용자 정의',
+  'settings.provider.custom.description': '직접 엔드포인트 URL을 입력하세요',
+  'settings.provider.badge.recommended': '권장',
+  'settings.provider.badge.backup': '백업',
+  'settings.provider.badge.manual': '수동',
+  'settings.provider.hint': 'URL은 선택한 제공자가 관리합니다. 개별적으로 편집하려면 사용자 정의로 전환하세요.'
 }
 
 export default settings

--- a/src/renderer/i18n/ko/settings.ts
+++ b/src/renderer/i18n/ko/settings.ts
@@ -76,7 +76,14 @@ const settings: SettingMessages = {
   'settings.evm.rpc.unhealthy': 'RPC 엔드포인트가 응답하지 않습니다. 연결을 확인하거나 다른 URL을 시도하세요.',
   'settings.ledgerMode.lockWalletWarning': 'Ledger 모드로 진입하려면 먼저 지갑을 잠금하세요',
   'settings.wallet.whitelist': '화이트리스트',
-  'settings.wallet.customToken': '사용자 정의 토큰'
+  'settings.wallet.customToken': '사용자 정의 토큰',
+  'settings.provider.label': 'Provider',
+  'settings.provider.custom': 'Custom',
+  'settings.provider.custom.description': 'Enter your own endpoint URLs',
+  'settings.provider.badge.recommended': 'Recommended',
+  'settings.provider.badge.backup': 'Backup',
+  'settings.provider.badge.manual': 'Manual',
+  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
 }
 
 export default settings

--- a/src/renderer/i18n/ru/settings.ts
+++ b/src/renderer/i18n/ru/settings.ts
@@ -75,7 +75,14 @@ const settings: SettingMessages = {
   'settings.evm.rpc.unhealthy': 'Конечная точка RPC не отвечает. Проверьте подключение или попробуйте другой URL.',
   'settings.ledgerMode.lockWalletWarning': 'Сначала заблокируйте кошелек, чтобы войти в режим Ledger',
   'settings.wallet.whitelist': 'Белый список',
-  'settings.wallet.customToken': 'Пользовательский токен'
+  'settings.wallet.customToken': 'Пользовательский токен',
+  'settings.provider.label': 'Provider',
+  'settings.provider.custom': 'Custom',
+  'settings.provider.custom.description': 'Enter your own endpoint URLs',
+  'settings.provider.badge.recommended': 'Recommended',
+  'settings.provider.badge.backup': 'Backup',
+  'settings.provider.badge.manual': 'Manual',
+  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
 }
 
 export default settings

--- a/src/renderer/i18n/ru/settings.ts
+++ b/src/renderer/i18n/ru/settings.ts
@@ -62,6 +62,7 @@ const settings: SettingMessages = {
   'settings.expert.mayachain.title': 'URL-адреса Mayachain',
   'settings.expert.midgardMaya.title': 'Midgard Mayachain',
   'settings.expert.mayanodeApi.title': 'API MayaNode',
+  'settings.expert.mayanodeRpc.title': 'RPC MayaNode',
   'settings.expert.evm.title': 'URL RPC цепей EVM',
   'settings.expert.evm.eth.title': 'RPC Ethereum',
   'settings.expert.evm.bsc.title': 'RPC BSC',
@@ -76,13 +77,14 @@ const settings: SettingMessages = {
   'settings.ledgerMode.lockWalletWarning': 'Сначала заблокируйте кошелек, чтобы войти в режим Ledger',
   'settings.wallet.whitelist': 'Белый список',
   'settings.wallet.customToken': 'Пользовательский токен',
-  'settings.provider.label': 'Provider',
-  'settings.provider.custom': 'Custom',
-  'settings.provider.custom.description': 'Enter your own endpoint URLs',
-  'settings.provider.badge.recommended': 'Recommended',
-  'settings.provider.badge.backup': 'Backup',
-  'settings.provider.badge.manual': 'Manual',
-  'settings.provider.hint': 'URLs are managed by the selected provider. Switch to Custom to edit individually.'
+  'settings.provider.label': 'Провайдер',
+  'settings.provider.custom': 'Пользовательский',
+  'settings.provider.custom.description': 'Введите собственные URL конечных точек',
+  'settings.provider.badge.recommended': 'Рекомендуется',
+  'settings.provider.badge.backup': 'Резервный',
+  'settings.provider.badge.manual': 'Вручную',
+  'settings.provider.hint':
+    'URL-адреса управляются выбранным провайдером. Переключитесь на «Пользовательский», чтобы редактировать их индивидуально.'
 }
 
 export default settings

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -703,6 +703,13 @@ type SettingMessageKey =
   | 'settings.ledgerMode.lockWalletWarning'
   | 'settings.wallet.whitelist'
   | 'settings.wallet.customToken'
+  | 'settings.provider.label'
+  | 'settings.provider.custom'
+  | 'settings.provider.custom.description'
+  | 'settings.provider.badge.recommended'
+  | 'settings.provider.badge.backup'
+  | 'settings.provider.badge.manual'
+  | 'settings.provider.hint'
 
 export type SettingMessages = { [key in SettingMessageKey]: string }
 

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -689,6 +689,7 @@ type SettingMessageKey =
   | 'settings.expert.mayachain.title'
   | 'settings.expert.midgardMaya.title'
   | 'settings.expert.mayanodeApi.title'
+  | 'settings.expert.mayanodeRpc.title'
   | 'settings.expert.evm.title'
   | 'settings.expert.evm.eth.title'
   | 'settings.expert.evm.bsc.title'

--- a/src/renderer/services/storage/common.ts
+++ b/src/renderer/services/storage/common.ts
@@ -3,7 +3,7 @@ import { pipe } from 'fp-ts/function'
 import * as O from 'fp-ts/Option'
 import * as RxOp from 'rxjs/operators'
 
-import { CommonStorage, LastOpenedWallet } from '../../../shared/api/types'
+import { ApiUrls, CommonStorage, LastOpenedWallet } from '../../../shared/api/types'
 import { DEFAULT_ARB_RPC_URLS } from '../../../shared/arb/const'
 import { DEFAULT_AVAX_RPC_URLS } from '../../../shared/avax/const'
 import { DEFAULT_BASE_RPC_URLS } from '../../../shared/base/const'
@@ -15,6 +15,8 @@ import { DEFAULT_LOCALE } from '../../../shared/i18n/const'
 import { DEFAULT_MAYANODE_API_URLS, DEFAULT_MAYANODE_RPC_URLS } from '../../../shared/mayachain/const'
 import { DEFAULT_MIDGARD_MAYA_URLS } from '../../../shared/mayaMidgard/const'
 import { DEFAULT_MIDGARD_URLS } from '../../../shared/midgard/const'
+import { PROVIDER_REGISTRY } from '../../../shared/providers'
+import { ProviderId, ProviderSectionKey } from '../../../shared/providers/types'
 import { DEFAULT_THORNODE_API_URLS, DEFAULT_THORNODE_RPC_URLS } from '../../../shared/thorchain/const'
 import { observableState } from '../../helpers/stateHelper'
 import { StorageState, StoragePartialState } from './types'
@@ -143,6 +145,26 @@ const modifyStorage = (oPartialData: StoragePartialState<CommonStorage>) => {
   )
 }
 
+/**
+ * Applies a provider's URLs to storage. Looks up the provider in the registry
+ * and writes its URLs to the existing storage fields (midgard, thornodeApi, etc.).
+ * If 'custom' is selected, does nothing — URLs are edited individually.
+ */
+const applyProvider = (section: ProviderSectionKey, providerId: ProviderId) => {
+  if (providerId === 'custom') return
+
+  const config = PROVIDER_REGISTRY[section]
+  const provider = config.providers.find((p) => p.id === providerId)
+  if (!provider) return
+
+  const urlUpdates: Record<string, ApiUrls> = {}
+  for (const slot of config.slots) {
+    urlUpdates[slot as string] = (provider.urls as Record<string, ApiUrls>)[slot as string]
+  }
+
+  modifyStorage(O.some(urlUpdates))
+}
+
 // Initial state load
 window.apiCommonStorage.get().then(
   (result) => setStorageState(O.some(result)),
@@ -167,5 +189,6 @@ export {
   avaxRpc$,
   baseRpc$,
   lastOpenedWallet$,
-  evmGasMultiplier$
+  evmGasMultiplier$,
+  applyProvider
 }

--- a/src/renderer/views/app/AppExpertModeView.tsx
+++ b/src/renderer/views/app/AppExpertModeView.tsx
@@ -84,16 +84,20 @@ export const AppExpertModeView = (): JSX.Element => {
   // EVM Gas multiplier
   const { multiplier: gasMultiplier, setMultiplier: setGasMultiplier } = useEvmGasMultiplier()
 
-  // Derive active provider by matching current URLs against the registry
-  const detectProvider = useCallback((section: ProviderSectionKey, currentUrls: Record<string, string>): ProviderId => {
-    const config = PROVIDER_REGISTRY[section]
-    for (const provider of config.providers) {
-      const urls = provider.urls as Record<string, Record<string, string>>
-      const allMatch = config.slots.every((slot) => urls[slot as string]?.mainnet === currentUrls[slot as string])
-      if (allMatch) return provider.id
-    }
-    return 'custom'
-  }, [])
+  // Derive active provider by matching current URLs against the registry for the active network.
+  // Compare per-network (not hardcoded to mainnet) so detection works on stagenet/testnet too.
+  const detectProvider = useCallback(
+    (section: ProviderSectionKey, currentUrls: Record<string, string>): ProviderId => {
+      const config = PROVIDER_REGISTRY[section]
+      for (const provider of config.providers) {
+        const urls = provider.urls as Record<string, Record<string, string>>
+        const allMatch = config.slots.every((slot) => urls[slot as string]?.[network] === currentUrls[slot as string])
+        if (allMatch) return provider.id
+      }
+      return 'custom'
+    },
+    [network]
+  )
 
   const thorchainProvider = detectProvider('thorchain', {
     midgard: FP.pipe(midgardUrl, RD.toNullable) ?? '',

--- a/src/renderer/views/app/AppExpertModeView.tsx
+++ b/src/renderer/views/app/AppExpertModeView.tsx
@@ -1,8 +1,11 @@
 import { useCallback } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
+import { function as FP } from 'fp-ts'
 import { useObservableState } from 'observable-hooks'
 
+import { PROVIDER_REGISTRY } from '../../../shared/providers'
+import { ProviderId, ProviderSectionKey } from '../../../shared/providers/types'
 import { AppExpertMode } from '../../components/settings/AppExpertMode'
 import { useMidgardContext } from '../../contexts/MidgardContext'
 import { useMidgardMayaContext } from '../../contexts/MidgardMayaContext'
@@ -11,6 +14,7 @@ import { useEvmRpcUrl } from '../../hooks/useEvmRpcUrl'
 import { useMayachainClientUrl } from '../../hooks/useMayachainClientUrl'
 import { useNetwork } from '../../hooks/useNetwork'
 import { useThorchainClientUrl } from '../../hooks/useThorchainClientUrl'
+import { applyProvider } from '../../services/storage/common'
 
 export const AppExpertModeView = (): JSX.Element => {
   const { network } = useNetwork()
@@ -80,6 +84,33 @@ export const AppExpertModeView = (): JSX.Element => {
   // EVM Gas multiplier
   const { multiplier: gasMultiplier, setMultiplier: setGasMultiplier } = useEvmGasMultiplier()
 
+  // Derive active provider by matching current URLs against the registry
+  const detectProvider = useCallback((section: ProviderSectionKey, currentUrls: Record<string, string>): ProviderId => {
+    const config = PROVIDER_REGISTRY[section]
+    for (const provider of config.providers) {
+      const urls = provider.urls as Record<string, Record<string, string>>
+      const allMatch = config.slots.every((slot) => urls[slot as string]?.mainnet === currentUrls[slot as string])
+      if (allMatch) return provider.id
+    }
+    return 'custom'
+  }, [])
+
+  const thorchainProvider = detectProvider('thorchain', {
+    midgard: FP.pipe(midgardUrl, RD.toNullable) ?? '',
+    thornodeApi: thornodeNodeUrl,
+    thornodeRpc: thornodeRpcUrl
+  })
+
+  const mayachainProvider = detectProvider('mayachain', {
+    midgardMaya: FP.pipe(midgardMayaUrl, RD.toNullable) ?? '',
+    mayanodeApi: mayanodeNodeUrl,
+    mayanodeRpc: mayanodeRpcUrl
+  })
+
+  const handleChangeProvider = useCallback((section: ProviderSectionKey, providerId: ProviderId) => {
+    applyProvider(section, providerId)
+  }, [])
+
   const updateMidgardUrlHandler = useCallback(
     (url: string) => {
       setMidgardUrl(url, network)
@@ -132,6 +163,10 @@ export const AppExpertModeView = (): JSX.Element => {
       // EVM Gas multiplier
       gasMultiplier={gasMultiplier}
       onChangeGasMultiplier={setGasMultiplier}
+      // Provider selections (derived from current URLs)
+      thorchainProvider={thorchainProvider}
+      mayachainProvider={mayachainProvider}
+      onChangeProvider={handleChangeProvider}
     />
   )
 }

--- a/src/shared/providers/config.ts
+++ b/src/shared/providers/config.ts
@@ -1,0 +1,94 @@
+import { DEFAULT_MAYANODE_API_URLS, DEFAULT_MAYANODE_RPC_URLS } from '../mayachain/const'
+import { DEFAULT_MIDGARD_MAYA_URLS } from '../mayaMidgard/const'
+import { DEFAULT_MIDGARD_URLS } from '../midgard/const'
+import { DEFAULT_THORNODE_API_URLS, DEFAULT_THORNODE_RPC_URLS } from '../thorchain/const'
+import { ChainProviderConfig, ProviderRegistry } from './types'
+
+// ── THORChain ──────────────────────────────────────────────
+
+type ThorSlots = 'midgard' | 'thornodeApi' | 'thornodeRpc'
+
+const thorchainConfig: ChainProviderConfig<ThorSlots> = {
+  label: 'THORChain',
+  slots: ['midgard', 'thornodeApi', 'thornodeRpc'],
+  slotLabels: {
+    midgard: 'Midgard',
+    thornodeApi: 'THORNode API',
+    thornodeRpc: 'THORNode RPC'
+  },
+  defaultProviderId: 'liquify',
+  providers: [
+    {
+      id: 'liquify',
+      name: 'Liquify',
+      description: 'Primary public gateway',
+      badge: 'recommended',
+      domain: 'gateway.liquify.com',
+      urls: {
+        midgard: DEFAULT_MIDGARD_URLS,
+        thornodeApi: DEFAULT_THORNODE_API_URLS,
+        thornodeRpc: DEFAULT_THORNODE_RPC_URLS
+      }
+    },
+    {
+      id: 'chainnet',
+      name: 'Chainnet',
+      description: 'Community backup infrastructure',
+      badge: 'backup',
+      domain: 'thorchain.network',
+      urls: {
+        midgard: {
+          mainnet: 'https://midgard.thorchain.network',
+          stagenet: '',
+          testnet: ''
+        },
+        thornodeApi: {
+          mainnet: 'https://thornode.thorchain.network',
+          stagenet: '',
+          testnet: ''
+        },
+        thornodeRpc: {
+          mainnet: 'https://rpc.thorchain.network',
+          stagenet: '',
+          testnet: ''
+        }
+      }
+    }
+  ]
+}
+
+// ── MayaChain ──────────────────────────────────────────────
+
+type MayaSlots = 'midgardMaya' | 'mayanodeApi' | 'mayanodeRpc'
+
+const mayachainConfig: ChainProviderConfig<MayaSlots> = {
+  label: 'MAYAChain',
+  slots: ['midgardMaya', 'mayanodeApi', 'mayanodeRpc'],
+  slotLabels: {
+    midgardMaya: 'Midgard Maya',
+    mayanodeApi: 'MAYANode API',
+    mayanodeRpc: 'MAYANode RPC'
+  },
+  defaultProviderId: 'mayachain',
+  providers: [
+    {
+      id: 'mayachain',
+      name: 'MAYAChain',
+      description: 'Official MAYAChain infrastructure',
+      badge: 'recommended',
+      domain: 'mayachain.info',
+      urls: {
+        midgardMaya: DEFAULT_MIDGARD_MAYA_URLS,
+        mayanodeApi: DEFAULT_MAYANODE_API_URLS,
+        mayanodeRpc: DEFAULT_MAYANODE_RPC_URLS
+      }
+    }
+  ]
+}
+
+// ── Registry ───────────────────────────────────────────────
+
+export const PROVIDER_REGISTRY: ProviderRegistry = {
+  thorchain: thorchainConfig,
+  mayachain: mayachainConfig
+}

--- a/src/shared/providers/index.ts
+++ b/src/shared/providers/index.ts
@@ -1,0 +1,2 @@
+export * from './types'
+export { PROVIDER_REGISTRY } from './config'

--- a/src/shared/providers/types.ts
+++ b/src/shared/providers/types.ts
@@ -1,0 +1,52 @@
+import { ApiUrls } from '../api/types'
+
+/** Identifier for a provider. 'custom' means user-edited URLs. */
+export type ProviderId = string
+
+/** Badge type shown in the UI next to a provider name */
+export type ProviderBadge = 'recommended' | 'backup'
+
+/**
+ * URL slot keys — maps to the CommonStorage URL field names.
+ * THORChain needs 3 (midgard, thornodeApi, thornodeRpc).
+ * MayaChain needs 3 (midgardMaya, mayanodeApi, mayanodeRpc).
+ * EVM chains need 1 each.
+ */
+export type UrlSlotKey =
+  | 'midgard'
+  | 'thornodeApi'
+  | 'thornodeRpc'
+  | 'midgardMaya'
+  | 'mayanodeApi'
+  | 'mayanodeRpc'
+  | 'ethRpc'
+  | 'bscRpc'
+  | 'arbRpc'
+  | 'avaxRpc'
+  | 'baseRpc'
+
+/** A single provider entry — defines the URLs it supplies for a chain section */
+export type ProviderEntry<Slots extends UrlSlotKey = UrlSlotKey> = {
+  readonly id: ProviderId
+  readonly name: string
+  readonly description: string
+  readonly badge?: ProviderBadge
+  readonly domain: string
+  readonly urls: Readonly<Record<Slots, ApiUrls>>
+}
+
+/** Config for one chain section in Expert Mode */
+export type ChainProviderConfig<Slots extends UrlSlotKey = UrlSlotKey> = {
+  readonly label: string
+  readonly slots: readonly Slots[]
+  readonly slotLabels: Readonly<Record<Slots, string>>
+  readonly providers: readonly ProviderEntry<Slots>[]
+  readonly defaultProviderId: ProviderId
+}
+
+/** Section keys — one per group in Expert Mode */
+export type ProviderSectionKey = 'thorchain' | 'mayachain'
+
+/** The full static registry — each section can have different slot types */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ProviderRegistry = Readonly<Record<ProviderSectionKey, ChainProviderConfig<any>>>


### PR DESCRIPTION
## Summary



### Provider Selector (Expert Mode)
- New **Provider Selector** dropdown in THORChain and MayaChain settings sections
- Users can pick from **Liquify** (recommended), **Chainnet** (backup), or **Custom** (manual entry)
- Selecting a provider writes its pre-configured URLs to the existing storage fields — no new storage schema
- Active provider is **derived from current URLs** by matching against the registry — no new persisted state
- When a preset provider is selected, URLs display as read-only text (no edit/test buttons)
- When Custom is selected, URLs are fully editable (existing behavior)
- ADVANCED toggle removed from THORChain/MayaChain sections (provider selector replaces it)

### Provider Config
- New `src/shared/providers/` directory with static provider registry
- Liquify entries reference existing `DEFAULT_*_URLS` constants (no URL duplication)
- Chainnet URLs are the only new data
- Adding a new provider = adding an entry to the config array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added endpoint provider selection for Thorchain and Mayachain in Expert Mode settings.
  * Users can now choose from preset providers (with auto-managed URLs) or select "Custom" to configure URLs individually.
  * Provider selection includes badges (recommended, backup) and domain information.

* **Internationalization**
  * Added provider configuration UI translations for English, German, Spanish, French, Hindi, Korean, and Russian.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asgardex/asgardex-desktop/pull/1033)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->