### PR TITLE
chore: add Flatpak build target for Linux

### DIFF
--- a/.electronbuildrc.config.js
+++ b/.electronbuildrc.config.js
@@ -101,8 +101,16 @@ module.exports = {
       '--talk-name=org.freedesktop.Notifications',
       // Hardware wallet (Ledger) USB access via host udev/USB devices
       '--device=all',
-      // Persist user config/wallet files under the app home
-      '--filesystem=home'
+      // Read-only access to the native (.deb/AppImage) config dir so the
+      // first-run migration can import existing keystores into the sandbox.
+      // Use the LITERAL host path, not the `xdg-config` token: the token
+      // bind-mounts onto the app's own per-app config dir (so `:ro` would make
+      // the whole data dir read-only), whereas the literal path mounts the host
+      // dir separately, keeping the app's sandbox data writable.
+      // The app's own data lives in the per-app sandbox dir (no grant needed);
+      // export/import of keystore files goes through the FileChooser portal.
+      // Note: case-sensitive — must match app.name (`ASGARDEX`).
+      '--filesystem=~/.config/ASGARDEX:ro'
     ]
   },
   publish: {

--- a/.electronbuildrc.config.js
+++ b/.electronbuildrc.config.js
@@ -80,7 +80,8 @@ module.exports = {
   },
   flatpak: {
     // Reverse-DNS app id (matches appId). Used as the Flatpak ref.
-    license: 'MIT',
+    // `license` is a path to the license file, not an SPDX identifier.
+    license: 'LICENSE',
     // Pin runtime/base to a current, supported freedesktop release.
     // org.electronjs.Electron2.BaseApp ships matching branches.
     runtimeVersion: '24.08',

--- a/.electronbuildrc.config.js
+++ b/.electronbuildrc.config.js
@@ -62,6 +62,10 @@ module.exports = {
       {
         target: 'AppImage',
         arch: ['x64']
+      },
+      {
+        target: 'flatpak',
+        arch: ['x64']
       }
     ],
     desktop: {
@@ -73,6 +77,32 @@ module.exports = {
       Type: 'Application',
       Categories: 'Finance'
     }
+  },
+  flatpak: {
+    // Reverse-DNS app id (matches appId). Used as the Flatpak ref.
+    license: 'MIT',
+    // Pin runtime/base to a current, supported freedesktop release.
+    // org.electronjs.Electron2.BaseApp ships matching branches.
+    runtimeVersion: '24.08',
+    baseVersion: '24.08',
+    finishArgs: [
+      // Rendering (Wayland + X11 fallback)
+      '--socket=wayland',
+      '--socket=x11',
+      '--share=ipc',
+      // GPU / OpenGL
+      '--device=dri',
+      // Audio
+      '--socket=pulseaudio',
+      // Network access (RPC, Midgard, etc.)
+      '--share=network',
+      // System notifications
+      '--talk-name=org.freedesktop.Notifications',
+      // Hardware wallet (Ledger) USB access via host udev/USB devices
+      '--device=all',
+      // Persist user config/wallet files under the app home
+      '--filesystem=home'
+    ]
   },
   publish: {
     provider: 'github',

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -30,6 +30,15 @@ jobs:
       - name: Install missing dependencies
         run: sudo apt-get update && sudo apt-get install -y libudev-dev libusb-1.0-0-dev
 
+      - name: Install Flatpak tooling
+        run: |
+          sudo apt-get install -y flatpak flatpak-builder elfutils
+          flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          flatpak install --user -y flathub \
+            org.freedesktop.Platform//24.08 \
+            org.freedesktop.Sdk//24.08 \
+            org.electronjs.Electron2.BaseApp//24.08
+
       - name: Install dependencies
         run: yarn install --immutable
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /coverage
 /build
 /release
+/.flatpak-builder
 
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -381,6 +381,16 @@ By adding a Ledger account to a wallet, ASGARDEX saves its `address` and some ex
 
 Whenever a Ledger has been removed in `Wallet` -> `Settings`, its data will be removed from `ledgers.json`. By removing all Ledger accounts from each wallet `ledgers.json` will be empty and won't include any Ledger related data. The same by removing all wallets.
 
+### Linux: Ledger device access (udev rules)
+
+On Linux the Ledger USB device is only accessible after the Ledger `udev` rules are installed — without them the app (any of `*.deb`, AppImage, or Flatpak) fails to connect with errors like "Getting address from Ledger failed". Install the rules once, then unplug and replug the device:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | sudo bash
+```
+
+This is a host-level requirement and is independent of the Flatpak sandbox (the Flatpak grants USB device access via `--device=all`).
+
 ## Vultisig (BETA)
 
 ASGARDEX supports [Vultisig](https://vultisig.com/) MPC (multi-party computation) wallets as a third wallet mode alongside Keystore and Ledger. The integration is currently in **beta** -- a "BETA" indicator is shown in the UI when Vultisig mode is active.

--- a/README.md
+++ b/README.md
@@ -287,6 +287,28 @@ ASGARDEX follows [security recommendation made by Electron team](https://www.ele
 yarn package:electron
 ```
 
+### Flatpak (Linux)
+
+On Linux, `yarn package:electron` builds a Flatpak bundle alongside the `deb` and `AppImage` targets. The Flatpak target needs `flatpak` and `flatpak-builder` installed, plus the runtimes it bundles against (the config pins freedesktop `24.08`):
+
+```bash
+# Build tooling (use your distro's package manager)
+sudo apt install flatpak flatpak-builder
+
+# Runtimes / base app
+flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
+flatpak install --user flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08 org.electronjs.Electron2.BaseApp//24.08
+```
+
+The bundle is written to `release/ASGARDEX-<version>-linux.flatpak`. Install and run it with:
+
+```bash
+flatpak install --user --bundle release/ASGARDEX-<version>-linux.flatpak
+flatpak run org.thorchain.asgardex
+```
+
+> Switching from a `*.deb`/AppImage install? Existing keystores are imported into the sandbox automatically on first launch — see [Keystores → Linux](#linux).
+
 ## Keystores
 
 By creating or importing a keystore wallet, ASGARDEX is adding its encrypted keystore into `wallets.json` in [Electron's `appData` folder](https://www.electronjs.org/docs/api/app#appgetpathname) at following location:
@@ -314,9 +336,13 @@ By creating or importing a keystore wallet, ASGARDEX is adding its encrypted key
 ```bash
 # ASGARDEX installed from *.deb
 ~/.config/ASGARDEX/storage/wallets.json
+# ASGARDEX installed from *.flatpak (sandboxed path)
+~/.var/app/org.thorchain.asgardex/config/ASGARDEX/storage/wallets.json
 # ASGARDEX built and run locally
 ~/.config/Electron/storage/wallets.json
 ```
+
+The Flatpak runs in a sandbox, so `~/.config` is redirected to `~/.var/app/org.thorchain.asgardex/config`. When switching from the `*.deb`/AppImage install, ASGARDEX imports the existing `~/.config/ASGARDEX/storage` into the sandbox automatically on first launch (the native files are left untouched).
 
 By removing a wallet in `Wallet` -> `Settings` its data will be removed from `wallets.json`. ASGARDEX will prompt a message to users to inform about saving its phrase on a save place before removing the wallet.
 

--- a/src/main/api/storageMigration.ts
+++ b/src/main/api/storageMigration.ts
@@ -1,0 +1,71 @@
+import os from 'os'
+import path from 'path'
+
+import log from 'electron-log'
+import * as fs from 'fs-extra'
+
+import { APP_NAME, STORAGE_DIR } from './const'
+
+// Marker dropped into the sandbox storage once a host import has run,
+// so the migration never repeats (even if the user later removes all wallets).
+const MIGRATION_MARKER = path.join(STORAGE_DIR, '.host-storage-migrated')
+
+/**
+ * Returns `true` if the given `wallets.json` exists and holds at least one wallet.
+ * Any read/parse problem is treated as "no wallets" so migration logic stays safe.
+ */
+const hasWallets = async (walletsFile: string): Promise<boolean> => {
+  try {
+    if (!(await fs.pathExists(walletsFile))) return false
+    const content = await fs.readJSON(walletsFile)
+    return Array.isArray(content) && content.length > 0
+  } catch (_) {
+    return false
+  }
+}
+
+/**
+ * One-time import of keystores/storage when running inside a Flatpak sandbox.
+ *
+ * Electron's `userData` resolves to `~/.config/ASGARDEX` for the native
+ * `.deb`/`AppImage` install, but inside the Flatpak sandbox `~/.config` is
+ * redirected to `~/.var/app/<appId>/config`, so wallets created by the native
+ * install are invisible to the Flatpak. Because the manifest grants
+ * `--filesystem=home`, the real host `~/.config/ASGARDEX/storage` is still
+ * readable, so on first run we copy it into the sandbox storage.
+ *
+ * Guards (all must hold, otherwise it is a no-op):
+ *  - running inside a Flatpak sandbox (`FLATPAK_ID` is set),
+ *  - the migration has not run before (no marker file),
+ *  - the sandbox has no wallets yet (never overwrite real sandbox data),
+ *  - the host install actually has wallets to import.
+ *
+ * Failures are logged and swallowed — migration must never block startup.
+ */
+export const migrateHostStorageIntoFlatpak = async (): Promise<void> => {
+  // Only relevant inside a Flatpak sandbox
+  if (!process.env.FLATPAK_ID) return
+
+  try {
+    // Already migrated → nothing to do
+    if (await fs.pathExists(MIGRATION_MARKER)) return
+
+    // Never clobber a sandbox that already holds wallets
+    if (await hasWallets(path.join(STORAGE_DIR, 'wallets.json'))) return
+
+    // Host (native) storage, reachable thanks to `--filesystem=home`
+    const hostStorage = path.join(os.homedir(), '.config', APP_NAME, 'storage')
+    if (!(await hasWallets(path.join(hostStorage, 'wallets.json')))) return
+
+    log.info(`[storage-migration] Importing host storage from ${hostStorage} into Flatpak sandbox`)
+    await fs.ensureDir(STORAGE_DIR)
+    // Sandbox holds only empty defaults at this point, so a full overwrite is safe
+    // and ensures the empty `wallets.json` is replaced by the host's.
+    await fs.copy(hostStorage, STORAGE_DIR, { overwrite: true })
+    await fs.writeFile(MIGRATION_MARKER, new Date().toISOString())
+    log.info('[storage-migration] Host storage imported successfully')
+  } catch (error) {
+    // Never block startup because of a failed migration
+    log.error(`[storage-migration] Failed to import host storage: ${error}`)
+  }
+}

--- a/src/main/api/storageMigration.ts
+++ b/src/main/api/storageMigration.ts
@@ -62,6 +62,8 @@ export const migrateHostStorageIntoFlatpak = async (): Promise<void> => {
     // Sandbox holds only empty defaults at this point, so a full overwrite is safe
     // and ensures the empty `wallets.json` is replaced by the host's.
     await fs.copy(hostStorage, STORAGE_DIR, { overwrite: true })
+    // MIGRATION_MARKER is a constant path under the app-controlled STORAGE_DIR (no user input).
+    /* trunk-ignore(eslint/security/detect-non-literal-fs-filename) */
     await fs.writeFile(MIGRATION_MARKER, new Date().toISOString())
     log.info('[storage-migration] Host storage imported successfully')
   } catch (error) {

--- a/src/main/electron.ts
+++ b/src/main/electron.ts
@@ -33,6 +33,7 @@ import {
 import { approveLedgerERC20Token } from './api/ledger/evm/approve'
 import { registerMpcIpcHandlers } from './api/mpc'
 import { disposeSDK } from './api/mpc/sdk'
+import { migrateHostStorageIntoFlatpak } from './api/storageMigration'
 import { openExternal } from './api/url'
 import IPCMessages from './ipc/messages'
 import { setMenu } from './menu'
@@ -254,6 +255,9 @@ const init = async () => {
   if (IS_DEV) {
     await setupDevEnv()
   }
+  // Import keystores/storage from a native (.deb/AppImage) install on first
+  // Flatpak run, before the renderer reads them. No-op outside Flatpak.
+  await migrateHostStorageIntoFlatpak()
   await initMainWindow()
   app.on('window-all-closed', allClosedHandler)
   app.on('activate', activateHandler)


### PR DESCRIPTION
Add a flatpak target to the electron-builder Linux config alongside the existing deb/AppImage targets, with a flatpak config block pinning the runtime/base to freedesktop 24.08 (electron-builder's default 20.08 is EOL).

finish-args grant Wayland/X11, network, audio, notifications, home filesystem, and crucially --device=all so Ledger hardware wallets work inside the Flatpak sandbox.

CI: install flatpak/flatpak-builder and the 24.08 Platform/Sdk/BaseApp runtimes in the Linux build workflow.

This is phase 1 (local .flatpak bundle) toward a future Flathub listing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux Flatpak packaging support alongside existing distribution formats.
  * On first launch in Flatpak, the app can automatically import existing keystore/storage data into the sandbox when applicable.

* **Chores**
  * Updated Linux build configuration and CI to install Flatpak tooling and produce Flatpak artifacts.
  * Added Flatpak builder output to ignore rules.

* **Documentation**
  * Updated the README with Flatpak (Linux) installation/running steps and sandboxed keystore storage locations, including migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->