### PR TITLE
ci: automate release draft creation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+# Configuration for GitHub's automatically-generated release notes
+# (used by `gh release create --generate-notes` in release.yml).
+# Categorizes merged PRs by label, mirroring the CHANGELOG.md sections.
+# Docs: https://docs.github.com/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  categories:
+    - title: Add
+      labels:
+        - enhancement
+        - feature
+    - title: Update / Fixes
+      labels:
+        - bug
+        - fix
+        - fixes
+    - title: Chores
+      labels:
+        - chore
+        - dependencies
+        - github-actions
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Create release draft
+
+# When a release/** or hotfix/** branch is pushed, automatically create a
+# DRAFT GitHub release tagged vX.Y.Z (version read from package.json), with
+# auto-generated notes. The build-{macos,win,linux} workflows trigger on the
+# same push and electron-builder (`--publish always`) attaches their artifacts
+# to this draft. A human still signs (where needed) and clicks "Publish".
+#
+# This removes the manual "create the release draft + tag" step from RELEASE.md.
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - 'release/**'
+      - 'hotfix/**'
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v4
+
+      - name: Read version from package.json
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Create draft release (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.pkg.outputs.version }}"
+          # Never clobber an existing release — electron-builder may have already
+          # created/populated it, or an admin may have signed the draft.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — leaving it untouched."
+          else
+            gh release create "$TAG" \
+              --draft \
+              --target "$GITHUB_REF_NAME" \
+              --title "$TAG" \
+              --generate-notes
+            echo "Created draft release $TAG targeting $GITHUB_REF_NAME"
+          fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,12 +1,13 @@
 # How to release
 
 1. Dev bumps `version` in `package.json`.
-2. Dev drafts a new release as described [here](https://help.github.com/articles/creating-releases/) and edits the release draft to populate it with changes. The "Tag version" should be the `version` in `package.json`, but prefixed with `v.`. Target branch should be `release/xyz` or `hotfix/xyz` (**never** target to `develop` nor `master`)
-   - E.g if the version is `1.0.0`, then the GitHub tag should be `v1.0.0`
-
-3. Dev pushes changes to master, which triggers GitHub actions to build all binaries.
-   - Ensure that `.yml` files aren't being left out in the artifacts. These are needed for auto-update to work correctly.
-4. Once all binaries have been uploaded to the draft, Dev message THORCHAIN-ADMIN and they signs and updates the draft
+2. Dev creates a `release/xyz` (or `hotfix/xyz`) branch and pushes it (**never** target `develop` nor `master`). This single push triggers GitHub Actions to:
+   - **Create a draft release** tagged `vX.Y.Z` (read from `package.json`) with auto-generated notes — see [`.github/workflows/release.yml`](.github/workflows/release.yml). Notes are categorized via [`.github/release.yml`](.github/release.yml) by PR label, so labelling merged PRs keeps the changelog tidy.
+   - **Build all binaries** (macOS / Windows / Linux), which `electron-builder` attaches to the draft.
+   - E.g. if the version is `1.0.0`, the tag is `v1.0.0`.
+   - The draft step is idempotent: if a release for that tag already exists it is left untouched, so re-pushing the branch will not clobber a signed draft.
+3. Ensure that `.yml` files aren't being left out in the artifacts. These are needed for auto-update to work correctly.
+4. Once all binaries have been uploaded to the draft, Dev messages THORCHAIN-ADMIN and they sign and update the draft.
 5. Once they are done, publish the release. GitHub will tag the latest commit for you.
 
 ## Links


### PR DESCRIPTION
## Summary

Reduces the manual release process by auto-creating the GitHub draft release. **Additive only** — existing `build-{macos,win,linux}.yml` workflows are untouched.

### What changes
- **`.github/workflows/release.yml`** (new) — on push to `release/**` or `hotfix/**`, reads `version` from `package.json` and creates a **draft** release tagged `vX.Y.Z` with `--generate-notes`. `electron-builder` (`--publish always`) then attaches build artifacts to that draft. **Idempotent**: if a release for the tag already exists, it's left untouched (won't clobber a signed draft on re-push).
- **`.github/release.yml`** (new) — categorizes the auto-generated notes by PR label (Add / Update-Fixes / Chores / Other), mirroring `CHANGELOG.md` sections.
- **`RELEASE.md`** — updated to document the now-automated draft step.

### Manual steps this removes
- Hand-creating the GitHub release draft + tag (old RELEASE.md step 2).
- Hand-assembling release notes (now generated from merged-PR labels).

### Still manual (by design, out of scope here)
- Version bump in `package.json`.
- Admin signing of the draft + clicking **Publish**.
- `CHANGELOG.md` is still hand-written (the auto-notes can seed it).

### Race note
`release.yml` is a single lightweight API call (~seconds); the build workflows reach their publish step only after compile+sign+notarize (minutes), so the draft reliably exists first. A fully race-proof setup (gating builds on `workflow_run`) is a heavier follow-up and intentionally not done here.

### Test plan
- [ ] YAML validated locally (`js-yaml`) — passes.
- [ ] Dry-run on a throwaway `release/0.0.0-test` branch in a fork/sandbox to confirm the draft is created and notes render.
- [ ] Confirm `electron-builder` attaches artifacts to the pre-created draft (vs. creating its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated release drafts are now created when pushing to designated release branches
  * Release notes are automatically categorized based on pull request labels for better organization
  * Updated documentation for the new automated release workflow process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->