### PR TITLE
feat(btc): keystore Taproot (P2TR) — derive, display, receive & send

### DIFF
--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
@@ -32,7 +32,7 @@ const balances: Partial<Record<EnabledChain, ChainBalances>> = {
     {
       walletType: WalletType.Keystore,
       walletAddress: O.some('doge keystore'),
-
+      hdMode: 'default',
       chain: MAYAChain,
       balances: RD.success([
         {
@@ -61,6 +61,7 @@ const balances: Partial<Record<EnabledChain, ChainBalances>> = {
     {
       walletType: WalletType.Keystore,
       walletAddress: O.some('btc keystore'),
+      hdMode: 'default',
       chain: BTCChain,
       balances: RD.success([
         {
@@ -80,6 +81,7 @@ const balances: Partial<Record<EnabledChain, ChainBalances>> = {
     {
       walletType: WalletType.Keystore,
       walletAddress: O.some('eth keystore'),
+      hdMode: 'default',
       chain: ETHChain,
       balances: RD.success([
         {
@@ -99,6 +101,7 @@ const balances: Partial<Record<EnabledChain, ChainBalances>> = {
     {
       walletType: WalletType.Keystore,
       walletAddress: O.some('thor keystore'),
+      hdMode: 'default',
       chain: THORChain,
       balances: RD.success([
         {
@@ -118,6 +121,7 @@ const balances: Partial<Record<EnabledChain, ChainBalances>> = {
     {
       walletType: WalletType.Keystore,
       walletAddress: O.some('ltc keystore'),
+      hdMode: 'default',
       chain: LTCChain,
       balances: RD.success([
         {

--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.stories.tsx
@@ -68,10 +68,30 @@ const balances: Partial<Record<EnabledChain, ChainBalances>> = {
           walletType: WalletType.Keystore,
           amount: baseAmount('1000000'),
           asset: AssetBTC,
-          walletAddress: 'DOGE wallet address',
+          walletAddress: 'BTC wallet address',
           walletAccount: 0,
           walletIndex: 0,
           hdMode: 'default'
+        }
+      ]),
+      balancesType: 'all'
+    },
+    // Taproot (P2TR) sibling — exercises the TAPROOT chip in the chain-row
+    // header (rendered when `hdMode === 'p2tr'`).
+    {
+      walletType: WalletType.Keystore,
+      walletAddress: O.some('btc taproot keystore'),
+      hdMode: 'p2tr',
+      chain: BTCChain,
+      balances: RD.success([
+        {
+          walletType: WalletType.Keystore,
+          amount: baseAmount('500000'),
+          asset: AssetBTC,
+          walletAddress: 'BTC taproot wallet address',
+          walletAccount: 0,
+          walletIndex: 0,
+          hdMode: 'p2tr'
         }
       ]),
       balancesType: 'all'

--- a/src/renderer/components/wallet/assets/AssetsTableCollapsable.tsx
+++ b/src/renderer/components/wallet/assets/AssetsTableCollapsable.tsx
@@ -593,7 +593,10 @@ export const AssetsTableCollapsable = memo(function AssetsTableCollapsable(props
   )
 
   const renderHeader = useCallback(
-    ({ chain, walletType, walletAddress: oWalletAddress, balances: balancesRD }: ChainBalance, isOpen: boolean) => {
+    (
+      { chain, walletType, walletAddress: oWalletAddress, balances: balancesRD, hdMode }: ChainBalance,
+      isOpen: boolean
+    ) => {
       const walletAddress = FP.pipe(
         oWalletAddress,
         O.getOrElse(() => intl.formatMessage({ id: 'wallet.errors.address.invalid' }))
@@ -623,6 +626,11 @@ export const AssetsTableCollapsable = memo(function AssetsTableCollapsable(props
             {!isKeystoreWallet(walletType) && (
               <WalletTypeLabel className="border border-solid border-gray0 bg-bg2 dark:border-gray0d dark:bg-bg2d">
                 {walletTypeToI18n(walletType, intl)}
+              </WalletTypeLabel>
+            )}
+            {hdMode === 'p2tr' && (
+              <WalletTypeLabel className="border border-solid border-gray0 bg-bg2 dark:border-gray0d dark:bg-bg2d">
+                {intl.formatMessage({ id: 'common.taproot' })}
               </WalletTypeLabel>
             )}
             <Label

--- a/src/renderer/services/bitcoin/balances.ts
+++ b/src/renderer/services/bitcoin/balances.ts
@@ -3,7 +3,7 @@ import { observableState } from '../../helpers/stateHelper'
 import * as C from '../clients'
 import { createEnhancedClient$ } from '../clients'
 import { isKeystoreReloadTrigger } from '../wallet/types'
-import { client$, readOnlyClient$ } from './common'
+import { client$, clientTR$, readOnlyClient$ } from './common'
 
 /**
  * `ObservableState` to reload `Balances`
@@ -17,6 +17,14 @@ const { get$: reloadLedgerBalances$, set: setReloadLedgerBalances } = observable
  * Enhanced client that falls back to read-only client for standalone ledger mode
  */
 const enhancedClient$ = createEnhancedClient$(client$, readOnlyClient$)
+
+/**
+ * Enhanced Taproot client. Falls back to the same read-only (P2WPKH) client when
+ * no keystore phrase is available so generic providers/explorer URLs still resolve,
+ * but the `client$` returned from `addressUITR$` ensures Taproot rows only appear
+ * in keystore mode.
+ */
+const enhancedClientTR$ = createEnhancedClient$(clientTR$, readOnlyClient$)
 
 const resetReloadBalances = (walletType: WalletType) => {
   if (isKeystoreReloadTrigger(walletType)) {
@@ -50,8 +58,13 @@ const balances$ = ({
   // Select trigger based on wallet type
   const trigger$ = isKeystoreReloadTrigger(walletType) ? reloadBalances$ : reloadLedgerBalances$
 
+  // Route keystore Taproot balances through the P2TR client so `getAddressAsync`
+  // yields the `bc1p…` address. SegWit and all Ledger/Vultisig balances continue
+  // through the original client.
+  const targetClient$ = hdMode === 'p2tr' ? enhancedClientTR$ : enhancedClient$
+
   return C.balances$({
-    client$: enhancedClient$,
+    client$: targetClient$,
     trigger$,
     walletType,
     walletAccount,

--- a/src/renderer/services/bitcoin/common.ts
+++ b/src/renderer/services/bitcoin/common.ts
@@ -21,6 +21,7 @@ import { isError } from '../../../shared/utils/guard'
 import { logger } from '../../helpers/logger'
 import { clientNetwork$ } from '../app/service'
 import * as C from '../clients'
+import { keystoreAddress$, keystoreAddressUI$ } from '../clients/address'
 import { keystoreService } from '../wallet/keystore'
 import { getPhrase } from '../wallet/util'
 import { ClientState, ClientState$ } from './types'
@@ -54,52 +55,67 @@ const BlockcypherDataProviders: UtxoOnlineDataProviders = {
   [Network.Mainnet]: mainnetBlockcypherProvider
 }
 
+const dataProviders = [BlockcypherDataProviders, HaskoinDataProviders, BitgoProviders]
+
+const feeBounds = { lower: LOWER_FEE_BOUND, upper: UPPER_FEE_BOUND }
+
 /**
- * Stream to create an observable BitcoinClient depending on existing phrase in keystore
- *
- * Whenever a phrase has been added to keystore, a new `BitcoinClient` will be created.
- * By the other hand: Whenever a phrase has been removed, `ClientState` is set to `initial`
- * A `BitcoinClient` will never be created as long as no phrase is available
+ * Build a keystore-derived `BitcoinClient` factory bound to a given `AddressFormat`.
+ * Used to produce a Native SegWit (P2WPKH) client and, in parallel, a Taproot (P2TR)
+ * client off the same mnemonic so the keystore wallet can expose both addresses.
  */
-const clientState$: ClientState$ = FP.pipe(
-  Rx.combineLatest([keystoreService.keystoreState$, clientNetwork$]),
-  RxOp.switchMap(
-    ([keystore, network]): ClientState$ =>
-      Rx.of(
-        FP.pipe(
-          getPhrase(keystore),
-          O.map<string, ClientState>((phrase, addressFormat = AddressFormat.P2WPKH) => {
-            try {
-              const btcInitParams = {
-                ...defaultBTCParams,
-                phrase: phrase,
-                network: network,
-                dataProviders: [BlockcypherDataProviders, HaskoinDataProviders, BitgoProviders],
-                addressFormat,
-                rootDerivationPaths:
-                  addressFormat === AddressFormat.P2TR ? tapRootDerivationPaths : defaultBTCParams.rootDerivationPaths,
-                feeBounds: {
-                  lower: LOWER_FEE_BOUND,
-                  upper: UPPER_FEE_BOUND
+const createKeystoreClientState$ = (addressFormat: AddressFormat): ClientState$ =>
+  FP.pipe(
+    Rx.combineLatest([keystoreService.keystoreState$, clientNetwork$]),
+    RxOp.switchMap(
+      ([keystore, network]): ClientState$ =>
+        Rx.of(
+          FP.pipe(
+            getPhrase(keystore),
+            O.map<string, ClientState>((phrase) => {
+              try {
+                const btcInitParams = {
+                  ...defaultBTCParams,
+                  phrase,
+                  network,
+                  dataProviders,
+                  addressFormat,
+                  rootDerivationPaths:
+                    addressFormat === AddressFormat.P2TR
+                      ? tapRootDerivationPaths
+                      : defaultBTCParams.rootDerivationPaths,
+                  feeBounds
                 }
+                const client = new BitcoinClient(btcInitParams)
+                return RD.success(client)
+              } catch (error) {
+                logger.error(`Failed to create BTC client (addressFormat=${AddressFormat[addressFormat]})`, error)
+                return RD.failure<Error>(isError(error) ? error : new Error('Unknown error'))
               }
-              const client = new BitcoinClient(btcInitParams)
-              return RD.success(client)
-            } catch (error) {
-              logger.error('Failed to create BTC client', error)
-              return RD.failure<Error>(isError(error) ? error : new Error('Unknown error'))
-            }
-          }),
-          // Set back to `initial` if no phrase is available (locked wallet)
-          O.getOrElse<ClientState>(() => RD.initial)
-        )
-      ).pipe(RxOp.startWith(RD.pending))
-  ),
-  RxOp.startWith<ClientState>(RD.initial),
-  RxOp.shareReplay(1)
-)
+            }),
+            // Set back to `initial` if no phrase is available (locked wallet)
+            O.getOrElse<ClientState>(() => RD.initial)
+          )
+        ).pipe(RxOp.startWith(RD.pending))
+    ),
+    RxOp.startWith<ClientState>(RD.initial),
+    RxOp.shareReplay(1)
+  )
+
+/**
+ * Stream of the Native SegWit (P2WPKH) keystore client — the historical default.
+ */
+const clientState$: ClientState$ = createKeystoreClientState$(AddressFormat.P2WPKH)
+
+/**
+ * Stream of the Taproot (P2TR) keystore client, derived from the same phrase but
+ * using the BIP86 taproot derivation paths from `@xchainjs/xchain-bitcoin`.
+ */
+const clientStateTR$: ClientState$ = createKeystoreClientState$(AddressFormat.P2TR)
 
 const client$: Observable<O.Option<BitcoinClient>> = clientState$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))
+
+const clientTR$: Observable<O.Option<BitcoinClient>> = clientStateTR$.pipe(RxOp.map(RD.toOption), RxOp.shareReplay(1))
 
 /**
  * Read-only BTC client for balance queries without requiring keystore
@@ -113,13 +129,10 @@ const readOnlyClientState$: Observable<RD.RemoteData<Error, BitcoinClient>> = FP
       const btcInitParams = {
         ...defaultBTCParams,
         network: network,
-        dataProviders: [BlockcypherDataProviders, HaskoinDataProviders, BitgoProviders],
+        dataProviders,
         addressFormat: AddressFormat.P2WPKH,
         rootDerivationPaths: defaultBTCParams.rootDerivationPaths,
-        feeBounds: {
-          lower: LOWER_FEE_BOUND,
-          upper: UPPER_FEE_BOUND
-        }
+        feeBounds
       }
       const client = new BitcoinClient(btcInitParams)
       return RD.success(client)
@@ -138,18 +151,34 @@ const readOnlyClient$: Observable<O.Option<BitcoinClient>> = readOnlyClientState
 )
 
 /**
- * BTC `Address`
+ * BTC `Address` — Native SegWit (P2WPKH) keystore address (also serves Ledger/Vultisig modes
+ * via the unified `addressUI$` resolver).
  */
 const address$: C.WalletAddress$ = C.address$(client$, BTCChain)
+const addressUI$: C.WalletAddress$ = C.addressUI$(client$, BTCChain)
 
 /**
- * BTC `Address`
+ * BTC `Address` — Taproot (P2TR) keystore address. Keystore-only: this emits `O.none` in
+ * Ledger / Vultisig standalone modes (where `clientTR$` is unavailable), so no spurious
+ * Taproot row appears for those wallet modes.
  */
-const addressUI$: C.WalletAddress$ = C.addressUI$(client$, BTCChain)
+const addressTR$: C.WalletAddress$ = keystoreAddress$(clientTR$, BTCChain, 'p2tr')
+const addressUITR$: C.WalletAddress$ = keystoreAddressUI$(clientTR$, BTCChain, 'p2tr')
 
 /**
  * Explorer url depending on selected network
  */
 const explorerUrl$: C.ExplorerUrl$ = C.explorerUrl$(client$)
 
-export { client$, clientState$, readOnlyClient$, address$, addressUI$, explorerUrl$ }
+export {
+  client$,
+  clientState$,
+  clientTR$,
+  clientStateTR$,
+  readOnlyClient$,
+  address$,
+  addressUI$,
+  addressTR$,
+  addressUITR$,
+  explorerUrl$
+}

--- a/src/renderer/services/bitcoin/index.ts
+++ b/src/renderer/services/bitcoin/index.ts
@@ -4,7 +4,17 @@ import * as RxOp from 'rxjs/operators'
 
 import { network$ } from '../app/service'
 import { balances$, reloadBalances, getBalanceByAddress$, reloadBalances$, resetReloadBalances } from './balances'
-import { client$, clientState$, address$, addressUI$, explorerUrl$, readOnlyClient$ } from './common'
+import {
+  client$,
+  clientState$,
+  clientTR$,
+  address$,
+  addressUI$,
+  addressTR$,
+  addressUITR$,
+  explorerUrl$,
+  readOnlyClient$
+} from './common'
 import { createFeesService } from './fees'
 import { createTransactionService } from './transaction'
 
@@ -14,19 +24,31 @@ const combinedClient$ = Rx.combineLatest([client$, readOnlyClient$]).pipe(
   RxOp.shareReplay(1)
 )
 
+// Combined Taproot client — keystore-only, falls back to read-only client for generic
+// data-provider calls (history, fee rates). Tx signing still requires the keystore client.
+const combinedClientTR$ = Rx.combineLatest([clientTR$, readOnlyClient$]).pipe(
+  RxOp.map(([client, readOnlyClient]) => O.alt(() => readOnlyClient)(client)),
+  RxOp.shareReplay(1)
+)
+
 const { subscribeTx, txRD$, resetTx, sendTx, txs$, tx$, txStatus$ } = createTransactionService(
   combinedClient$,
+  combinedClientTR$,
   network$
 )
 const { fees$, reloadFees, feesWithRates$, reloadFeesWithRates } = createFeesService(combinedClient$)
 
 export {
   combinedClient$,
+  combinedClientTR$,
   client$,
   clientState$,
+  clientTR$,
   explorerUrl$,
   address$,
   addressUI$,
+  addressTR$,
+  addressUITR$,
   reloadBalances,
   reloadBalances$,
   resetReloadBalances,

--- a/src/renderer/services/bitcoin/transaction.ts
+++ b/src/renderer/services/bitcoin/transaction.ts
@@ -18,12 +18,21 @@ import { createVultisigUtxoTx } from '../utxo/vultisigTx'
 import { TxHashLD, ErrorId } from '../wallet/types'
 import { Client$ } from './types'
 
-export const createTransactionService = (client$: Client$, network$: Network$): TransactionService => {
+export const createTransactionService = (
+  client$: Client$,
+  clientTR$: Client$,
+  network$: Network$
+): TransactionService => {
   const common = C.createTransactionService(client$)
+  const commonTR = C.createTransactionService(clientTR$)
+
+  // Pick the keystore client matching the sender's derivation: Taproot (P2TR) or
+  // the default Native SegWit (P2WPKH) client.
+  const keystoreClientByHDMode$ = (params: SendTxParams): Client$ => (params.hdMode === 'p2tr' ? clientTR$ : client$)
 
   const sendKeystoreMaxTx = (params: SendTxParams): TxHashLD =>
     FP.pipe(
-      client$,
+      keystoreClientByHDMode$(params),
       RxOp.switchMap(FP.flow(O.fold<Client, Rx.Observable<Client>>(() => Rx.EMPTY, Rx.of))),
       RxOp.switchMap((client) =>
         Rx.from(
@@ -117,7 +126,10 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
 
         if (params.sendMax) return sendKeystoreMaxTx(params)
 
-        return common.sendTx(params)
+        // Keystore: route Taproot sends to the P2TR client; everything else
+        // continues through the Native SegWit (P2WPKH) client.
+        const keystoreCommon = params.hdMode === 'p2tr' ? commonTR : common
+        return keystoreCommon.sendTx(params)
       })
     )
 

--- a/src/renderer/services/bitcoin/transaction.ts
+++ b/src/renderer/services/bitcoin/transaction.ts
@@ -24,6 +24,19 @@ export const createTransactionService = (
   network$: Network$
 ): TransactionService => {
   const common = C.createTransactionService(client$)
+  // `commonTR` mirrors `common` but with the Taproot keystore client. Of the
+  // services it exposes, only `sendTx`/`subscribeTx` are derivation-sensitive
+  // (they sign + broadcast a tx, so they need the right private key). The rest
+  // — `txs$`, `tx$`, `txStatus$`, `txRD$`, `resetTx` — are returned from `common`
+  // via the `{ ...common, ... }` spread at the end of this function. That's
+  // correct because:
+  //   • `txs$` / `tx$` ask the data provider for transactions of a given
+  //     `walletAddress` / `txHash`; the result depends on the address/hash the
+  //     caller passes in, not on the client's `addressFormat`.
+  //   • `txStatus$` polls a tx by hash.
+  //   • `txRD$` / `resetTx` track the last-sent-tx-hash state in memory.
+  // So a single client suffices for those — both `bc1q…` and `bc1p…` queries
+  // resolve correctly when their address is passed through.
   const commonTR = C.createTransactionService(clientTR$)
 
   // Pick the keystore client matching the sender's derivation: Taproot (P2TR) or
@@ -133,8 +146,26 @@ export const createTransactionService = (
       })
     )
 
+  /**
+   * `subscribeTx` is the fire-and-forget counterpart to `sendTx`: it triggers
+   * `client.transfer(params)` and writes the resulting hash into an internal
+   * `txRD$` state observable. Today no BTC view actually calls it (`sendTx`
+   * drives the send pipeline), but it's part of the exported `TransactionService`
+   * surface, so we route it by `hdMode` for parity with `sendTx`. Without this,
+   * `subscribeTx({ hdMode: 'p2tr', … })` would silently sign with the SegWit
+   * private key.
+   *
+   * Note: the side-effect of writing to `commonTR.txRD$` lands on the TR-side
+   * state observable, which isn't exported. If a future caller wants to observe
+   * the result via `txRD$`, the two state streams will need to be merged. For
+   * now this just gets the signing right.
+   */
+  const subscribeTx = (params: SendTxParams): Rx.Subscription =>
+    params.hdMode === 'p2tr' ? commonTR.subscribeTx(params) : common.subscribeTx(params)
+
   return {
     ...common,
-    sendTx
+    sendTx,
+    subscribeTx
   }
 }

--- a/src/renderer/services/clients/address.ts
+++ b/src/renderer/services/clients/address.ts
@@ -3,7 +3,7 @@ import { function as FP, option as O } from 'fp-ts'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
-import { WalletAddress, WalletType } from '../../../shared/wallet/types'
+import { HDMode, WalletAddress, WalletType } from '../../../shared/wallet/types'
 import { removeAddressPrefix } from '../../helpers/addressHelper'
 import { WalletAddress$, XChainClient$ } from '../clients/types'
 import { appWalletService } from '../wallet/appWallet'
@@ -79,5 +79,62 @@ export const addressUI$: (client$: XChainClient$, chain: Chain) => WalletAddress
 export const address$: (client$: XChainClient$, chain: Chain) => WalletAddress$ = (client$, chain) =>
   FP.pipe(
     addressUI$(client$, chain),
+    RxOp.map(O.map((wAddress: WalletAddress) => ({ ...wAddress, address: removeAddressPrefix(wAddress.address) })))
+  )
+
+/**
+ * Keystore-only address resolver for a secondary derivation (e.g. BTC Taproot).
+ *
+ * Unlike `addressUI$`, this never consults the unified Vultisig / Ledger address —
+ * it derives strictly from the provided xchainjs client and emits `O.none` when no
+ * client is available. The supplied `hdMode` is stamped onto the resulting
+ * `WalletAddress` so downstream consumers (balances cache, dedup keys) can
+ * distinguish it from the primary keystore address for the same chain.
+ */
+export const keystoreAddressUI$: (client$: XChainClient$, chain: Chain, hdMode?: HDMode) => WalletAddress$ = (
+  client$,
+  chain,
+  hdMode = 'default'
+) =>
+  client$.pipe(
+    RxOp.switchMap((oClient) =>
+      FP.pipe(
+        oClient,
+        O.fold(
+          () => Rx.of<O.Option<WalletAddress>>(O.none),
+          (client) =>
+            Rx.from(client.getAddressAsync(0)).pipe(
+              RxOp.map(
+                (address: Address): O.Option<WalletAddress> =>
+                  O.some({
+                    address,
+                    chain,
+                    type: WalletType.Keystore,
+                    walletAccount: 0,
+                    walletIndex: 0,
+                    hdMode
+                  })
+              ),
+              RxOp.catchError(() => Rx.of<O.Option<WalletAddress>>(O.none))
+            )
+        )
+      )
+    ),
+    RxOp.distinctUntilChanged((a, b) =>
+      O.getEq({
+        equals: (x: WalletAddress, y: WalletAddress) =>
+          x.address === y.address && x.type === y.type && x.chain === y.chain && x.hdMode === y.hdMode
+      }).equals(a, b)
+    ),
+    RxOp.shareReplay(1)
+  )
+
+export const keystoreAddress$: (client$: XChainClient$, chain: Chain, hdMode?: HDMode) => WalletAddress$ = (
+  client$,
+  chain,
+  hdMode = 'default'
+) =>
+  FP.pipe(
+    keystoreAddressUI$(client$, chain, hdMode),
     RxOp.map(O.map((wAddress: WalletAddress) => ({ ...wAddress, address: removeAddressPrefix(wAddress.address) })))
   )

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -71,6 +71,15 @@ import {
   isVultisigMode
 } from './types'
 
+/**
+ * Default derivation marker for chain/wallet combinations that have no further
+ * mode to distinguish (i.e. every chain except BTC keystore, which carries
+ * `'p2tr'` for the Taproot row). Kept as a typed constant so call sites don't
+ * have to repeat `'default' as HDMode` casts that TypeScript would otherwise
+ * narrow to the literal type.
+ */
+const DEFAULT_HD_MODE: HDMode = 'default'
+
 export const createBalancesService = ({
   keystore$,
   network$,
@@ -542,16 +551,26 @@ export const createBalancesService = ({
   }
 
   /**
-   * Factory to create a chain balance observable that uses dynamic wallet type from addressUI$
+   * Factory to create a chain balance observable that uses dynamic wallet type from addressUI$.
+   *
+   * `hdMode` parameter stamps the placeholder `ChainBalance` emitted while the
+   * address is still resolving (e.g. keystore unlocking). Without it the BTC
+   * Taproot row would briefly impersonate Native SegWit (`'default'`) before
+   * its address is derived — harmless today (the row renders nothing while
+   * `walletAddress: O.none && balances: RD.initial`) but semantically wrong and
+   * a latent bug for any future code that reads `ChainBalance.hdMode` in the
+   * loading state.
    */
   const createChainBalance$ = ({
     chain,
     addressUI$,
-    walletBalanceType
+    walletBalanceType,
+    hdMode = DEFAULT_HD_MODE
   }: {
     chain: Chain
     addressUI$: Rx.Observable<O.Option<WalletAddress>>
     walletBalanceType: WalletBalanceType
+    hdMode?: HDMode
   }): ChainBalance$ =>
     addressUI$.pipe(
       RxOp.switchMap((oWalletAddress) =>
@@ -565,7 +584,7 @@ export const createBalancesService = ({
                 walletAddress: O.none,
                 walletAccount: 0,
                 walletIndex: 0,
-                hdMode: 'default' as HDMode,
+                hdMode,
                 balances: RD.initial,
                 balancesType: walletBalanceType
               }),
@@ -669,7 +688,7 @@ export const createBalancesService = ({
                 walletType: WalletType.Ledger,
                 chain,
                 walletAddress: O.none,
-                hdMode: 'default',
+                hdMode: DEFAULT_HD_MODE,
                 balances: RD.initial,
                 balancesType: walletBalanceType
               }),
@@ -739,7 +758,7 @@ export const createBalancesService = ({
                 walletType: WalletType.Vultisig,
                 chain,
                 walletAddress: O.none,
-                hdMode: 'default',
+                hdMode: DEFAULT_HD_MODE,
                 balances: RD.initial,
                 balancesType: walletBalanceType
               }),
@@ -752,13 +771,13 @@ export const createBalancesService = ({
                   walletAccount: 0, // Vultisig doesn't use HD derivation
                   walletIndex: 0,
                   walletBalanceType,
-                  hdMode: 'default'
+                  hdMode: DEFAULT_HD_MODE
                 }),
                 RxOp.map<WalletBalancesRD, ChainBalance>((balances) => ({
                   walletType: WalletType.Vultisig,
                   chain,
                   walletAddress: O.some(address),
-                  hdMode: 'default',
+                  hdMode: DEFAULT_HD_MODE,
                   balances,
                   balancesType: walletBalanceType
                 }))
@@ -890,13 +909,15 @@ export const createBalancesService = ({
   const btcChainBalanceTR$: ChainBalance$ = createChainBalance$({
     chain: BTCChain,
     addressUI$: BTC.addressUITR$,
-    walletBalanceType: 'all'
+    walletBalanceType: 'all',
+    hdMode: 'p2tr'
   })
 
   const btcChainBalanceConfirmedTR$: ChainBalance$ = createChainBalance$({
     chain: BTCChain,
     addressUI$: BTC.addressUITR$,
-    walletBalanceType: 'confirmed'
+    walletBalanceType: 'confirmed',
+    hdMode: 'p2tr'
   })
 
   /**

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -429,12 +429,21 @@ export const createBalancesService = ({
   // `hdMode` is part of the cache key so the BTC keystore's Native SegWit (default)
   // and Taproot (p2tr) balances don't overwrite each other in the cache. For all
   // other chains/wallet modes `hdMode` is effectively constant per (chain, walletType).
+  //
+  // `walletAccount` + `walletIndex` are also included so the cache stays correct
+  // if/when the keystore ever gains multi-account/multi-index support. Today the
+  // keystore pipeline pins both to 0 and Ledger entries are unique by
+  // (keystoreId, chain, network, hdMode), so this is purely defensive — it just
+  // future-proofs the cache against silently returning a sibling derivation's
+  // balance.
   const balanceCacheKey = (
     chain: Chain,
     walletType: WalletType,
     walletBalanceType: WalletBalanceType,
-    hdMode: HDMode
-  ): string => `${chain}|${walletType}|${walletBalanceType}|${hdMode}`
+    hdMode: HDMode,
+    walletAccount: number,
+    walletIndex: number
+  ): string => `${chain}|${walletType}|${walletBalanceType}|${hdMode}|${walletAccount}|${walletIndex}`
 
   // Whenever network is changed, reset stored balances
   const networkSub = network$.subscribe(() => {
@@ -504,7 +513,9 @@ export const createBalancesService = ({
     return FP.pipe(
       reload$,
       RxOp.switchMap((shouldReloadData) => {
-        const savedResult = walletBalancesState.get(balanceCacheKey(chain, walletType, walletBalanceType, hdMode))
+        const savedResult = walletBalancesState.get(
+          balanceCacheKey(chain, walletType, walletBalanceType, hdMode, walletAccount, walletIndex)
+        )
         // For every new simple subscription return cached results if they exist
         if (!shouldReloadData && savedResult) {
           return Rx.of(savedResult)
@@ -518,7 +529,10 @@ export const createBalancesService = ({
           // For every successful load save results to the memory-based cache
           // to avoid unwanted data re-requesting.
           liveData.map((balances) => {
-            walletBalancesState.set(balanceCacheKey(chain, walletType, walletBalanceType, hdMode), RD.success(balances))
+            walletBalancesState.set(
+              balanceCacheKey(chain, walletType, walletBalanceType, hdMode, walletAccount, walletIndex),
+              RD.success(balances)
+            )
             return balances
           }),
           RxOp.startWith(savedResult || RD.initial)

--- a/src/renderer/services/wallet/balances.ts
+++ b/src/renderer/services/wallet/balances.ts
@@ -426,8 +426,15 @@ export const createBalancesService = ({
    * balances data which might be very expensive.
    */
   const walletBalancesState: Map<string, WalletBalancesRD> = new Map()
-  const balanceCacheKey = (chain: Chain, walletType: WalletType, walletBalanceType: WalletBalanceType): string =>
-    `${chain}|${walletType}|${walletBalanceType}`
+  // `hdMode` is part of the cache key so the BTC keystore's Native SegWit (default)
+  // and Taproot (p2tr) balances don't overwrite each other in the cache. For all
+  // other chains/wallet modes `hdMode` is effectively constant per (chain, walletType).
+  const balanceCacheKey = (
+    chain: Chain,
+    walletType: WalletType,
+    walletBalanceType: WalletBalanceType,
+    hdMode: HDMode
+  ): string => `${chain}|${walletType}|${walletBalanceType}|${hdMode}`
 
   // Whenever network is changed, reset stored balances
   const networkSub = network$.subscribe(() => {
@@ -497,7 +504,7 @@ export const createBalancesService = ({
     return FP.pipe(
       reload$,
       RxOp.switchMap((shouldReloadData) => {
-        const savedResult = walletBalancesState.get(balanceCacheKey(chain, walletType, walletBalanceType))
+        const savedResult = walletBalancesState.get(balanceCacheKey(chain, walletType, walletBalanceType, hdMode))
         // For every new simple subscription return cached results if they exist
         if (!shouldReloadData && savedResult) {
           return Rx.of(savedResult)
@@ -511,7 +518,7 @@ export const createBalancesService = ({
           // For every successful load save results to the memory-based cache
           // to avoid unwanted data re-requesting.
           liveData.map((balances) => {
-            walletBalancesState.set(balanceCacheKey(chain, walletType, walletBalanceType), RD.success(balances))
+            walletBalancesState.set(balanceCacheKey(chain, walletType, walletBalanceType, hdMode), RD.success(balances))
             return balances
           }),
           RxOp.startWith(savedResult || RD.initial)
@@ -544,6 +551,7 @@ export const createBalancesService = ({
                 walletAddress: O.none,
                 walletAccount: 0,
                 walletIndex: 0,
+                hdMode: 'default' as HDMode,
                 balances: RD.initial,
                 balancesType: walletBalanceType
               }),
@@ -562,6 +570,7 @@ export const createBalancesService = ({
                   walletAddress: O.some(walletAddress.address),
                   walletAccount: walletAddress.walletAccount,
                   walletIndex: walletAddress.walletIndex,
+                  hdMode: walletAddress.hdMode,
                   balances,
                   balancesType: walletBalanceType
                 }))
@@ -646,6 +655,7 @@ export const createBalancesService = ({
                 walletType: WalletType.Ledger,
                 chain,
                 walletAddress: O.none,
+                hdMode: 'default',
                 balances: RD.initial,
                 balancesType: walletBalanceType
               }),
@@ -715,6 +725,7 @@ export const createBalancesService = ({
                 walletType: WalletType.Vultisig,
                 chain,
                 walletAddress: O.none,
+                hdMode: 'default',
                 balances: RD.initial,
                 balancesType: walletBalanceType
               }),
@@ -733,6 +744,7 @@ export const createBalancesService = ({
                   walletType: WalletType.Vultisig,
                   chain,
                   walletAddress: O.some(address),
+                  hdMode: 'default',
                   balances,
                   balancesType: walletBalanceType
                 }))
@@ -854,6 +866,22 @@ export const createBalancesService = ({
   const btcChainBalanceConfirmed$: ChainBalance$ = createChainBalance$({
     chain: BTCChain,
     addressUI$: BTC.addressUI$,
+    walletBalanceType: 'confirmed'
+  })
+
+  /**
+   * BTC Taproot (P2TR) keystore balances. `addressUITR$` is keystore-only and emits
+   * `O.none` for Ledger/Vultisig modes, so no Taproot row appears for those modes.
+   */
+  const btcChainBalanceTR$: ChainBalance$ = createChainBalance$({
+    chain: BTCChain,
+    addressUI$: BTC.addressUITR$,
+    walletBalanceType: 'all'
+  })
+
+  const btcChainBalanceConfirmedTR$: ChainBalance$ = createChainBalance$({
+    chain: BTCChain,
+    addressUI$: BTC.addressUITR$,
     walletBalanceType: 'confirmed'
   })
 
@@ -1307,7 +1335,14 @@ export const createBalancesService = ({
   const chainBalanceObservables: Record<Chain, ChainBalance$[]> = {
     THOR: [thorChainBalance$, thorLedgerChainBalance$],
     MAYA: [mayaChainBalance$, mayaLedgerChainBalance$],
-    BTC: [btcChainBalance$, btcChainBalanceConfirmed$, btcLedgerChainBalance$, btcLedgerChainBalanceConfirmed$],
+    BTC: [
+      btcChainBalance$,
+      btcChainBalanceConfirmed$,
+      btcChainBalanceTR$,
+      btcChainBalanceConfirmedTR$,
+      btcLedgerChainBalance$,
+      btcLedgerChainBalanceConfirmed$
+    ],
     BCH: [bchChainBalance$, bchLedgerChainBalance$],
     DASH: [dashBalance$, dashLedgerChainBalance$],
     ETH: [ethChainBalance$, ethLedgerChainBalance$],

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -330,6 +330,12 @@ export type ChainBalance = {
   walletType: WalletType
   walletAddress: O.Option<Address>
   chain: Chain
+  /**
+   * Derivation mode of this `ChainBalance`. For most chains/wallet types this is
+   * `'default'`. For Bitcoin keystore wallets it distinguishes Native SegWit
+   * (`'default'`) from Taproot (`'p2tr'`) so the two coexist as separate rows.
+   */
+  hdMode: HDMode
   balances: WalletBalancesRD
   balancesType: WalletBalanceType
 }

--- a/src/renderer/views/wallet/AssetsView.tsx
+++ b/src/renderer/views/wallet/AssetsView.tsx
@@ -97,7 +97,9 @@ export const AssetsView = (): JSX.Element => {
         if (!enabledChains.has(balance.chain)) {
           return false
         }
-        const key = `${balance.chain}-${balance.walletType}`
+        // Include hdMode so e.g. keystore BTC Native SegWit (default) and Taproot (p2tr)
+        // both surface as distinct rows instead of collapsing into a single BTC entry.
+        const key = `${balance.chain}-${balance.walletType}-${balance.hdMode}`
         if (seen.has(key)) {
           return false
         }


### PR DESCRIPTION
# Adds Taproot (P2TR) support for **keystore** BTC wallets. 
The keystore now derives
  **both** a Native SegWit (`bc1q…`) and a Taproot (`bc1p…`) address from the same
  mnemonic — they appear as two distinct rows in the assets list, each with its own
  balance, address, and send/receive flow. Sending from the Taproot address is wired
  through `xchain-bitcoin`'s P2TR client. Ledger Taproot was already wired upstream
  via `LedgerChainSelectView` and is unchanged.

  **Out of scope (Phase 3, follow-up):** swaps / LP / deposits from a Taproot keystore
  address. `addressByChain$(BTCChain)` and the THORChain/Maya flows still assume one
  BTC address per wallet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Bitcoin Taproot (P2TR) derivation alongside Native SegWit.
  * Taproot wallets display as distinct asset rows with a Taproot wallet label.

* **Bug Fixes**
  * Balance caching and deduplication now respect derivation mode so SegWit and Taproot balances don’t collide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asgardex/asgardex-desktop/pull/1052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->