### PR TITLE
feat(swap): surface output destination at signing (THOR/Maya)

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -57,6 +57,7 @@ import { unionAssets } from '../../helpers/fp/array'
 import { eqAsset, eqBaseAmount, eqOAsset, eqOApproveParams } from '../../helpers/fp/eq'
 import { sequenceSOption, sequenceTOption } from '../../helpers/fpHelpers'
 import { logger } from '../../helpers/logger'
+import { parseSwapMemoDestination } from '../../helpers/memoHelper'
 import { addOneClickSwapToTrackerFromQuote } from '../../helpers/oneClickTransactionTracker'
 import * as PoolHelpers from '../../helpers/poolHelper'
 import * as PoolHelpersMaya from '../../helpers/poolHelperMaya'
@@ -103,6 +104,7 @@ import { Tooltip } from '../uielements/tooltip'
 import { ErrorLabel } from './components/ErrorLabel'
 import { RecipientAddressSection } from './components/RecipientAddressSection'
 import { useSwapConfirmationModals } from './components/SwapConfirmationModals'
+import { SwapDestinationConfirmation } from './components/SwapDestinationConfirmation'
 import { SwapDetailsPanel } from './components/SwapDetailsPanel'
 import { SwapSettings } from './components/SwapSettings'
 import { SwapSubmitSection } from './components/SwapSubmitSection'
@@ -673,6 +675,22 @@ export const Swap = ({
   })
 
   // ─── Remaining component logic ─────────────────────────────────────────────
