### PR TITLE
fix: add fallback password cache for Vultisig vault operations

### DIFF
--- a/src/main/api/mpc/index.ts
+++ b/src/main/api/mpc/index.ts
@@ -22,7 +22,7 @@ import {
   SerializedVault,
   SignBytesParams
 } from '../../../shared/api/mpcTypes'
-import { disposeSDK, getSDK, initializeSDK, isSDKInitialized } from './sdk'
+import { cachePassword, disposeSDK, getSDK, initializeSDK, isSDKInitialized } from './sdk'
 
 /**
  * Safely send IPC message — guards against destroyed renderer windows
@@ -473,6 +473,7 @@ export function registerMpcIpcHandlers(ipcMain: IpcMain): void {
 
       log.info(`[MPC IPC] Unlocking vault: ${vaultId}`)
       await vault.unlock(password)
+      cachePassword(vaultId, password)
       log.info(`[MPC IPC] Vault unlocked successfully: ${vaultId}`)
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)

--- a/src/main/api/mpc/sdk.ts
+++ b/src/main/api/mpc/sdk.ts
@@ -15,6 +15,9 @@ let _disposing = false
 // Password cache TTL (5 minutes)
 const PASSWORD_CACHE_TTL = 5 * 60 * 1000
 
+// Fallback password store — survives SDK internal cache eviction
+const _passwordFallback = new Map<string, string>()
+
 /**
  * Initialize the Vultisig SDK
  * Must be called before any other SDK operations.
@@ -49,6 +52,11 @@ export async function initializeSDK(): Promise<Vultisig> {
         defaultTTL: PASSWORD_CACHE_TTL
       },
       onPasswordRequired: async (vaultId: string, vaultName: string) => {
+        const cached = _passwordFallback.get(vaultId)
+        if (cached) {
+          log.info(`[MPC SDK] onPasswordRequired fired — returning fallback password for "${vaultName}"`)
+          return cached
+        }
         const msg = `Password required for vault "${vaultName}" (${vaultId}) — unlock the vault first via apiMpc.unlockVault`
         log.warn(`[MPC SDK] onPasswordRequired fired (cache miss): ${msg}`)
         throw new Error(msg)
@@ -93,6 +101,13 @@ export function getSDK(): Vultisig {
 /**
  * Dispose the SDK instance
  */
+/**
+ * Store password in fallback cache after successful unlock
+ */
+export function cachePassword(vaultId: string, password: string): void {
+  _passwordFallback.set(vaultId, password)
+}
+
 export function disposeSDK(): void {
   _disposing = true
   if (sdkInstance) {


### PR DESCRIPTION
## Summary
- Vultisig SDK internal password cache can be evicted between unlockVault and sendTransaction IPC calls, causing Password required errors even though the user unlocked the vault seconds earlier
- Add a process-level Map fallback that stores the password on successful unlock
- The onPasswordRequired callback now checks this fallback before throwing, ensuring signing operations succeed without re-entering the password

## Reproduction
1. Create a Vultisig Fast Vault
2. Unlock the vault with password
3. Navigate to SWAP and execute a swap -> VaultError: Failed to get password for vault error

## Changes
- src/main/api/mpc/sdk.ts: Add _passwordFallback Map and cachePassword() export; update onPasswordRequired to return fallback before throwing
- src/main/api/mpc/index.ts: Import cachePassword and call it after successful vault.unlock()

## Test plan
- [ ] Unlock a Vultisig vault and immediately execute a SWAP - should succeed without password error
- [ ] Restart the app, unlock, and try sending - should work
- [ ] Verify incorrect password still fails on unlock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault unlocks are now more reliable after a password cache miss.
  * Previously entered passwords can now be reused when the app needs to retry an unlock, reducing unexpected unlock failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->