### PR TITLE
chore: exclude major version bumps from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@ updates:
     commit-message:
       prefix: chore(deps)
       prefix-development: chore(dev-deps)
+    # Major bumps are deliberate migrations handled manually (e.g. rxjs #774,
+    # eslint #719) — exclude them so they don't reopen daily. Security updates
+    # bypass `ignore` and still flow through regardless.
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
     groups:
       # @xchainjs/* is bumped whenever new versions ship upstream (not on a
       # fixed release cadence) — group them into one reviewable PR.


### PR DESCRIPTION
## Summary

Caps the Dependabot noise. The initial run opened 15 PRs because nothing excluded **major** versions, so every deliberate migration (rxjs 6→7 #774, eslint 8→10 #719, vitest 3→4, electron-vite 3→5, @vultisig/sdk 0.x→2.x) got its own PR — and would reopen daily.

This adds an `ignore` rule for `version-update:semver-major` on the npm ecosystem.

### Effect
- Dependabot now opens only **grouped minor/patch** updates + the **xchainjs group** + **security** fixes (security bypasses `ignore`).
- Major upgrades become intentional, manual work tracked by their issues.

### Steady state
Daily check → quiet most days; xchainjs minors picked up within ~24h; a grouped dev-deps PR now and then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to adjust version update handling for dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->