+
+  // THOR/Maya ONLY: the output destination encoded in the SIGNED memo
+  // (`=:ASSET:DESTADDR:…`), which should equal the recipient the user entered.
+  // Surfaced at signing so a redirected destination (e.g. a tampered quote
+  // response) is human-visible. Chainflip/OneClick are intentionally excluded:
+  // their `recipient` is the deposit/inbound address the source funds are sent
+  // TO (not where the output lands), so it is neither the output destination
+  // nor comparable to the user's recipient. See `SwapDestinationConfirmation`.
+  const oOutputDestination: O.Option<Address> = useMemo(
+    () =>
+      FP.pipe(
+        oSwapParams,
+        O.chain(({ memo }) => parseSwapMemoDestination(memo))
+      ),
+    [oSwapParams]
+  )
 
   const setAmountToSwap = useCallback(
     (newAmountToSwap: BaseAmount) => {
@@ -2078,6 +2096,13 @@ export const Swap = ({
                 ? intl.formatMessage({ id: 'common.balance.loading' })
                 : undefined
           }
+        />
+      )}
+      {!lockedWallet && (
+        <SwapDestinationConfirmation
+          outputDestination={oOutputDestination}
+          intendedRecipient={effectiveRecipientAddress}
+          hidePrivateData={hidePrivateData}
         />
       )}
       <div className="flex flex-col items-center justify-center">

--- a/src/renderer/components/swap/components/SwapDestinationConfirmation.tsx
+++ b/src/renderer/components/swap/components/SwapDestinationConfirmation.tsx
@@ -1,0 +1,86 @@
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+import { Address } from '@xchainjs/xchain-util'
+import clsx from 'clsx'
+import { function as FP, option as O } from 'fp-ts'
+import { useIntl } from 'react-intl'
+
+import { swapDestinationMatches } from '../../../helpers/memoHelper'
+import { hiddenString } from '../../../helpers/stringHelper'
+
+type Props = {
+  // THOR/Maya only: address the swap output is paid to, parsed from the signed
+  // memo (`=:ASSET:DESTADDR:…`). `None` for memo-less protocols (Chainflip,
+  // OneClick), where this section does not render.
+  outputDestination: O.Option<Address>
+  // Recipient the user entered/selected, sent to the quote endpoint.
+  intendedRecipient: O.Option<Address>
+  hidePrivateData: boolean
+}
+
+/**
+ * Surfaces, at signing time, the address a THORChain/MAYAChain swap output will
+ * be paid to (taken from the memo that is actually signed), so a redirected
+ * destination is human-visible. When the signed destination differs from the
+ * recipient the user entered, shows a non-blocking warning. This is a
+ * visibility aid, not a hard gate — see `parseSwapMemoDestination` for the
+ * aggregator-memo caveat. Only applies to memo-based protocols (THOR/Maya);
+ * Chainflip/OneClick use a deposit-address transfer with no output memo.
+ */
+export const SwapDestinationConfirmation = ({
+  outputDestination,
+  intendedRecipient,
+  hidePrivateData
+}: Props): JSX.Element | null => {
+  const intl = useIntl()
+
+  return FP.pipe(
+    outputDestination,
+    O.fold(
+      () => null,
+      (destination) => {
+        const mismatch = FP.pipe(
+          intendedRecipient,
+          O.map((recipient) => !swapDestinationMatches(destination, recipient)),
+          O.getOrElse(() => false)
+        )
+
+        return (
+          <div className="mb-[14px] w-full rounded-lg border border-solid border-gray0 p-3 dark:border-gray0d">
+            <div className="mb-1 font-main text-[12px] text-gray2 uppercase dark:text-gray2d">
+              {intl.formatMessage({ id: 'swap.destination.title' })}
+            </div>
+            <div className="font-main text-[13px] break-all text-text0 normal-case dark:text-text0d">
+              {hidePrivateData ? hiddenString : destination}
+            </div>
+            <div className="mt-1 font-main text-[11px] text-gray1 dark:text-gray1d">
+              {intl.formatMessage({ id: 'swap.destination.info' })}
+            </div>
+            {mismatch && (
+              <div
+                className={clsx(
+                  'mt-2 flex items-start gap-1 rounded-md p-2',
+                  'font-main text-[12px] text-warning0 dark:text-warning0d',
+                  'bg-warning0/10 dark:bg-warning0d/10'
+                )}
+                aria-live="polite">
+                <ExclamationTriangleIcon className="mt-[1px] h-[14px] w-[14px] shrink-0" />
+                <span>
+                  {intl.formatMessage(
+                    { id: 'swap.destination.mismatch' },
+                    {
+                      recipient: FP.pipe(
+                        intendedRecipient,
+                        O.map((r) => (hidePrivateData ? hiddenString : r)),
+                        O.getOrElse(() => '')
+                      )
+                    }
+                  )}
+                </span>
+              </div>
+            )}
+          </div>
+        )
+      }
+    )
+  )
+}

--- a/src/renderer/helpers/memoHelper.test.ts
+++ b/src/renderer/helpers/memoHelper.test.ts
@@ -1,0 +1,42 @@
+import { option as O } from 'fp-ts'
+
+import { parseSwapMemoDestination, swapDestinationMatches } from './memoHelper'
+
+describe('helpers/memoHelper', () => {
+  describe('parseSwapMemoDestination', () => {
+    it('extracts the destination from a THORChain swap memo (= alias)', () => {
+      const memo = '=:ETH.ETH:0xRecipient:1000/3/0:dx:10'
+      expect(parseSwapMemoDestination(memo)).toEqual(O.some('0xRecipient'))
+    })
+
+    it('extracts the destination from a SWAP-prefixed memo', () => {
+      const memo = 'SWAP:BTC.BTC:bc1qrecipient:0/1/1'
+      expect(parseSwapMemoDestination(memo)).toEqual(O.some('bc1qrecipient'))
+    })
+
+    it('returns None for a non-swap memo (e.g. deposit/add)', () => {
+      expect(parseSwapMemoDestination('+:BTC.BTC:thoraddr')).toBeNone()
+      expect(parseSwapMemoDestination('LEAVE:thoraddr')).toBeNone()
+    })
+
+    it('returns None when there is no destination or the memo is empty', () => {
+      expect(parseSwapMemoDestination('=:ETH.ETH')).toBeNone()
+      expect(parseSwapMemoDestination('=:ETH.ETH:')).toBeNone()
+      expect(parseSwapMemoDestination('')).toBeNone()
+    })
+  })
+
+  describe('swapDestinationMatches', () => {
+    it('matches identical addresses', () => {
+      expect(swapDestinationMatches('thor1abc', 'thor1abc')).toBe(true)
+    })
+
+    it('matches ignoring case (EVM checksum) and surrounding whitespace', () => {
+      expect(swapDestinationMatches('0xAbCdEf', ' 0xabcdef ')).toBe(true)
+    })
+
+    it('does not match different addresses', () => {
+      expect(swapDestinationMatches('0xrecipient', '0xattacker')).toBe(false)
+    })
+  })
+})

--- a/src/renderer/helpers/memoHelper.test.ts
+++ b/src/renderer/helpers/memoHelper.test.ts
@@ -31,12 +31,26 @@ describe('helpers/memoHelper', () => {
       expect(swapDestinationMatches('thor1abc', 'thor1abc')).toBe(true)
     })
 
-    it('matches ignoring case (EVM checksum) and surrounding whitespace', () => {
-      expect(swapDestinationMatches('0xAbCdEf', ' 0xabcdef ')).toBe(true)
+    it('matches EVM addresses ignoring checksum case and surrounding whitespace', () => {
+      const checksummed = '0xF155e9cDd77a5d77073ab43d17F661507c08e23D'
+      const lower = ` ${checksummed.toLowerCase()} `
+      expect(swapDestinationMatches(checksummed, lower)).toBe(true)
+    })
+
+    it('compares non-EVM (Base58) addresses case-sensitively', () => {
+      // Differ only in case — must NOT be treated as equal for case-sensitive formats
+      expect(swapDestinationMatches('1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2', '1bvbmseystwetqtfn5au4m4gfg7xjanvn2')).toBe(
+        false
+      )
     })
 
     it('does not match different addresses', () => {
-      expect(swapDestinationMatches('0xrecipient', '0xattacker')).toBe(false)
+      expect(
+        swapDestinationMatches(
+          '0xF155e9cDd77a5d77073ab43d17F661507c08e23D',
+          '0x0000000000000000000000000000000000000000'
+        )
+      ).toBe(false)
     })
   })
 })

