### PR TITLE
fix: pin browserify-sign + pbkdf2 (renderer crash regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - bump `@chainflip/sdk` to 2.1.1 to fix transaction-tracking log spam [#1041](https://github.com/asgardex/asgardex-desktop/pull/1041)
 - update xchainjs packages [#1045](https://github.com/asgardex/asgardex-desktop/pull/1045)
 - bump and lock axios, bump vulnerable dependencies [#1046](https://github.com/asgardex/asgardex-desktop/pull/1046)
+- pin `pbkdf2` (3.1.2) and `browserify-sign` (4.2.1) — newer releases ship a browser-incompatible `readable-stream` that crashed the renderer on load (build passes, only fails at runtime) [#1082](https://github.com/asgardex/asgardex-desktop/pull/1082)
 
 # 1.43.2
 

--- a/electron.vite.config.mjs
+++ b/electron.vite.config.mjs
@@ -74,6 +74,12 @@ export default defineConfig(async ({ mode }) => {
         }
       },
       resolve: {
+        // NOTE: `crypto-browserify` and its deps `pbkdf2` / `browserify-sign` are
+        // version-pinned in package.json → resolutions. Newer releases pull a
+        // readable-stream 2.x build that crashes this renderer bundle at runtime
+        // ("Cannot read properties of undefined (reading 'slice')"). `yarn build`
+        // passes regardless, so launch `yarn dev` and confirm the app loads before
+        // bumping these. See PR #1082.
         alias: {
           process: 'process/browser',
           stream: 'stream-browserify',

--- a/electron.vite.config.mjs
+++ b/electron.vite.config.mjs
@@ -79,7 +79,6 @@ export default defineConfig(async ({ mode }) => {
           stream: 'stream-browserify',
           crypto: 'crypto-browserify',
           assert: 'assert',
-          util: 'util',
           path: path.resolve(__dirname, 'empty.js'),
           url: path.resolve(__dirname, 'empty.js'),
           https: path.resolve(__dirname, 'empty.js'),
@@ -89,7 +88,7 @@ export default defineConfig(async ({ mode }) => {
         }
       },
       optimizeDeps: {
-        include: ['process', 'buffer', 'assert', 'util', '@xchainjs/zcash-js'],
+        include: ['process', 'buffer', 'assert', '@xchainjs/zcash-js'],
         esbuildOptions: {
           inject: ['./src/shims/buffer-shim.js']
         }

--- a/electron.vite.config.mjs
+++ b/electron.vite.config.mjs
@@ -79,6 +79,7 @@ export default defineConfig(async ({ mode }) => {
           stream: 'stream-browserify',
           crypto: 'crypto-browserify',
           assert: 'assert',
+          util: 'util',
           path: path.resolve(__dirname, 'empty.js'),
           url: path.resolve(__dirname, 'empty.js'),
           https: path.resolve(__dirname, 'empty.js'),
@@ -88,7 +89,7 @@ export default defineConfig(async ({ mode }) => {
         }
       },
       optimizeDeps: {
-        include: ['process', 'buffer', 'assert', '@xchainjs/zcash-js'],
+        include: ['process', 'buffer', 'assert', 'util', '@xchainjs/zcash-js'],
         esbuildOptions: {
           inject: ['./src/shims/buffer-shim.js']
         }

--- a/package.json
+++ b/package.json
@@ -207,7 +207,8 @@
     "bn.js": "4.12.0",
     "bigint-buffer": "1.0.1",
     "form-data": "4.0.4",
-    "bignumber.js": "^10.0.1"
+    "bignumber.js": "^10.0.1",
+    "pbkdf2": "3.1.2"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "tailwindcss": "^4.3.1",
     "ts-node": "10.9.2",
     "typescript": "5.8.3",
+    "util": "^0.12.5",
     "vite": "^6.3.5",
     "vite-plugin-svgr": "^4.3.0",
     "vite-plugin-wasm": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -195,7 +195,6 @@
     "tailwindcss": "^4.3.1",
     "ts-node": "10.9.2",
     "typescript": "5.8.3",
-    "util": "^0.12.5",
     "vite": "^6.3.5",
     "vite-plugin-svgr": "^4.3.0",
     "vite-plugin-wasm": "^3.6.0",
@@ -209,7 +208,8 @@
     "bigint-buffer": "1.0.1",
     "form-data": "4.0.4",
     "bignumber.js": "^10.0.1",
-    "pbkdf2": "3.1.2"
+    "pbkdf2": "3.1.2",
+    "browserify-sign": "4.2.1"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7190,7 +7190,6 @@ __metadata:
     tailwindcss: "npm:^4.3.1"
     ts-node: "npm:10.9.2"
     typescript: "npm:5.8.3"
-    util: "npm:^0.12.5"
     uuid: "npm:^8.3.2"
     vite: "npm:^6.3.5"
     vite-plugin-svgr: "npm:^4.3.0"
@@ -7811,7 +7810,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserify-rsa@npm:^4.1.1":
+"browserify-rsa@npm:^4.0.1":
   version: 4.1.1
   resolution: "browserify-rsa@npm:4.1.1"
   dependencies:
@@ -7822,20 +7821,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserify-sign@npm:^4.2.3":
-  version: 4.2.5
-  resolution: "browserify-sign@npm:4.2.5"
+"browserify-sign@npm:4.2.1":
+  version: 4.2.1
+  resolution: "browserify-sign@npm:4.2.1"
   dependencies:
-    bn.js: "npm:^5.2.2"
-    browserify-rsa: "npm:^4.1.1"
+    bn.js: "npm:^5.1.1"
+    browserify-rsa: "npm:^4.0.1"
     create-hash: "npm:^1.2.0"
     create-hmac: "npm:^1.1.7"
-    elliptic: "npm:^6.6.1"
+    elliptic: "npm:^6.5.3"
     inherits: "npm:^2.0.4"
-    parse-asn1: "npm:^5.1.9"
-    readable-stream: "npm:^2.3.8"
-    safe-buffer: "npm:^5.2.1"
-  checksum: 10/ccfe54ab61b8e01e84c507b60912f9ae8701f4e53accc3d85c3773db13f14c51f17b684167735d28c59aaf5523ee59c66cc831ddc178bc7f598257e590ca1a35
+    parse-asn1: "npm:^5.1.5"
+    readable-stream: "npm:^3.6.0"
+    safe-buffer: "npm:^5.2.0"
+  checksum: 10/bf3f9177587a4155bcd64cb4f56f3a0fd6f5aa590188a5f12c07b5dfb50815a1248e90abc8a1dbd75bd42cb825fec09c57ffc8dc7bfba8704875403b762312b4
   languageName: node
   linkType: hard
 
@@ -9346,7 +9345,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:^6.5.7, elliptic@npm:^6.6.1":
+"elliptic@npm:^6.5.7":
   version: 6.6.1
   resolution: "elliptic@npm:6.6.1"
   dependencies:
@@ -13490,7 +13489,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-asn1@npm:^5.1.9":
+"parse-asn1@npm:^5.1.5":
   version: 5.1.9
   resolution: "parse-asn1@npm:5.1.9"
   dependencies:
@@ -14254,21 +14253,6 @@ __metadata:
     parse-json: "npm:^5.0.0"
     type-fest: "npm:^0.6.0"
   checksum: 10/eb696e60528b29aebe10e499ba93f44991908c57d70f2d26f369e46b8b9afc208ef11b4ba64f67630f31df8b6872129e0a8933c8c53b7b4daf0eace536901222
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^2.3.8":
-  version: 2.3.8
-  resolution: "readable-stream@npm:2.3.8"
-  dependencies:
-    core-util-is: "npm:~1.0.0"
-    inherits: "npm:~2.0.3"
-    isarray: "npm:~1.0.0"
-    process-nextick-args: "npm:~2.0.0"
-    safe-buffer: "npm:~5.1.1"
-    string_decoder: "npm:~1.1.1"
-    util-deprecate: "npm:~1.0.1"
-  checksum: 10/8500dd3a90e391d6c5d889256d50ec6026c059fadee98ae9aa9b86757d60ac46fff24fafb7a39fa41d54cb39d8be56cc77be202ebd4cd8ffcf4cb226cbaa40d4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7190,6 +7190,7 @@ __metadata:
     tailwindcss: "npm:^4.3.1"
     ts-node: "npm:10.9.2"
     typescript: "npm:5.8.3"
+    util: "npm:^0.12.5"
     uuid: "npm:^8.3.2"
     vite: "npm:^6.3.5"
     vite-plugin-svgr: "npm:^4.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11044,18 +11044,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hash-base@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "hash-base@npm:3.1.2"
-  dependencies:
-    inherits: "npm:^2.0.4"
-    readable-stream: "npm:^2.3.8"
-    safe-buffer: "npm:^5.2.1"
-    to-buffer: "npm:^1.2.1"
-  checksum: 10/f2100420521ec77736ebd9279f2c0b3ab2820136a2fa408ea36f3201d3f6984cda166806e6a0287f92adf179430bedfbdd74348ac351e24a3eff9f01a8c406b0
-  languageName: node
-  linkType: hard
-
 "hash-base@npm:~3.0.4":
   version: 3.0.5
   resolution: "hash-base@npm:3.0.5"
@@ -13605,7 +13593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pbkdf2@npm:^3.0.3":
+"pbkdf2@npm:3.1.2":
   version: 3.1.2
   resolution: "pbkdf2@npm:3.1.2"
   dependencies:
@@ -13615,20 +13603,6 @@ __metadata:
     safe-buffer: "npm:^5.0.1"
     sha.js: "npm:^2.4.8"
   checksum: 10/40bdf30df1c9bb1ae41ec50c11e480cf0d36484b7c7933bf55e4451d1d0e3f09589df70935c56e7fccc5702779a0d7b842d012be8c08a187b44eb24d55bb9460
-  languageName: node
-  linkType: hard
-
-"pbkdf2@npm:^3.1.2, pbkdf2@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "pbkdf2@npm:3.1.5"
-  dependencies:
-    create-hash: "npm:^1.2.0"
-    create-hmac: "npm:^1.1.7"
-    ripemd160: "npm:^2.0.3"
-    safe-buffer: "npm:^5.2.1"
-    sha.js: "npm:^2.4.12"
-    to-buffer: "npm:^1.2.1"
-  checksum: 10/ce1c9a2ebbc843c86090ec6cac6d07429dece7c1fdb87437ce6cf869d0429cc39cab61bc34215585f4a00d8009862df45e197fbd54f3508ccba8ff312a88261b
   languageName: node
   linkType: hard
 
@@ -14602,16 +14576,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ripemd160@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "ripemd160@npm:2.0.3"
-  dependencies:
-    hash-base: "npm:^3.1.2"
-    inherits: "npm:^2.0.4"
-  checksum: 10/d15d42ea0460426675e5320f86d3468ab408af95b1761cf35f8d32c0c97b4d3bb72b7226e990e643b96e1637a8ad26b343a6c7666e1a297bcab4f305a1d9d3e3
-  languageName: node
-  linkType: hard
-
 "ripple-address-codec@npm:^5.0.0":
   version: 5.0.0
   resolution: "ripple-address-codec@npm:5.0.0"
@@ -15091,19 +15055,6 @@ __metadata:
   bin:
     sha.js: ./bin.js
   checksum: 10/d833bfa3e0a67579a6ce6e1bc95571f05246e0a441dd8c76e3057972f2a3e098465687a4369b07e83a0375a88703577f71b5b2e966809e67ebc340dbedb478c7
-  languageName: node
-  linkType: hard
-
-"sha.js@npm:^2.4.12":
-  version: 2.4.12
-  resolution: "sha.js@npm:2.4.12"
-  dependencies:
-    inherits: "npm:^2.0.4"
-    safe-buffer: "npm:^5.2.1"
-    to-buffer: "npm:^1.2.0"
-  bin:
-    sha.js: bin.js
-  checksum: 10/39c0993592c2ab34eb2daae2199a2a1d502713765aecb611fd97c0c4ab7cd53e902d628e1962aaf384bafd28f55951fef46dcc78799069ce41d74b03aa13b5a7
   languageName: node
   linkType: hard
 
@@ -15861,17 +15812,6 @@ __metadata:
   dependencies:
     rimraf: "npm:^3.0.0"
   checksum: 10/445148d72df3ce99356bc89a7857a0c5c3b32958697a14e50952c6f7cf0a8016e746ababe9a74c1aa52f04c526661992f14659eba34d3c6701d49ba2f3cf781b
-  languageName: node
-  linkType: hard
-
-"to-buffer@npm:^1.2.0, to-buffer@npm:^1.2.1":
-  version: 1.2.2
-  resolution: "to-buffer@npm:1.2.2"
-  dependencies:
-    isarray: "npm:^2.0.5"
-    safe-buffer: "npm:^5.2.1"
-    typed-array-buffer: "npm:^1.0.3"
-  checksum: 10/69d806c20524ff1e4c44d49276bc96ff282dcae484780a3974e275dabeb75651ea430b074a2a4023701e63b3e1d87811cd82c0972f35280fe5461710e4872aba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

After #1071 merged, the dev app crashes on load with a blank screen:

\`\`\`
Uncaught TypeError: Cannot read properties of undefined (reading 'slice')
  at .../browserify-sign/node_modules/readable-stream/lib/_stream_writable.js
  at .../crypto-browserify/index.js
\`\`\`

## Root cause

#1071's dev-dependency group bumped **crypto-browserify 3.12.0 → 3.12.1**, which pulled **browserify-sign 4.2.5**. browserify-sign 4.2.5 **downgraded** its `readable-stream` dependency from `^3.6.0` → `^2.3.8`. readable-stream **2.3.8** gets nested under browserify-sign and is not browser-safe in this renderer bundle → crash. The same class of issue affected **pbkdf2 3.1.5** (its own nested readable-stream).

Critically: `yarn build` compiles fine — this only manifests at **runtime** in the Electron renderer, which is why CI (build + unit tests) didn't catch it.

## Fix

Pin both regressed packages via `package.json` → `resolutions`:
- **`browserify-sign`: 4.2.1** — uses the hoisted, browser-safe `readable-stream@3.6.0`
- **`pbkdf2`: 3.1.2** — last browser-safe release

`readable-stream@2.3.8` is now removed from the tree entirely, and no crypto deps nest their own copy.

## Prevention
- CHANGELOG.md note
- A comment by the renderer crypto polyfill aliases in `electron.vite.config.mjs` (since `package.json` resolutions can't carry a comment)

## Verification
- `yarn build` ✅
- `yarn test` — 869 pass ✅
- Manual: `yarn dev --force` → renderer loads, no crash ✅ (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a runtime renderer crash to improve application stability by pinning specific cryptography/signing package versions.
* **Chores**
  * Documented the stabilization change in the changelog and added a configuration note to clarify why version pinning is necessary (and how to best verify it during development).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->