### PR TITLE
fix: use CACAO_DECIMAL for MAYAChain pool asset depth scale in SymDeposit

### DIFF
--- a/src/renderer/components/deposit/add/Deposit.helper.test.ts
+++ b/src/renderer/components/deposit/add/Deposit.helper.test.ts
@@ -2,6 +2,7 @@ import * as RD from '@devexperts/remote-data-ts'
 import { BTC_DECIMAL } from '@xchainjs/xchain-bitcoin'
 import { BSC_GAS_ASSET_DECIMAL } from '@xchainjs/xchain-bsc'
 import { ETH_GAS_ASSET_DECIMAL } from '@xchainjs/xchain-ethereum'
+import { CACAO_DECIMAL } from '@xchainjs/xchain-mayachain'
 import { assetAmount, assetToBase, baseAmount } from '@xchainjs/xchain-util'
 import { option as O } from 'fp-ts'
 
@@ -215,6 +216,23 @@ describe('deposit/Deposit.helper', () => {
         poolAssetDecimals: THORCHAIN_DECIMAL
       })
       expect(eqBaseAmount.equals(result, baseAmount(2500, 8))).toBeTruthy()
+    })
+    it('MAYAChain: correct result with poolAssetDecimals=CACAO_DECIMAL', () => {
+      // Pool depth: 20 CACAO, 10 ADA (both stored in 1e10 scale)
+      const mayaPoolData = {
+        dexBalance: baseAmount(200000000000, CACAO_DECIMAL), // 20 CACAO in 1e10
+        assetBalance: baseAmount(100000000000, CACAO_DECIMAL) // 10 ADA in 1e10
+      }
+      const runeAmount = baseAmount(400000000000, CACAO_DECIMAL) // 40 CACAO in 1e10
+      const assetDecimal = 6 // ADA
+      const result = getAssetAmountToDeposit({
+        runeAmount,
+        poolData: mayaPoolData,
+        assetDecimal,
+        poolAssetDecimals: CACAO_DECIMAL
+      })
+      // 40 CACAO * (assetDepth 10 / runeDepth 20) = 20 ADA → baseAmount(20_000_000, 6)
+      expect(eqBaseAmount.equals(result, baseAmount(20000000, 6))).toBeTruthy()
     })
   })
 

--- a/src/renderer/components/deposit/add/SymDeposit.tsx
+++ b/src/renderer/components/deposit/add/SymDeposit.tsx
@@ -218,10 +218,10 @@ export const SymDeposit = (props: Props) => {
     [protocol] // Dependency
   )
 
-  // Pool asset depth scale: THORChain always uses 1e8, MAYAChain uses native scale (e.g. 1e4 for MAYA.MAYA, 1e8 for BTC)
+  // Pool asset depth scale: THORChain stores depths in 1e8, MAYAChain stores depths in 1e10 (CACAO_DECIMAL)
   const poolAssetDecimals = useMemo(
-    () => (protocol === THORChain ? THORCHAIN_DECIMAL : Math.min(assetDecimal, THORCHAIN_DECIMAL)),
-    [protocol, assetDecimal]
+    () => (protocol === THORChain ? THORCHAIN_DECIMAL : CACAO_DECIMAL),
+    [protocol]
   )
 
   const prevAsset = useRef<O.Option<AnyAsset>>(O.none)

--- a/src/renderer/helpers/poolHelperMaya.ts
+++ b/src/renderer/helpers/poolHelperMaya.ts
@@ -13,7 +13,7 @@ import { getPoolDetail, toPoolData } from '../services/midgard/mayaMidgard/utils
 import { PoolAddress, PoolData, PricePool } from '../services/midgard/midgardTypes'
 import { PoolTableRowData, PoolTableRowsData } from '../views/pools/Pools.types'
 import { getPoolTableRowDataMaya, getValueOfAsset1InAsset2, getValueOfRuneInAsset } from '../views/pools/Pools.utils'
-import { convertBaseAmountDecimal, isCacaoAsset, isMayaAsset, to1e8BaseAmount, to1e10BaseAmount } from './assetHelper'
+import { convertBaseAmountDecimal, isCacaoAsset, to1e8BaseAmount } from './assetHelper'
 import { eqAsset, eqChain, eqString } from './fp/eq'
 import { ordBaseAmount } from './fp/ord'
 import { sequenceTOption, sequenceTOptionFromArray } from './fpHelpers'