--- a/src/renderer/helpers/memoHelper.ts
+++ b/src/renderer/helpers/memoHelper.ts
@@ -1,6 +1,7 @@
 import { Network } from '@xchainjs/xchain-client'
 import { THORChain } from '@xchainjs/xchain-thorchain'
 import { Address, AnyAsset, AssetType, BaseAmount, Chain } from '@xchainjs/xchain-util'
+import { option as O } from 'fp-ts'
 
 import { getAsgardexThorname } from '../../shared/const'
 
@@ -191,6 +192,40 @@ export const applyStreamingToMemo = (memo: string, streamingInterval: number, st
 
   return parts.join(':')
 }
+
+/**
+ * Extracts the destination (output) address from a THORChain/MAYAChain swap memo.
+ *
+ * Swap memos are `SWAP:ASSET:DESTADDR:…` (or the `=` alias), so the destination
+ * lives in position 2. Returns `None` if the memo isn't a swap memo or carries
+ * no destination.
+ *
+ * NOTE: dex-aggregator / streaming-output memos may place an aggregator contract
+ * in this position rather than the final recipient — so a value here is the
+ * address the swap output is paid to, which for plain swaps is the recipient.
+ */
+export const parseSwapMemoDestination = (memo: string): O.Option<Address> => {
+  if (!memo?.trim()) return O.none
+
+  const parts = memo.split(DELIMITER)
+  // Need at least function:asset:destination
+  if (parts.length < 3) return O.none
+
+  const fn = parts[0].trim().toLowerCase()
+  if (fn !== 'swap' && fn !== '=') return O.none
+
+  const dest = parts[2]?.trim()
+  return dest ? O.some(dest) : O.none
+}
+
+/**
+ * Loose, display-layer address equality used to flag a swap whose output
+ * destination differs from the recipient the user entered. Case-insensitive and
+ * trimmed so EVM checksum casing never triggers a false mismatch. This is a
+ * non-authoritative warning heuristic, not a security boundary.
+ */
+export const swapDestinationMatches = (a: Address, b: Address): boolean =>
+  a.trim().toLowerCase() === b.trim().toLowerCase()
 
 // With stagenet, remove all affiliate config from memo
 export const updateMemo = (memo: string, network: Network): string => {

--- a/src/renderer/helpers/memoHelper.ts
+++ b/src/renderer/helpers/memoHelper.ts
@@ -220,12 +220,19 @@ export const parseSwapMemoDestination = (memo: string): O.Option<Address> => {
 
 /**
  * Loose, display-layer address equality used to flag a swap whose output
- * destination differs from the recipient the user entered. Case-insensitive and
- * trimmed so EVM checksum casing never triggers a false mismatch. This is a
- * non-authoritative warning heuristic, not a security boundary.
+ * destination differs from the recipient the user entered. Trimmed, and
+ * case-insensitive ONLY for EVM-style addresses (so checksum casing never
+ * triggers a false mismatch); compared exactly otherwise, since Base58 formats
+ * (BTC/LTC/DOGE legacy) are case-sensitive and lowercasing them could mask a
+ * genuine mismatch. This is a non-authoritative warning heuristic, not a
+ * security boundary.
  */
-export const swapDestinationMatches = (a: Address, b: Address): boolean =>
-  a.trim().toLowerCase() === b.trim().toLowerCase()
+export const swapDestinationMatches = (a: Address, b: Address): boolean => {
+  const left = a.trim()
+  const right = b.trim()
+  const isEvmLike = (v: string) => /^0x[0-9a-fA-F]{40}$/.test(v)
+  return isEvmLike(left) && isEvmLike(right) ? left.toLowerCase() === right.toLowerCase() : left === right
+}
 
 // With stagenet, remove all affiliate config from memo
 export const updateMemo = (memo: string, network: Network): string => {

--- a/src/renderer/i18n/de/swap.ts
+++ b/src/renderer/i18n/de/swap.ts
@@ -43,7 +43,10 @@ const swap: SwapMessages = {
   'swap.mode.rapid': 'Rapid',
   'swap.mode.streaming': 'Streaming',
   'swap.mode.instant': 'Sofort',
-  'swap.settings.subSwaps.auto': 'Auto Swap-Anzahl'
+  'swap.settings.subSwaps.auto': 'Auto Swap-Anzahl',
+  'swap.destination.title': 'Ausgabeziel',
+  'swap.destination.info': 'Die Swap-Ausgabe wird an diese Adresse gesendet. Überprüfe sie vor dem Signieren.',
+  'swap.destination.mismatch': 'Dies unterscheidet sich vom Empfänger, den du eingegeben hast ({recipient}). Fahre nur fort, wenn du dieses Ziel erkennst.'
 }
 
 export default swap

--- a/src/renderer/i18n/en/swap.ts
+++ b/src/renderer/i18n/en/swap.ts
@@ -42,7 +42,10 @@ const swap: SwapMessages = {
   'swap.mode.rapid': 'Rapid',
   'swap.mode.streaming': 'Streaming',
   'swap.mode.instant': 'Instant',
-  'swap.settings.subSwaps.auto': 'Auto swap count'
+  'swap.settings.subSwaps.auto': 'Auto swap count',
+  'swap.destination.title': 'Output destination',
+  'swap.destination.info': 'The swap output will be sent to this address. Verify it before signing.',
+  'swap.destination.mismatch': 'This differs from the recipient you entered ({recipient}). Only continue if you recognize this destination.'
 }
 
 export default swap

--- a/src/renderer/i18n/es/swap.ts
+++ b/src/renderer/i18n/es/swap.ts
@@ -44,7 +44,10 @@ const swap: SwapMessages = {
   'swap.mode.rapid': 'Rapid',
   'swap.mode.streaming': 'Streaming',
   'swap.mode.instant': 'Instantáneo',
-  'swap.settings.subSwaps.auto': 'Cantidad auto de swaps'
+  'swap.settings.subSwaps.auto': 'Cantidad auto de swaps',
+  'swap.destination.title': 'Destino de salida',
+  'swap.destination.info': 'La salida del swap se enviará a esta dirección. Verifica antes de firmar.',
+  'swap.destination.mismatch': 'Esto difiere del destinatario que ingresaste ({recipient}). Solo continúa si reconoces este destino.'
 }
 
 export default swap

--- a/src/renderer/i18n/fr/swap.ts
+++ b/src/renderer/i18n/fr/swap.ts
@@ -43,7 +43,10 @@ const swap: SwapMessages = {
   'swap.mode.rapid': 'Rapid',
   'swap.mode.streaming': 'Streaming',
   'swap.mode.instant': 'Instantané',
-  'swap.settings.subSwaps.auto': 'Nombre auto de swaps'
+  'swap.settings.subSwaps.auto': 'Nombre auto de swaps',
+  'swap.destination.title': 'Destination de sortie',
+  'swap.destination.info': 'La sortie du swap sera envoyée à cette adresse. Vérifiez-la avant de signer.',
+  'swap.destination.mismatch': 'Cela diffère du destinataire que vous avez entré ({recipient}). Continuez uniquement si vous reconnaissez cette destination.'
 }
 
 export default swap

--- a/src/renderer/i18n/hi/swap.ts
+++ b/src/renderer/i18n/hi/swap.ts
@@ -42,6 +42,9 @@ const swap: SwapMessages = {
   'swap.mode.rapid': 'रैपिड',
   'swap.mode.streaming': 'स्ट्रीमिंग',
   'swap.mode.instant': 'तुरंत',
-  'swap.settings.subSwaps.auto': 'ऑटो स्वैप संख्या'
+  'swap.settings.subSwaps.auto': 'ऑटो स्वैप संख्या',
+  'swap.destination.title': 'आउटपुट गंतव्य',
+  'swap.destination.info': 'स्वैप आउटपुट इस पते पर भेजा जाएगा। हस्ताक्षर करने से पहले इसे सत्यापित करें।',
+  'swap.destination.mismatch': 'यह आपके द्वारा दर्ज किए गए प्राप्तकर्ता ({recipient}) से भिन्न है। केवल तभी जारी रखें जब आप इस गंतव्य को पहचानते हों।'
 }
 export default swap

--- a/src/renderer/i18n/ko/swap.ts
+++ b/src/renderer/i18n/ko/swap.ts
@@ -42,7 +42,10 @@ const swap: SwapMessages = {
   'swap.mode.rapid': '래피드',
   'swap.mode.streaming': '스트리밍',
   'swap.mode.instant': '즉시',
-  'swap.settings.subSwaps.auto': '자동 스왑 횟수'
+  'swap.settings.subSwaps.auto': '자동 스왑 횟수',
+  'swap.destination.title': '출력 대상',
+  'swap.destination.info': '스왑 출력이 이 주소로 전송됩니다. 서명하기 전에 확인하세요.',
+  'swap.destination.mismatch': '이는 입력한 수신자({recipient})와 다릅니다. 이 대상을 인식하는 경우에만 계속하세요.'
 }
 
 export default swap

--- a/src/renderer/i18n/ru/swap.ts
+++ b/src/renderer/i18n/ru/swap.ts
@@ -45,7 +45,7 @@ const swap: SwapMessages = {
   'swap.mode.instant': 'Мгновенно',
   'swap.settings.subSwaps.auto': 'Авто количество свопов',
   'swap.destination.title': 'Адрес вывода',
-  'swap.destination.info': 'Результат своп будет отправлен на этот адрес. Проверьте его перед подписанием.',
+  'swap.destination.info': 'Результат обмена будет отправлен на этот адрес. Проверьте его перед подписанием.',
   'swap.destination.mismatch': 'Это отличается от получателя, которого вы указали ({recipient}). Продолжайте только если вы узнаете этот адрес.'
 }
 

--- a/src/renderer/i18n/ru/swap.ts
+++ b/src/renderer/i18n/ru/swap.ts
@@ -43,7 +43,10 @@ const swap: SwapMessages = {
   'swap.mode.rapid': 'Rapid',
   'swap.mode.streaming': 'Streaming',
   'swap.mode.instant': 'Мгновенно',
-  'swap.settings.subSwaps.auto': 'Авто количество свопов'
+  'swap.settings.subSwaps.auto': 'Авто количество свопов',
+  'swap.destination.title': 'Адрес вывода',
+  'swap.destination.info': 'Результат своп будет отправлен на этот адрес. Проверьте его перед подписанием.',
+  'swap.destination.mismatch': 'Это отличается от получателя, которого вы указали ({recipient}). Продолжайте только если вы узнаете этот адрес.'
 }
 
 export default swap

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -794,6 +794,9 @@ type SwapMessageKey =
   | 'swap.mode.streaming'
   | 'swap.mode.instant'
   | 'swap.settings.subSwaps.auto'
+  | 'swap.destination.title'
+  | 'swap.destination.info'
+  | 'swap.destination.mismatch'
 
 export type SwapMessages = { [key in SwapMessageKey]: string }
 


### PR DESCRIPTION
## Summary

Surfaces, at signing time, the address a **THORChain/MAYAChain** swap output is actually paid to — parsed from the **signed** memo (`=:ASSET:DESTADDR:…`) — rendered in a section directly above the Swap button. Previously this was only visible in the collapsed Swap Details panel, so a redirected output destination wasn't human-visible at the moment of signing.

If the signed memo destination differs from the recipient the user entered, a **non-blocking** amber warning is shown.

## Context

Follow-up to an internal report: ASGARDEX validates the inbound/deposit address against `/inbound_addresses`, but the swap **output** memo (which encodes where the output is paid) was taken verbatim from the quote response and never surfaced or checked against the user's own recipient. Realistically low severity — the destination round-trips through the quote (the client supplies it), default endpoints are curated THORNodes over HTTPS, and the memo *was* shown (collapsed) — so this lands as a **visibility aid**, not a hard gate.

## Scope: memo-based protocols only

Only THOR/Maya encode the output destination in a parseable memo field. **Chainflip/OneClick are intentionally excluded** — they use a deposit-address transfer where `recipient` is the *inbound* address the source funds are sent **to** (not where the output lands), so it's neither the output destination nor comparable to the user's recipient. The section renders nothing for them. (This fixes a false "destination mismatch" that showed the BTC inbound address on a OneClick BTC→ETH swap.)

## Changes

- **`memoHelper`**: `parseSwapMemoDestination` (extracts memo position 2 for `SWAP`/`=` memos) + `swapDestinationMatches` (case-insensitive/trimmed compare so EVM checksum casing doesn't false-trigger). Both deliberately heuristic — not a security boundary. Unit tests added.
- **`SwapDestinationConfirmation`** component, wired into `Swap.tsx` above the submit button; derives the destination only from the THOR/Maya signed memo.
- **i18n**: `swap.destination.{title,info,mismatch}` across all 7 locales (`{recipient}` placeholder preserved).

## Caveat

Dex-aggregator / streaming-output memos can place an aggregator contract in the destination position; the warning is non-blocking precisely so that edge case never hard-stops a swap. Noted in code.

## Verification

- `yarn test` — new `memoHelper` tests pass (7/7)
- `yarn build` — type-checks clean
- `yarn check:trunk` — ✔ No issues
- Manual dev check: OneClick swap no longer shows the section; THOR/Maya shows the destination with correct match/mismatch behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap output destination is now extracted from THOR/Maya swap memos and shown during signing, with private data hidden when applicable.
  * Added a non-blocking destination mismatch warning if the signed destination doesn’t match the intended recipient (shown only when the wallet isn’t locked).
* **Internationalization**
  * Added swap destination confirmation and mismatch warning strings across English, German, Spanish, French, Hindi, Korean, and Russian.
* **Tests**
  * Added coverage for swap memo destination parsing and destination matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->