### PR TITLE
fix(header): hide THOR/MAYA volume below 1400px to prevent narrow-screen wrap

### DIFF
--- a/src/renderer/components/header/stats/HeaderStats.tsx
+++ b/src/renderer/components/header/stats/HeaderStats.tsx
@@ -245,14 +245,14 @@ export const HeaderStats = (props: Props): JSX.Element => {
           {runePriceLabel}
         </Label>
 
-        {!isSmallMobileView && (
-          <>
-            <div className="h-5 w-[1px] bg-gray2 dark:bg-gray2d" />
-            <Label className="!w-auto" color="gray" textTransform="uppercase">
-              {volume24PriceRuneLabel}
-            </Label>
-          </>
-        )}
+        {/* Volume hides below 1400px so the 4 pills + right-side controls don't
+            overflow / wrap in the 1200–1400px range (where xl kicks TCY+FLIP in). */}
+        <div className="hidden items-center space-x-2 min-[1400px]:flex">
+          <div className="h-5 w-[1px] bg-gray2 dark:bg-gray2d" />
+          <Label className="!w-auto" color="gray" textTransform="uppercase">
+            {volume24PriceRuneLabel}
+          </Label>
+        </div>
       </div>
 
       {isSmallMobileView ||
@@ -294,14 +294,13 @@ export const HeaderStats = (props: Props): JSX.Element => {
           {mayaPriceLabel}
         </Label>
 
-        {!isSmallMobileView && (
-          <>
-            <div className="h-5 w-[1px] bg-gray2 dark:bg-gray2d" />
-            <Label className="!w-auto" color="gray" textTransform="uppercase">
-              {volume24PriceMayaLabel}
-            </Label>
-          </>
-        )}
+        {/* Same 1400px gate as THOR — keeps both volume slots in sync. */}
+        <div className="hidden items-center space-x-2 min-[1400px]:flex">
+          <div className="h-5 w-[1px] bg-gray2 dark:bg-gray2d" />
+          <Label className="!w-auto" color="gray" textTransform="uppercase">
+            {volume24PriceMayaLabel}
+          </Label>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

  At widths between roughly 1200px and 1400px the header overflowed: the `xl`
  breakpoint (1200px) makes TCY and FLIP pills appear, so all four stat pills plus
  the right-side controls (network indicator, theme, currency, wallet, settings)
  have to share one row. The THOR and MAYA pills also carry a 24h volume in this
  range, which pushed total width past the available space — the network button
  bumped into the MAYA pill and the row wrapped awkwardly.

  Hiding the volume slot on THOR and MAYA below 1400px buys back the space without
  losing core price info. Above 1400px the volume returns; below 576px (`xs`) it's
  hidden as before.

  ## Change

  `src/renderer/components/header/stats/HeaderStats.tsx` — replaced the
  `{!isSmallMobileView && <>…volume…</>}` conditional on both pills with a CSS-only
  gate: `<div className="hidden items-center space-x-2 min-[1400px]:flex">…</div>`.

  Pure Tailwind arbitrary-screen variant; no `useBreakpoint` change, no extra JS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the display of 24h volume information to be visible exclusively on larger screen sizes (1400px and above).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asgardex/asgardex-desktop/pull/1054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->