### PR TITLE
[Draft] fix: uppercase asset string for MAYA Midgard pool endpoints

### DIFF
--- a/src/renderer/services/midgard/mayaMidgard/pools.ts
+++ b/src/renderer/services/midgard/mayaMidgard/pools.ts
@@ -1,6 +1,13 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { DefaultApi } from '@xchainjs/xchain-mayamidgard'
-import { AnyAsset, assetFromString, assetToString, bn, Chain, currencySymbolByAsset } from '@xchainjs/xchain-util'
+import {
+  AnyAsset,
+  assetFromString,
+  assetToString as xchainAssetToString,
+  bn,
+  Chain,
+  currencySymbolByAsset
+} from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 import { array as A, function as FP, nonEmptyArray as NEA, predicate as P, option as O } from 'fp-ts'
 import * as Rx from 'rxjs'
@@ -76,6 +83,11 @@ import {
   toPoolsData,
   poolsPeriodToPoolPeriod
 } from './utils'
+
+// Midgard stores asset identifiers fully uppercase and rejects EIP-55 checksum
+// casing with HTTP 400. ETH token assets are EIP-55 internally (via ethers.getAddress),
+// so we uppercase at the Midgard boundary by shadowing assetToString in this file.
+const assetToString = (asset: AnyAsset): string => xchainAssetToString(asset).toUpperCase()
 
 const PRICE_POOL_KEY = 'asgdx-price-pool'
 


### PR DESCRIPTION
MAYA Midgard is case-sensitive on asset identifiers and rejects checksum casing with HTTP 400 (e.g. ETH.USDC-0xA0b86991...). Shadow assetToString in mayaMidgard/pools.ts to uppercase at the Midgard boundary; ETH token assets stay EIP-55 elsewhere in the renderer.

Add to Maya pools needs more testing - WIP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated asset identifier formatting to consistently display in uppercase across Midgard services.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asgardex/asgardex-desktop/pull/1044)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->