### PR TITLE
feat(chainflip): bump @chainflip/sdk to 2.2.1 and add Tron support

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "homepage": "https://thorchain.org",
   "dependencies": {
     "@asgardex/asgardex-theme": "^0.2.0",
-    "@chainflip/sdk": "2.1.1",
+    "@chainflip/sdk": "2.2.1",
     "@devexperts/remote-data-ts": "^2.1.1",
     "@headlessui/react": "^2.2.4",
     "@heroicons/react": "^2.2.0",

--- a/src/renderer/services/chainflip/chainflip.ts
+++ b/src/renderer/services/chainflip/chainflip.ts
@@ -35,7 +35,7 @@ const logger = createScopedLogger('chainflip')
 const sdk = new SwapSDK({
   network: 'mainnet',
   enabledFeatures: {
-    dca: true
+    dcaV2: true
   }
 })
 const assetsData = new CachedValue(() => sdk.getAssets(), 24 * 60 * 60 * 1000)

--- a/src/renderer/services/chainflip/utils.ts
+++ b/src/renderer/services/chainflip/utils.ts
@@ -1,4 +1,5 @@
 import { Asset as CAsset, AssetData, Chain as CChain, Chains } from '@chainflip/sdk/swap'
+import { TRONChain } from '@xchainjs/xchain-tron'
 import {
   AnyAsset,
   Asset as XAsset,
@@ -18,6 +19,8 @@ export const cChainToXChain = (chain: CChain): XChain | null => {
       return 'ARB'
     case 'Solana':
       return 'SOL'
+    case 'Tron':
+      return TRONChain
     case 'Assethub':
       return null // Assethub is not supported in XChainJS, return null instead of throwing
     default:
@@ -35,6 +38,8 @@ export const xChainToCChain = (chain: XChain): CChain => {
       return Chains.Arbitrum
     case 'SOL':
       return Chains.Solana
+    case TRONChain:
+      return Chains.Tron
     default:
       throw Error('Unsupported chain in Chainflip')
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,19 +577,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainflip/bitcoin@npm:2.1.1":
-  version: 2.1.1
-  resolution: "@chainflip/bitcoin@npm:2.1.1"
-  dependencies:
-    "@chainflip/utils": "npm:2.1.2"
-    bignumber.js: "npm:^9.3.1"
-    bitcoinjs-lib: "npm:7.0.1"
-    scale-ts: "npm:^1.6.1"
-    zod: "npm:^3.25.75"
-  checksum: 10/239f37c1dba3ed7b6c049cadaf81b9ca98dfa591534b4090b397058d5496118385afed86d63728e3cbb626ebf55a7b001f54f082e560afe70af311b9f83f42d6
-  languageName: node
-  linkType: hard
-
 "@chainflip/bitcoin@npm:2.2.0":
   version: 2.2.0
   resolution: "@chainflip/bitcoin@npm:2.2.0"
@@ -603,16 +590,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainflip/rpc@npm:2.1.3":
-  version: 2.1.3
-  resolution: "@chainflip/rpc@npm:2.1.3"
-  dependencies:
-    "@chainflip/utils": "npm:2.1.2"
-    zod: "npm:^3.25.75"
-  checksum: 10/2d9c4238f24fa1421aa27b2cc234bd8e970c5342f1b8222aa1c8c46a11661c4b8fa46c7250f8bcba1abdc8932391ed2d4115194bf7ad954cde6a1f955654e603
-  languageName: node
-  linkType: hard
-
 "@chainflip/rpc@npm:2.2.0":
   version: 2.2.0
   resolution: "@chainflip/rpc@npm:2.2.0"
@@ -623,16 +600,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainflip/scale@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "@chainflip/scale@npm:1.11.0"
-  dependencies:
-    "@chainflip/utils": "npm:^0.8.22"
-    scale-ts: "npm:^1.6.1"
-  checksum: 10/5eddc76f4b7fdcc63fda374718861875dce9493c33663affcbe4f78012a8998854ae4fb9469e10cd85ef6a10ec1ba3247d4fbc735b4fc9a2475769673ab664e1
-  languageName: node
-  linkType: hard
-
 "@chainflip/scale@npm:^2.2.0":
   version: 2.2.0
   resolution: "@chainflip/scale@npm:2.2.0"
@@ -640,23 +607,6 @@ __metadata:
     "@chainflip/utils": "npm:2.2.0"
     scale-ts: "npm:^1.6.1"
   checksum: 10/50cd46cae99069d9952fa46b9afec607b1d505af544d17f9f315f53cd651318227f0be2ee216a6752ab56c886fd68f818d8eb7e2c856e507e6c6d32f70b7e8fb
-  languageName: node
-  linkType: hard
-
-"@chainflip/sdk@npm:2.1.1":
-  version: 2.1.1
-  resolution: "@chainflip/sdk@npm:2.1.1"
-  dependencies:
-    "@chainflip/bitcoin": "npm:2.1.1"
-    "@chainflip/rpc": "npm:2.1.3"
-    "@chainflip/solana": "npm:2.2.2"
-    "@chainflip/utils": "npm:2.1.4"
-    "@ts-rest/core": "npm:^3.52.1"
-    axios: "npm:^1.10.0"
-    bignumber.js: "npm:^9.3.0"
-    ethers: "npm:^6.14.4"
-    zod: "npm:^3.25.76"
-  checksum: 10/1ec63065bb384dbc508bc9c9e0e4866b5cf7172cb82b4b035e824566f6f70baa3fbe21f5078155844e182a9e8875e753ec43572c9fba0556c560e9a61c268bf4
   languageName: node
   linkType: hard
 
@@ -677,21 +627,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainflip/solana@npm:2.2.2":
-  version: 2.2.2
-  resolution: "@chainflip/solana@npm:2.2.2"
-  dependencies:
-    "@chainflip/scale": "npm:^1.11.0"
-    "@chainflip/utils": "npm:2.1.2"
-    "@coral-xyz/anchor": "npm:^0.32.1"
-    "@solana/web3.js": "npm:^1.98.4"
-    bn.js: "npm:^5.2.3"
-    scale-ts: "npm:^1.6.1"
-    zod: "npm:^3.25.75"
-  checksum: 10/08d9189b3d9082383ab687f544132d0e3b9e79b9edd346ef358882c7db58bc1a8849226ed334987215d1c9eb4104b0a0f35c59221cea81af58887ed201d0fbeb
-  languageName: node
-  linkType: hard
-
 "@chainflip/solana@npm:2.2.5":
   version: 2.2.5
   resolution: "@chainflip/solana@npm:2.2.5"
@@ -707,30 +642,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainflip/utils@npm:2.1.2":
-  version: 2.1.2
-  resolution: "@chainflip/utils@npm:2.1.2"
-  dependencies:
-    "@date-fns/utc": "npm:^2.1.1"
-    "@noble/hashes": "npm:^2.0.1"
-    bignumber.js: "npm:^9.3.1"
-    date-fns: "npm:4.1.0"
-  checksum: 10/14fbd0bdfffd5d942e7c4dba188d195d5f62f9b6f8538d362d89e60726b95b3eae12c27ab821d2f8c3e8c9a164aefe9e45ce03fd5462f6e619269f3fa21a0330
-  languageName: node
-  linkType: hard
-
-"@chainflip/utils@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@chainflip/utils@npm:2.1.4"
-  dependencies:
-    "@date-fns/utc": "npm:^2.1.1"
-    "@noble/hashes": "npm:^2.0.1"
-    bignumber.js: "npm:^9.3.1"
-    date-fns: "npm:4.1.0"
-  checksum: 10/c66f5f8f2011edc66a6fa8420ba69d0c1eee7435ea6513bd9322a515ccd62d335ad2f4aa79f66bbf3203d5ebc64fd6fc5bfc3ee05427d5644da5f4280696d914
-  languageName: node
-  linkType: hard
-
 "@chainflip/utils@npm:2.2.0":
   version: 2.2.0
   resolution: "@chainflip/utils@npm:2.2.0"
@@ -740,17 +651,6 @@ __metadata:
     bignumber.js: "npm:^11.1.1"
     date-fns: "npm:4.1.0"
   checksum: 10/3aaa3bb3f51a07edaa8f78ace33c688be6ba7f645e20ac69ef9fe072714f6bcf6ca5ca95965dcd140d33c06f258cbab8865985cac40285955890995cbeca31ff
-  languageName: node
-  linkType: hard
-
-"@chainflip/utils@npm:^0.8.22":
-  version: 0.8.22
-  resolution: "@chainflip/utils@npm:0.8.22"
-  dependencies:
-    "@date-fns/utc": "npm:^2.1.1"
-    bignumber.js: "npm:^9.3.1"
-    date-fns: "npm:4.1.0"
-  checksum: 10/82427ca06d18e7c524d65d668dd660c320ab6f24f92aeeda637f17849144af5711c639d5da49654a834c41d0f1910671607e74dee872e8e794fbb8537fc4c978
   languageName: node
   linkType: hard
 
@@ -7578,7 +7478,7 @@ __metadata:
   resolution: "asgardex@workspace:."
   dependencies:
     "@asgardex/asgardex-theme": "npm:^0.2.0"
-    "@chainflip/sdk": "npm:2.1.1"
+    "@chainflip/sdk": "npm:2.2.1"
     "@devexperts/remote-data-ts": "npm:^2.1.1"
     "@electron/notarize": "npm:^2.5.0"
     "@eslint/compat": "npm:2.1.0"
@@ -7873,17 +7773,6 @@ __metadata:
     form-data: "npm:^4.0.0"
     proxy-from-env: "npm:^1.1.0"
   checksum: 10/7f875ea13b9298cd7b40fd09985209f7a38d38321f1118c701520939de2f113c4ba137832fe8e3f811f99a38e12c8225481011023209a77b0c0641270e20cde1
-  languageName: node
-  linkType: hard
-
-"axios@npm:^1.10.0":
-  version: 1.12.2
-  resolution: "axios@npm:1.12.2"
-  dependencies:
-    follow-redirects: "npm:^1.15.6"
-    form-data: "npm:^4.0.4"
-    proxy-from-env: "npm:^1.1.0"
-  checksum: 10/886a79770594eaad76493fecf90344b567bd956240609b5dcd09bd0afe8d3e6f1ad6d3257a93a483b6192b409d4b673d9515a34619e3e3ed1b2c0ec2a83b20ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Bump @chainflip/sdk 2.1.1 → 2.2.1 (and @chainflip/* 2.2.x sub-deps)
- Rename removed `dca` feature flag to `dcaV2` (SDK 2.2.x DCA v2)
- Map Tron ↔ chainflip in cChainToXChain / xChainToCChain so TRX and Tron USDT are recognised as supported assets instead of throwing "Unsupported chain in XChainJS"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TRON chain identifier translation to improve cross-chain compatibility in swap flows.
  * Enabled DCA v2 in swap SDK initialization to support the latest DCA behavior.
* **Chores**
  * Updated the chainflip SDK dependency to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->