### PR TITLE
chore: add Dependabot config (npm + GitHub Actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # JavaScript / TypeScript dependencies (Yarn 4)
+  - package-ecosystem: npm
+    directory: /
+    # Daily so new @xchainjs/* releases (published out-of-band, on their own
+    # cadence) are picked up within ~24h rather than waiting for a weekly poll.
+    # Dependabot polls on a schedule — this is the most responsive option short
+    # of true event-driven updates.
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(dev-deps)
+    groups:
+      # @xchainjs/* is bumped whenever new versions ship upstream (not on a
+      # fixed release cadence) — group them into one reviewable PR.
+      xchainjs:
+        patterns:
+          - '@xchainjs/*'
+      # Collapse routine dev-dependency minor/patch bumps to reduce PR noise.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  # Keep GitHub Actions in CI/release workflows up to date
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: ci(actions)


### PR DESCRIPTION
## Summary

Adds Dependabot version updates. Addresses #879.

- **`.github/dependabot.yml`** (new):
  - **npm (Yarn 4), daily** — new `@xchainjs/*` releases (published on their own upstream cadence) are picked up within ~24h and grouped into a single reviewable PR.
  - Dev-dependency minor/patch bumps grouped to reduce PR noise.
  - **GitHub Actions, weekly** — keeps CI/release workflow actions current.

## Note
Dependabot is poll-based, so "automatic on new xchainjs versions" means a daily check — the most responsive Dependabot setting (no true event-driven trigger exists). If a tighter window is needed, a small hourly cron Action diffing installed vs. latest `@xchainjs/*` could replace this.

## Test plan
- [x] YAML validated locally (`js-yaml`).
- [ ] Confirm Dependabot picks up the config (Insights → Dependency graph → Dependabot) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates for npm packages and GitHub Actions workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->