### PR TITLE
fix(keystore): polyfill crypto.timingSafeEqual for renderer unlock

### DIFF
--- a/electron.vite.config.mjs
+++ b/electron.vite.config.mjs
@@ -83,7 +83,9 @@ export default defineConfig(async ({ mode }) => {
         alias: {
           process: 'process/browser',
           stream: 'stream-browserify',
-          crypto: 'crypto-browserify',
+          // Shim wraps crypto-browserify and adds `timingSafeEqual` (missing in
+          // the browser polyfill) so xchain-crypto >= 1.0.7 keystore decrypt works.
+          crypto: path.resolve(__dirname, 'src/shims/crypto-shim.js'),
           assert: 'assert',
           path: path.resolve(__dirname, 'empty.js'),
           url: path.resolve(__dirname, 'empty.js'),

--- a/src/shims/crypto-shim.js
+++ b/src/shims/crypto-shim.js
@@ -1,0 +1,33 @@
+// Browser `crypto` polyfill for the renderer.
+//
+// `crypto-browserify` does not implement `timingSafeEqual` (a Node-only API).
+// xchain-crypto >= 1.0.7 hardened `decryptFromKeystore` to compare the keystore
+// MAC with `crypto.timingSafeEqual(...)` for a constant-time check. Without this
+// shim the renderer throws "crypto.timingSafeEqual is not a function" and wallet
+// unlock fails — while the test suite passes because Vitest runs in Node, which
+// has the real API. See CLAUDE.md "Pinned crypto polyfills" gotcha.
+//
+// We augment the existing polyfill in place (preserving all of its original
+// bindings) and re-export it as the renderer's `crypto` module via the alias in
+// electron.vite.config.mjs.
+import cryptoBrowserify from 'crypto-browserify'
+
+if (typeof cryptoBrowserify.timingSafeEqual !== 'function') {
+  cryptoBrowserify.timingSafeEqual = (a, b) => {
+    if (a.length !== b.length) {
+      throw new RangeError('Input buffers must have the same byte length')
+    }
+    // Constant-time comparison: never short-circuit on first mismatch.
+    let diff = 0
+    for (let i = 0; i < a.length; i++) {
+      diff |= a[i] ^ b[i]
+    }
+    return diff === 0
+  }
+}
+
+export * from 'crypto-browserify'
+// Also expose it as a static named binding so `import * as crypto from 'crypto'`
+// (namespace access) sees it, not only default-import access.
+export const timingSafeEqual = cryptoBrowserify.timingSafeEqual
+export default cryptoBrowserify


### PR DESCRIPTION
## Problem

Keystore **unlock is broken in the renderer** (`yarn dev` and production builds) on current `develop`. Unlocking throws:

```
TypeError: crypto.timingSafeEqual is not a function
```

## Root cause

`#1114` bumped `@xchainjs/xchain-crypto` 1.0.6 → 1.0.7, which hardened `decryptFromKeystore` to compare the keystore MAC using Node's **`crypto.timingSafeEqual()`** (constant-time comparison):

```js
if (computedMac.length !== expectedMac.length || !crypto.timingSafeEqual(computedMac, expectedMac))
  throw new Error('Invalid password')
```

The renderer aliases `crypto` → **`crypto-browserify`**, which does **not** implement `timingSafeEqual`. So the call is `undefined` at runtime → unlock fails.

It passed the **test suite** because Vitest runs in **Node**, which has the real `crypto.timingSafeEqual`. Classic "compiles fine, only crashes at runtime in the renderer" case (see CLAUDE.md → *Pinned crypto polyfills*).

This is independent of the chainflip/Tron work — it affects **every keystore unlock on develop**.

## Fix

- Add `src/shims/crypto-shim.js` — wraps `crypto-browserify` and adds a constant-time `timingSafeEqual` (following the existing `src/shims/buffer-shim.js` pattern).
- Point the renderer `crypto` alias at the shim (`electron.vite.config.mjs`).

Keeps `xchain-crypto` on **1.0.7** (which `xchain-thorchain`/`xchain-mayachain` now depend on, so pinning back to 1.0.6 would fight the coordinated release). Keystore **format is unchanged** — existing keystores decrypt exactly as before.

## Testing

- `yarn build` ✅
- Manual `yarn dev` ✅ — keystore unlock works again (verified by reviewer).

Upstream report filed against `xchainjs-lib` so the library guards this call for non-Node consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)