### PR TITLE
ci: shape release-draft notes (ASGARDEX header, summary slot, folded deps)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,5 @@
 # Configuration for GitHub's automatically-generated release notes
-# (used by `gh release create --generate-notes` in release.yml).
+# (used by the generate-notes API call in release.yml).
 # Categorizes merged PRs by label, mirroring the CHANGELOG.md sections.
 # Docs: https://docs.github.com/repositories/releasing-projects-on-github/automatically-generated-release-notes
 changelog:
@@ -16,6 +16,11 @@ changelog:
     - title: Chores
       labels:
         - chore
+    # Dependabot bumps land here. release.yml folds this section into a
+    # collapsible <details> block so batched updates don't flood the notes.
+    # The folding matches the section heading on the word "Dependencies".
+    - title: 📦 Dependencies
+      labels:
         - dependencies
         - github-actions
     - title: Other Changes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,46 @@ jobs:
           # created/populated it, or an admin may have signed the draft.
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists — leaving it untouched."
-          else
-            gh release create "$TAG" \
-              --draft \
-              --target "$GITHUB_REF_NAME" \
-              --title "$TAG" \
-              --generate-notes
-            echo "Created draft release $TAG targeting $GITHUB_REF_NAME"
+            exit 0
           fi
+
+          # Categorized notes (honors .github/release.yml label categories).
+          notes="$(gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$TAG" \
+            -f target_commitish="$GITHUB_REF_NAME" \
+            --jq '.body')"
+
+          # Fold the "📦 Dependencies" section into a collapsed <details> block
+          # so batched Dependabot bumps don't flood the changelog. generate-notes
+          # renders categories as H3 (### …) under "## What's Changed"; the
+          # <summary> replaces the heading, and the bullets are counted for it.
+          folded="$(printf '%s\n' "$notes" | awk '
+            function flush() {
+              if (n > 0) {
+                print "<details>"
+                printf "<summary>📦 Dependency updates (%d)</summary>\n\n", deps
+                for (i = 1; i <= n; i++) print buf[i]
+                print "</details>"
+                print ""
+              }
+              n = 0; deps = 0
+            }
+            /^#+[[:space:]].*Dependencies/ { collecting = 1; next }
+            collecting && /^#+[[:space:]]/ { flush(); collecting = 0; print; next }
+            collecting { buf[++n] = $0; if ($0 ~ /^[*-][[:space:]]/) deps++; next }
+            { print }
+            END { if (collecting) flush() }
+          ')"
+
+          # Prepend the ASGARDEX header + one-line summary slot. The website
+          # installer page extracts the first line under the title as the
+          # release summary (asgardex-website/src/app/lib/api.tsx), so an admin
+          # MUST replace the TODO line with the real summary before publishing.
+          body="$(printf '# ASGARDEX %s 🚀\n\n_TODO: replace with a concise one-line summary of this release (20–300 chars) — shown on the asgardex.com download page._\n\n%s\n' "$TAG" "$folded")"
+
+          gh release create "$TAG" \
+            --draft \
+            --target "$GITHUB_REF_NAME" \
+            --title "ASGARDEX $TAG 🚀" \
+            --notes "$body"
+          echo "Created draft release $TAG targeting $GITHUB_REF_NAME"


### PR DESCRIPTION
## Summary

Improves the auto-generated release **draft** so it starts closer to our published format and stops Dependabot from flooding the changelog.

### `.github/workflows/release.yml`
The draft body is now composed as:
1. `# ASGARDEX <tag> 🚀` header (matches published releases)
2. A visible `_TODO: one-line summary_` slot directly under the title
3. Categorized notes (via the generate-notes API), with the dependency section **folded into a collapsed `<details>` block**

Switched from `--generate-notes` to the `releases/generate-notes` API so the body can be composed; idempotency guard (never clobber an existing release) is unchanged.

### `.github/release.yml`
Split Dependabot bumps (`dependencies` + `github-actions` labels) into a dedicated `📦 Dependencies` category, leaving `Chores` for genuine `chore`-labelled PRs. The workflow folds this section.

## Why the header/summary matters

The asgardex-website installer page extracts the first line under the `# ASGARDEX …` title as the release summary (`asgardex-website/src/app/lib/api.tsx`, `extractReleaseSummary`). The summary is **editorial** — the workflow only places the slot; an admin replaces the TODO line before publishing (as today). For normal short version tags the title line is filtered by the parser, so the real summary line is what gets picked up.

## Verification

- `yarn check:trunk` — ✔ No issues (actionlint + shellcheck pass on the embedded bash).
- **Live preview** applied to the `v1.43.4-rc.1` test draft: 16 Dependabot bumps collapsed under "📦 Dependency updates (16)", header + summary slot on top.

> Note: the new `📦 Dependencies` category only takes effect once merged, since generate-notes reads `.github/release.yml` from the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)