@@ -151,14 +151,9 @@ export const getPoolPriceValue = ({
   // no pricing if balance asset === price pool asset
   if (eqAsset.equals(asset, priceAsset)) return O.some(amount)
 
-  // Maya Midgard reports assetDepth in 1e8 for most assets, but in native decimal for MAYA.MAYA (1e4).
-  // runeDepth is always in 1e10. getValueOfAsset1InAsset2 uses 1e8 internally,
-  // so input must match the assetDepth scale for correct pool ratios.
-  const amountNormalized = isCacaoAsset(asset)
-    ? amount // CACAO: native 1e10, used in getValueOfRuneInAsset where it matches runeDepth scale
-    : isMayaAsset(asset)
-      ? baseAmount(amount.amount(), 8) // MAYA: re-tag to decimal 8 without scaling (assetDepth is in native 1e4)
-      : to1e8BaseAmount(amount) // All other assets: assetDepth is in 1e8
+  // Pool data is normalized to CACAO_DECIMAL (1e10); getValueOfAsset1InAsset2 and
+  // getValueOfRuneInAsset expect inputs in 1e8.
+  const amountNormalized = to1e8BaseAmount(amount)
 
   return FP.pipe(
     getPoolDetail(poolDetails, asset),
@@ -194,8 +189,7 @@ export const getUSDValue = ({
   // no pricing if balance asset === price pool asset
   if (eqAsset.equals(asset, priceAsset)) return O.some(amount)
   if (isCacaoAsset(asset)) {
-    const amount1e10 = to1e10BaseAmount(amount)
-    return O.some(getValueOfRuneInAsset(amount1e10, pricePoolData))
+    return O.some(getValueOfRuneInAsset(to1e8BaseAmount(amount), pricePoolData))
   }
 
   return FP.pipe(

--- a/src/renderer/services/midgard/mayaMidgard/utils.ts
+++ b/src/renderer/services/midgard/mayaMidgard/utils.ts
@@ -213,32 +213,18 @@ export const getPoolDetail = (details: PoolDetails, asset: AnyAsset): O.Option<P
  * Converts `PoolDetails` to `PoolsDataMap`
  * Keys of the end HasMap is PoolDetails[i].asset
  */
-export const toPoolsData = (poolDetails: Array<Pick<PoolDetail, 'asset' | 'assetDepth' | 'runeDepth'>>): PoolsDataMap =>
-  poolDetails.reduce<PoolsDataMap>((acc, cur) => ({ ...acc, [cur.asset]: toPoolData(cur) }), {})
+export const toPoolsData = (
+  poolDetails: Array<Pick<PoolDetail, 'asset' | 'assetDepth' | 'runeDepth' | 'nativeDecimal'>>
+): PoolsDataMap => poolDetails.reduce<PoolsDataMap>((acc, cur) => ({ ...acc, [cur.asset]: toPoolData(cur) }), {})
 
 /**
- * Converts a `BaseAmount` string into `PoolData` balance (always `1e10` / CACAO_DECIMAL based)
- */
-export const toPoolBalance = (baseAmountString: string): BaseAmount => baseAmount(baseAmountString, CACAO_DECIMAL)
-
-/**
- * Transforms `PoolDetail` into `PoolData` (provided by `asgardex-util`)
- *
- * Note: Balances of `PoolData` are normalized to `CACAO_DECIMAL` (`1e10`) for MAYA Midgard data
- */
-export const toPoolData = ({ assetDepth, runeDepth }: Pick<PoolDetail, 'assetDepth' | 'runeDepth'>): PoolData => ({
-  assetBalance: toPoolBalance(assetDepth),
-  dexBalance: toPoolBalance(runeDepth)
-})
-
-/**
- * Transforms `PoolDetail` into `PoolData` with depths correctly normalized to `CACAO_DECIMAL` (`1e10`).
+ * Transforms `PoolDetail` into `PoolData` with depths normalized to `CACAO_DECIMAL` (`1e10`).
  *
  * MAYAMidgard encodes `runeDepth` (CACAO) in 1e8 units and `assetDepth` in the asset's
- * native decimal units (provided by `nativeDecimal`).  Both are scaled up to `CACAO_DECIMAL`
- * so that symmetric-deposit ratio calculations stay consistent with `poolAssetDecimals = CACAO_DECIMAL`.
+ * native decimal (provided by `nativeDecimal`).  Both are scaled to `CACAO_DECIMAL` so
+ * that deposit-ratio and price calculations are consistent with `poolAssetDecimals = CACAO_DECIMAL`.
  */
-export const toNormalizedPoolData = ({
+export const toPoolData = ({
   assetDepth,
   runeDepth,
   nativeDecimal

--- a/src/renderer/services/midgard/mayaMidgard/utils.ts
+++ b/src/renderer/services/midgard/mayaMidgard/utils.ts
@@ -232,6 +232,22 @@ export const toPoolData = ({ assetDepth, runeDepth }: Pick<PoolDetail, 'assetDep
 })
 
 /**
+ * Transforms `PoolDetail` into `PoolData` with depths correctly normalized to `CACAO_DECIMAL` (`1e10`).
+ *
+ * MAYAMidgard encodes `runeDepth` (CACAO) in 1e8 units and `assetDepth` in the asset's
+ * native decimal units (provided by `nativeDecimal`).  Both are scaled up to `CACAO_DECIMAL`
+ * so that symmetric-deposit ratio calculations stay consistent with `poolAssetDecimals = CACAO_DECIMAL`.
+ */
+export const toNormalizedPoolData = ({
+  assetDepth,
+  runeDepth,
+  nativeDecimal
+}: Pick<PoolDetail, 'assetDepth' | 'runeDepth' | 'nativeDecimal'>): PoolData => ({
+  dexBalance: convertBaseAmountDecimal(baseAmount(runeDepth, THORCHAIN_DECIMAL), CACAO_DECIMAL),
+  assetBalance: convertBaseAmountDecimal(baseAmount(assetDepth, parseInt(nativeDecimal, 10)), CACAO_DECIMAL)
+})
+
+/**
  * Filter out mini tokens from pool assets
  */
 export const filterPoolAssets = (poolAssets: string[]) => {

--- a/src/renderer/services/midgard/mayaMidgard/utils.ts
+++ b/src/renderer/services/midgard/mayaMidgard/utils.ts
@@ -217,14 +217,14 @@ export const toPoolsData = (poolDetails: Array<Pick<PoolDetail, 'asset' | 'asset
   poolDetails.reduce<PoolsDataMap>((acc, cur) => ({ ...acc, [cur.asset]: toPoolData(cur) }), {})
 
 /**
- * Converts a `BaseAmount` string into `PoolData` balance (always `1e8` decimal based)
+ * Converts a `BaseAmount` string into `PoolData` balance (always `1e10` / CACAO_DECIMAL based)
  */
 export const toPoolBalance = (baseAmountString: string): BaseAmount => baseAmount(baseAmountString, CACAO_DECIMAL)
 
 /**
  * Transforms `PoolDetail` into `PoolData` (provided by `asgardex-util`)
  *
- * Note: Balances of `PoolData` are always `1e8` based
+ * Note: Balances of `PoolData` are normalized to `CACAO_DECIMAL` (`1e10`) for MAYA Midgard data
  */
 export const toPoolData = ({ assetDepth, runeDepth }: Pick<PoolDetail, 'assetDepth' | 'runeDepth'>): PoolData => ({
   assetBalance: toPoolBalance(assetDepth),

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -38,8 +38,8 @@ import { usePricePoolMaya } from '../../../hooks/usePricePoolMaya'
 import { useProtocolLimit } from '../../../hooks/useProtocolLimit'
 import * as poolsRoutes from '../../../routes/pools'
 import { PoolAddress, PoolAssetsRD } from '../../../services/midgard/midgardTypes'
-import { toNormalizedPoolData } from '../../../services/midgard/mayaMidgard/utils'
-import { toPoolData } from '../../../services/midgard/thorMidgard/utils'
+import { toPoolData as toPoolDataMaya } from '../../../services/midgard/mayaMidgard/utils'
+import { toPoolData as toPoolDataThor } from '../../../services/midgard/thorMidgard/utils'
 import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
 import { useApp } from '../../../store/app/hooks'
 import { Props } from './SymDepositView.types'
@@ -324,7 +324,7 @@ export const SymDepositView = (props: Props) => {
             openAssetExplorerTxUrl={openAssetExplorerTxUrl}
             getRuneExplorerTxUrl={getRuneExplorerTxUrl}
             getAssetExplorerTxUrl={getAssetExplorerTxUrl}
-            poolData={protocol === THORChain ? toPoolData(poolDetail) : toNormalizedPoolData(poolDetail)}
+            poolData={protocol === THORChain ? toPoolDataThor(poolDetail) : toPoolDataMaya(poolDetail)}
             onChangeAsset={onChangeAsset}
             asset={assetWD}
             walletBalances={balancesState}

--- a/src/renderer/views/deposit/add/SymDepositView.tsx
+++ b/src/renderer/views/deposit/add/SymDepositView.tsx
@@ -38,6 +38,7 @@ import { usePricePoolMaya } from '../../../hooks/usePricePoolMaya'
 import { useProtocolLimit } from '../../../hooks/useProtocolLimit'
 import * as poolsRoutes from '../../../routes/pools'
 import { PoolAddress, PoolAssetsRD } from '../../../services/midgard/midgardTypes'
+import { toNormalizedPoolData } from '../../../services/midgard/mayaMidgard/utils'
 import { toPoolData } from '../../../services/midgard/thorMidgard/utils'
 import { DEFAULT_BALANCES_FILTER, INITIAL_BALANCES_STATE } from '../../../services/wallet/const'
 import { useApp } from '../../../store/app/hooks'
@@ -323,7 +324,7 @@ export const SymDepositView = (props: Props) => {
             openAssetExplorerTxUrl={openAssetExplorerTxUrl}
             getRuneExplorerTxUrl={getRuneExplorerTxUrl}
             getAssetExplorerTxUrl={getAssetExplorerTxUrl}
-            poolData={toPoolData(poolDetail)}
+            poolData={protocol === THORChain ? toPoolData(poolDetail) : toNormalizedPoolData(poolDetail)}
             onChangeAsset={onChangeAsset}
             asset={assetWD}
             walletBalances={balancesState}

--- a/src/renderer/views/wallet/PoolShareView.helper.ts
+++ b/src/renderer/views/wallet/PoolShareView.helper.ts
@@ -1,11 +1,10 @@
-import { CACAO_DECIMAL } from '@xchainjs/xchain-mayachain'
 import { THORChain } from '@xchainjs/xchain-thorchain'
 import { BaseAmount, Chain } from '@xchainjs/xchain-util'
 import { array as A, function as FP, option as O } from 'fp-ts'
 
 import { PoolShareTableData } from '../../components/PoolShares/PoolShares.types'
 import { ZERO_BASE_AMOUNT } from '../../const'
-import { convertBaseAmountDecimal, THORCHAIN_DECIMAL } from '../../helpers/assetHelper'
+import { THORCHAIN_DECIMAL, to1e8BaseAmount } from '../../helpers/assetHelper'
 import { isPoolDetails } from '../../helpers/poolHelper'
 import * as ShareHelpers from '../../helpers/poolShareHelper'
 import { PoolDetails as PoolDetailsMaya } from '../../services/midgard/mayaMidgard/types'
@@ -30,24 +29,22 @@ export const getSharesTotal = (
         isPoolDetails(poolDetails) ? getPoolDetail(poolDetails, asset) : getPoolDetailMaya(poolDetails, asset),
         O.map((poolDetail) => {
           // 1. get shares
-          const runeShare = ShareHelpers.getRuneShare(
-            units,
-            poolDetail,
-            protocol === THORChain ? THORCHAIN_DECIMAL : CACAO_DECIMAL
-          )
-          const dexDecimal = protocol === THORChain ? THORCHAIN_DECIMAL : CACAO_DECIMAL
+          // runeDepth is in 1e8 for both THORChain and MAYAChain midgard APIs
+          const runeShare = ShareHelpers.getRuneShare(units, poolDetail, THORCHAIN_DECIMAL)
           const assetDecimal = parseInt(poolDetail.nativeDecimal || '8', 10) || 8
+          // THORChain assetDepth is always in 1e8; MAYAChain assetDepth is in native decimal
+          const assetDexDecimal = protocol === THORChain ? THORCHAIN_DECIMAL : assetDecimal
           const assetShare = ShareHelpers.getAssetShare({
             liquidityUnits: units,
             detail: poolDetail,
             assetDecimal,
-            dexDecimal
+            dexDecimal: assetDexDecimal
           })
           const poolData = protocol === THORChain ? toPoolData(poolDetail) : toPoolDataMaya(poolDetail)
           // 2. price asset + rune
-          // Convert assetShare back to dexDecimal for pricing — poolData balances are in dexDecimal,
-          // so the raw amounts must be in the same base for correct ratio calculations
-          const assetShareForPricing = convertBaseAmountDecimal(assetShare, dexDecimal)
+          // Pool balances are normalized to 1e10 (MAYAChain) or 1e8 (THORChain);
+          // getValueOfAsset1InAsset2 expects input in 1e8
+          const assetShareForPricing = to1e8BaseAmount(assetShare)
           const assetDepositPrice = getValueOfAsset1InAsset2(assetShareForPricing, poolData, pricePoolData)
           const runeDepositPrice = getValueOfRuneInAsset(runeShare, pricePoolData)
 
@@ -72,23 +69,22 @@ export const getPoolShareTableData = (
       FP.pipe(
         isPoolDetails(poolDetails) ? getPoolDetail(poolDetails, asset) : getPoolDetailMaya(poolDetails, asset),
         O.map((poolDetail) => {
-          const runeShare = ShareHelpers.getRuneShare(
-            units,
-            poolDetail,
-            protocol === THORChain ? THORCHAIN_DECIMAL : CACAO_DECIMAL
-          )
-          const dexDecimal = protocol === THORChain ? THORCHAIN_DECIMAL : CACAO_DECIMAL
+          // runeDepth is in 1e8 for both THORChain and MAYAChain midgard APIs
+          const runeShare = ShareHelpers.getRuneShare(units, poolDetail, THORCHAIN_DECIMAL)
           const assetDecimal = parseInt(poolDetail.nativeDecimal || '8', 10) || 8
+          // THORChain assetDepth is always in 1e8; MAYAChain assetDepth is in native decimal
+          const assetDexDecimal = protocol === THORChain ? THORCHAIN_DECIMAL : assetDecimal
           const assetShare = ShareHelpers.getAssetShare({
             liquidityUnits: units,
             detail: poolDetail,
             assetDecimal,
-            dexDecimal
+            dexDecimal: assetDexDecimal
           })
           const sharePercent = ShareHelpers.getPoolShare(units, poolDetail)
           const poolData = protocol === THORChain ? toPoolData(poolDetail) : toPoolDataMaya(poolDetail)
-          // Convert assetShare back to dexDecimal for pricing — must match poolData's decimal base
-          const assetShareForPricing = convertBaseAmountDecimal(assetShare, dexDecimal)
+          // Pool balances are normalized to 1e10 (MAYAChain) or 1e8 (THORChain);
+          // getValueOfAsset1InAsset2 expects input in 1e8
+          const assetShareForPricing = to1e8BaseAmount(assetShare)
           const assetDepositPrice = getValueOfAsset1InAsset2(assetShareForPricing, poolData, pricePoolData)
           const runeDepositPrice = getValueOfRuneInAsset(runeShare, pricePoolData)
 


### PR DESCRIPTION
MAYAChain stores all pool depths in 1e10 (CACAO_DECIMAL), but poolAssetDecimals was computed as Math.min(assetDecimal, THORCHAIN_DECIMAL), giving 1e6 for ADA. This caused getAssetAmountToDeposit to misinterpret the 1e10-scale result as 1e6-scale, producing a ~10000x overestimate of the required asset amount.

Fixes: https://github.com/asgardex/asgardex-desktop/issues/1051

I wanted to test this before raising a PR, but there are problems with the API keys (Blockfrost and possibly others) in the Debian package I built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected decimal/normalization logic so deposit, pricing and pool-share values use protocol-specific scaling (THORChain vs Maya) and a consistent 1e8 base for cross-protocol calculations.

* **Tests**
  * Added a unit test verifying deposit amount computation for a Maya-style pool using the Maya decimal basis.

* **Documentation**
  * Updated comments and docs to reflect the revised decimal/normalization assumptions for Maya/THORChain balances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asgardex/asgardex-desktop/pull/1055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->