### PR TITLE
chore: bump electron-log to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "bignumber.js": "^10.0.1",
     "clsx": "^2.1.1",
     "electron-debug": "^3.2.0",
-    "electron-log": "^4.4.8",
+    "electron-log": "^5.4.4",
     "electron-updater": "6.3.4",
     "electron-window-state": "^5.0.3",
     "ethers": "6.14.4",

--- a/src/main/electron.ts
+++ b/src/main/electron.ts
@@ -3,7 +3,7 @@ import path, { join } from 'path'
 
 import { BrowserWindow, app, ipcMain, nativeImage } from 'electron'
 import electronDebug from 'electron-debug'
-import log, { warn } from 'electron-log'
+import log from 'electron-log'
 import windowStateKeeper from 'electron-window-state'
 import { either as E, function as FP } from 'fp-ts'
 
@@ -51,7 +51,7 @@ export const BASE_URL = IS_DEV ? BASE_URL_DEV : BASE_URL_PROD
 const APP_ICON = join(APP_ROOT, 'resources', process.platform.match('win32') ? 'icon.ico' : 'icon.png')
 
 const initLogger = () => {
-  log.transports.file.resolvePath = (variables: log.PathVariables) => {
+  log.transports.file.resolvePathFn = (variables: log.PathVariables) => {
     const safeFileName = sanitizePathSegment(variables.fileName as string, 'log file name')
     if (IS_DEV) {
       // Dev logs go to ./logs/ in the project root for easy access
@@ -106,7 +106,7 @@ const setupDevEnv = async () => {
   try {
     await installExtension(REACT_DEVELOPER_TOOLS)
   } catch (e) {
-    warn('unable to install devtools', e)
+    log.warn('unable to install devtools', e)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7179,7 +7179,7 @@ __metadata:
     electron-builder: "npm:^24.13.3"
     electron-debug: "npm:^3.2.0"
     electron-devtools-installer: "npm:^3.2.0"
-    electron-log: "npm:^4.4.8"
+    electron-log: "npm:^5.4.4"
     electron-updater: "npm:6.3.4"
     electron-vite: "npm:^3.1.0"
     electron-window-state: "npm:^5.0.3"
@@ -9272,10 +9272,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-log@npm:^4.4.8":
-  version: 4.4.8
-  resolution: "electron-log@npm:4.4.8"
-  checksum: 10/9416e1d04395e93b6bfdd9db3815d81b39286e53aa58e21817021ae7dd5a7f03ff5878ad9edcaa2be3e1d0a2d966f785880e10f197abc2a68b8cb7f5719529e5
+"electron-log@npm:^5.4.4":
+  version: 5.4.4
+  resolution: "electron-log@npm:5.4.4"
+  checksum: 10/e48c09d517281f6e5b708b4a82a785c5d17865ef4e22141a1efcd6d8692698c39565bd897771173b5e013efce91860e7b95c459c2dfd7dbbac5757264beb1b0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps `electron-log` `4.4.8` → `5.4.4`. Used in the main process only (5 files).

## v5 API migration (`src/main/electron.ts`)

- `transports.file.resolvePath` → **`resolvePathFn`** — v5 renamed it; `resolvePath` survives as a deprecated alias.
- Dropped the named `{ warn }` import — v5's destructured top-level log functions can lose their `this` binding. Now calls `log.warn(...)`.

The other 4 consumers (`appUpdate.ts`, `mpc/sdk.ts`, `mpc/index.ts`, `ledger/evm/address.ts`) use only `log.info/warn/error/debug`, which are unchanged in v5 — untouched.

## Verification

- `yarn build` — type-checks clean
- `yarn check:trunk` — ✔ No issues (1104 files)
- **Ran the dev app**: `logs/main.log` is written correctly via `resolvePathFn`, with proper v5 formatting (main debug + MPC IPC/SDK info lines).

## Notes

- electron-log is main-process only → no renderer-crash risk.
- No logging behavior changed: no remote transport is configured (logs stay local-disk only), and prod logging is unchanged (this PR doesn't touch levels).

Supersedes Dependabot **#1090** — close it once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `electron-log` dependency to the latest version for improved logging reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->