### PR TITLE
fix: resolve nested-button DOM warning in ProtocolSwitch dropdown

### DIFF
--- a/src/renderer/components/uielements/protocolSwitch/ProtocolSwitch.tsx
+++ b/src/renderer/components/uielements/protocolSwitch/ProtocolSwitch.tsx
@@ -68,16 +68,18 @@ export const ProtocolSwitch = ({ protocol, setProtocol, withAll = false, protoco
     return (
       <Dropdown
         trigger={
-          <button
-            type="button"
+          // `Dropdown` wraps the trigger in a headlessui `MenuButton` (itself a
+          // <button>), so the trigger must not be a <button> — use a <div> like
+          // every other Dropdown caller to avoid nested-button DOM nesting.
+          <div
             className={clsx(
-              'flex items-center gap-2 rounded-lg border border-solid border-gray0 px-3 py-2',
+              'flex cursor-pointer items-center gap-2 rounded-lg border border-solid border-gray0 px-3 py-2',
               'font-main-semi-bold text-sm text-text0 dark:border-gray0d dark:text-text0d',
               'hover:bg-bg1 dark:hover:bg-bg1d'
             )}>
             {activeLabel}
             <ChevronDownIcon className="h-4 w-4" />
-          </button>
+          </div>
         }
         options={protocols.map((p) => {
           const label = p === Protocol.All ? intl.formatMessage({ id: 'common.all' }) : (PROTOCOL_LABEL[p] ?? p)


### PR DESCRIPTION
## Problem

Clicking into the Portfolio view (narrow / below-`md` layout) logs a React warning:

```
Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>.
  ... at Dropdown → at ProtocolSwitch → at PortfolioView
```

## Cause

`Dropdown` wraps its `trigger` in a headlessui `MenuButton`, which renders a `<button>`. `ProtocolSwitch` passed its own `<button>` as the trigger → `<button>` nested inside `<button>`.

## Fix

Change the `ProtocolSwitch` trigger from a `<button>` to a `<div>`, matching every other `Dropdown` caller in the codebase (LocaleDropdown, HeaderPriceSelector, AppGeneralSettings, etc. all use `<div>`). `MenuButton` already provides the button role, click, and keyboard handling, so behaviour and accessibility are unchanged.

## Verification

- `yarn check:trunk` — ✔ No issues
- Dev (HMR): warning no longer logged; protocol dropdown still opens and selects correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)