### PR TITLE
feat(wallet): 24-word phrase option + randomized keystore id

### DIFF
--- a/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
+++ b/src/renderer/components/wallet/phrase/NewPhraseGenerate.tsx
@@ -30,7 +30,10 @@ export const NewPhraseGenerate = ({ onSubmit, walletId, walletNames }: Props) =>
   const [loading, setLoading] = useState(false)
   const intl = useIntl()
 
-  const [phrase, setPhrase] = useState(generatePhrase())
+  // Recovery phrase length in words. 12 (128-bit) stays the default; 24 (256-bit)
+  // is offered for users who want a higher-entropy phrase.
+  const [size, setSize] = useState<12 | 24>(12)
+  const [phrase, setPhrase] = useState(() => generatePhrase(size))
 
   const initialWalletName = useMemo(() => defaultWalletName(walletId), [walletId])
 
@@ -40,7 +43,12 @@ export const NewPhraseGenerate = ({ onSubmit, walletId, walletNames }: Props) =>
     event$.pipe(RxOp.debounceTime(100))
   )
 
-  useSubscription(refreshButtonClicked$, () => setPhrase(generatePhrase()))
+  useSubscription(refreshButtonClicked$, () => setPhrase(generatePhrase(size)))
+
+  const changeSize = useCallback((newSize: 12 | 24) => {
+    setSize(newSize)
+    setPhrase(generatePhrase(newSize))
+  }, [])
 
   const {
     register,
@@ -96,7 +104,28 @@ export const NewPhraseGenerate = ({ onSubmit, walletId, walletNames }: Props) =>
             textToCopy={phrase}
             label={intl.formatMessage({ id: 'wallet.create.copy.phrase' })}
           />
-          <RefreshButton onClick={clickRefreshButtonHandler} />
+          <div className="flex items-center gap-3">
+            <div
+              className="flex overflow-hidden rounded-full border border-solid border-gray0 dark:border-gray0d"
+              role="group"
+              aria-label={intl.formatMessage({ id: 'wallet.create.phrase.length' })}>
+              {([12, 24] as const).map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => changeSize(option)}
+                  aria-pressed={size === option}
+                  className={`px-3 py-1 text-sm font-bold transition-colors ${
+                    size === option
+                      ? 'bg-turquoise text-white'
+                      : 'bg-transparent text-text2 hover:text-text0 dark:text-text2d dark:hover:text-text0d'
+                  }`}>
+                  {intl.formatMessage({ id: 'wallet.create.phrase.words' }, { count: option })}
+                </button>
+              ))}
+            </div>
+            <RefreshButton onClick={clickRefreshButtonHandler} />
+          </div>
         </div>
         <div className="grid grid-cols-3 gap-1 rounded-xl border border-solid border-gray0 p-2 dark:border-gray0d">
           {phraseWords.map((word, index) => (

--- a/src/renderer/i18n/de/wallet.ts
+++ b/src/renderer/i18n/de/wallet.ts
@@ -65,6 +65,8 @@ const wallet: WalletMessages = {
   'wallet.txs.history': 'Transaktionsverlauf',
   'wallet.txs.history.disabled': 'Transaktionsverlauf für {chain} ist vorübergehend nicht verfügbar',
   'wallet.create.copy.phrase': 'Phrase kopieren',
+  'wallet.create.phrase.length': 'Länge der Wiederherstellungsphrase',
+  'wallet.create.phrase.words': '{count} Wörter',
   'wallet.create.error.phrase.empty': 'Erstelle eine neue Wallet und füge ein Guthaben hinzu',
   'wallet.add.another': 'Weitere Wallet hinzufügen',
   'wallet.add.label': 'Wallet hinzufügen',
@@ -137,7 +139,8 @@ const wallet: WalletMessages = {
   'wallet.vultisig.import.password.title': 'Vault-Passwort erforderlich',
   'wallet.vultisig.import.password.description': 'Dieser Vault ist verschlüsselt. Bitte geben Sie das Passwort ein.',
   'wallet.vultisig.export.password.title': 'Export Vault',
-  'wallet.vultisig.export.password.description': 'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
+  'wallet.vultisig.export.password.description':
+    'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
   'wallet.vultisig.import.success': 'Vault erfolgreich importiert',
   'wallet.vultisig.import.error': 'Fehler beim Importieren des Vaults',
   'wallet.vultisig.import.error.invalidPassword': 'Ungültiges Passwort',
@@ -180,7 +183,8 @@ const wallet: WalletMessages = {
   'wallet.vultisig.secureCreate.vaultName.placeholder': 'Mein sicherer Vault',
   'wallet.vultisig.secureCreate.password.optional': 'Passwort (optional)',
   'wallet.vultisig.secureCreate.password.placeholder': 'Optionales Verschlüsselungspasswort',
-  'wallet.vultisig.secureCreate.password.hint': 'Wenn gesetzt, wird dieses Passwort zum Signieren von Transaktionen benötigt.',
+  'wallet.vultisig.secureCreate.password.hint':
+    'Wenn gesetzt, wird dieses Passwort zum Signieren von Transaktionen benötigt.',
   'wallet.vultisig.secureCreate.enterName': 'Bitte einen Vault-Namen eingeben',
   'wallet.vultisig.secureCreate.submit': 'Sicheren Vault erstellen',
   'wallet.vultisig.secureCreate.waitingQr': 'Sichere Vault-Sitzung wird initialisiert...',

--- a/src/renderer/i18n/en/wallet.ts
+++ b/src/renderer/i18n/en/wallet.ts
@@ -63,6 +63,8 @@ const wallet: WalletMessages = {
   'wallet.txs.history': 'Transaction history',
   'wallet.txs.history.disabled': 'Transaction history for {chain} has been disabled temporarily',
   'wallet.create.copy.phrase': 'Copy phrase',
+  'wallet.create.phrase.length': 'Recovery phrase length',
+  'wallet.create.phrase.words': '{count} words',
   'wallet.create.error.phrase.empty': 'Create a new wallet, add funds to it',
   'wallet.add.another': 'Add another wallet',
   'wallet.add.label': 'Add wallet',
@@ -132,7 +134,8 @@ const wallet: WalletMessages = {
   'wallet.vultisig.import.password.title': 'Vault Password Required',
   'wallet.vultisig.import.password.description': 'This vault is encrypted. Please enter the password to import.',
   'wallet.vultisig.export.password.title': 'Export Vault',
-  'wallet.vultisig.export.password.description': 'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
+  'wallet.vultisig.export.password.description':
+    'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
   'wallet.vultisig.import.success': 'Vault imported successfully',
   'wallet.vultisig.import.error': 'Failed to import vault',
   'wallet.vultisig.import.error.invalidPassword': 'Invalid password',

--- a/src/renderer/i18n/es/wallet.ts
+++ b/src/renderer/i18n/es/wallet.ts
@@ -64,6 +64,8 @@ const wallet: WalletMessages = {
   'wallet.txs.history': 'Historial de transacciones',
   'wallet.txs.history.disabled': 'El historial de transacciones de {chain} se ha desactivado temporalmente',
   'wallet.create.copy.phrase': 'Copiar la frase',
+  'wallet.create.phrase.length': 'Longitud de la frase de recuperación',
+  'wallet.create.phrase.words': '{count} palabras',
   'wallet.create.error.phrase.empty': 'Crear un nuevo monedero, añadirle fondos',
   'wallet.add.another': 'Añadir otra cartera',
   'wallet.add.label': 'Añadir cartera',
@@ -133,7 +135,8 @@ const wallet: WalletMessages = {
   'wallet.vultisig.import.password.title': 'Contraseña del Vault Requerida',
   'wallet.vultisig.import.password.description': 'Este vault está encriptado. Por favor ingrese la contraseña.',
   'wallet.vultisig.export.password.title': 'Export Vault',
-  'wallet.vultisig.export.password.description': 'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
+  'wallet.vultisig.export.password.description':
+    'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
   'wallet.vultisig.import.success': 'Vault importado exitosamente',
   'wallet.vultisig.import.error': 'Error al importar el vault',
   'wallet.vultisig.import.error.invalidPassword': 'Contraseña inválida',
@@ -176,7 +179,8 @@ const wallet: WalletMessages = {
   'wallet.vultisig.secureCreate.vaultName.placeholder': 'Mi Vault Seguro',
   'wallet.vultisig.secureCreate.password.optional': 'Contraseña (opcional)',
   'wallet.vultisig.secureCreate.password.placeholder': 'Contraseña de cifrado opcional',
-  'wallet.vultisig.secureCreate.password.hint': 'Si se establece, esta contraseña será necesaria para firmar transacciones.',
+  'wallet.vultisig.secureCreate.password.hint':
+    'Si se establece, esta contraseña será necesaria para firmar transacciones.',
   'wallet.vultisig.secureCreate.enterName': 'Por favor ingresa un nombre para el vault',
   'wallet.vultisig.secureCreate.submit': 'Crear Vault Seguro',
   'wallet.vultisig.secureCreate.waitingQr': 'Inicializando sesión de vault seguro...',

--- a/src/renderer/i18n/fr/wallet.ts
+++ b/src/renderer/i18n/fr/wallet.ts
@@ -64,6 +64,8 @@ const wallet: WalletMessages = {
   'wallet.txs.history': 'Historique des transactions',
   'wallet.txs.history.disabled': "L'historique des transactions pour {chain} a été désactivé temporairement.",
   'wallet.create.copy.phrase': 'Copiez la phrase ci-dessous',
+  'wallet.create.phrase.length': 'Longueur de la phrase de récupération',
+  'wallet.create.phrase.words': '{count} mots',
   'wallet.create.error.phrase.empty': "Créez un nouveau portefeuille, et l'alimenter en fonds",
   'wallet.add.another': 'Ajouter un autre portefeuille',
   'wallet.add.label': 'Ajouter un portefeuille',

--- a/src/renderer/i18n/hi/wallet.ts
+++ b/src/renderer/i18n/hi/wallet.ts
@@ -63,6 +63,8 @@ const wallet: WalletMessages = {
   'wallet.txs.history': 'लेन-देन इतिहास',
   'wallet.txs.history.disabled': '{chain} के लिए लेन-देन इतिहास अस्थायी रूप से निष्क्रिय किया गया है',
   'wallet.create.copy.phrase': 'वाक्यांश कॉपी करें',
+  'wallet.create.phrase.length': 'रिकवरी वाक्यांश की लंबाई',
+  'wallet.create.phrase.words': '{count} शब्द',
   'wallet.create.error.phrase.empty': 'नया वॉलेट बनाएं, उसमें फंड जोड़ें',
   'wallet.add.another': 'एक और वॉलेट जोड़ें',
   'wallet.add.label': 'वॉलेट जोड़ें',
@@ -134,7 +136,8 @@ const wallet: WalletMessages = {
   'wallet.vultisig.import.password.title': 'Vault पासवर्ड आवश्यक',
   'wallet.vultisig.import.password.description': 'यह vault एन्क्रिप्टेड है। कृपया पासवर्ड दर्ज करें।',
   'wallet.vultisig.export.password.title': 'Export Vault',
-  'wallet.vultisig.export.password.description': 'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
+  'wallet.vultisig.export.password.description':
+    'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
   'wallet.vultisig.import.success': 'Vault सफलतापूर्वक आयात किया गया',
   'wallet.vultisig.import.error': 'Vault आयात करने में विफल',
   'wallet.vultisig.import.error.invalidPassword': 'अमान्य पासवर्ड',
@@ -177,7 +180,8 @@ const wallet: WalletMessages = {
   'wallet.vultisig.secureCreate.vaultName.placeholder': 'मेरा सुरक्षित Vault',
   'wallet.vultisig.secureCreate.password.optional': 'पासवर्ड (वैकल्पिक)',
   'wallet.vultisig.secureCreate.password.placeholder': 'वैकल्पिक एन्क्रिप्शन पासवर्ड',
-  'wallet.vultisig.secureCreate.password.hint': 'यदि सेट किया गया, तो लेन-देन पर हस्ताक्षर के लिए यह पासवर्ड आवश्यक होगा।',
+  'wallet.vultisig.secureCreate.password.hint':
+    'यदि सेट किया गया, तो लेन-देन पर हस्ताक्षर के लिए यह पासवर्ड आवश्यक होगा।',
   'wallet.vultisig.secureCreate.enterName': 'कृपया vault का नाम दर्ज करें',
   'wallet.vultisig.secureCreate.submit': 'सुरक्षित Vault बनाएं',
   'wallet.vultisig.secureCreate.waitingQr': 'सुरक्षित vault सत्र शुरू हो रहा है...',

--- a/src/renderer/i18n/ko/wallet.ts
+++ b/src/renderer/i18n/ko/wallet.ts
@@ -63,6 +63,8 @@ const wallet: WalletMessages = {
   'wallet.txs.history': '거래 내역',
   'wallet.txs.history.disabled': '{chain}의 거래 내역이 일시적으로 비활성화되었습니다.',
   'wallet.create.copy.phrase': '시드 구문 복사',
+  'wallet.create.phrase.length': '복구 구문 길이',
+  'wallet.create.phrase.words': '{count}개 단어',
   'wallet.create.error.phrase.empty': '새 지갑을 생성하고 자금을 추가하세요.',
   'wallet.add.another': '다른 지갑 추가',
   'wallet.add.label': '지갑 추가',
@@ -133,7 +135,8 @@ const wallet: WalletMessages = {
   'wallet.vultisig.import.password.title': 'Vault 비밀번호 필요',
   'wallet.vultisig.import.password.description': '이 vault는 암호화되어 있습니다. 비밀번호를 입력해 주세요.',
   'wallet.vultisig.export.password.title': 'Export Vault',
-  'wallet.vultisig.export.password.description': 'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
+  'wallet.vultisig.export.password.description':
+    'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
   'wallet.vultisig.import.success': 'Vault를 성공적으로 가져왔습니다',
   'wallet.vultisig.import.error': 'Vault 가져오기 실패',
   'wallet.vultisig.import.error.invalidPassword': '잘못된 비밀번호',

--- a/src/renderer/i18n/ru/wallet.ts
+++ b/src/renderer/i18n/ru/wallet.ts
@@ -63,6 +63,8 @@ const wallet: WalletMessages = {
   'wallet.txs.history': 'История переводов',
   'wallet.txs.history.disabled': 'История транзакций для {chain} была временно отключена',
   'wallet.create.copy.phrase': 'Скопируйте фразу ниже',
+  'wallet.create.phrase.length': 'Длина мнемонической фразы',
+  'wallet.create.phrase.words': '{count} слов',
   'wallet.create.error.phrase.empty': 'Создать новый кошелёк с балансом',
   'wallet.add.another': 'Добавить еще один кошелёк',
   'wallet.add.label': 'Добавить кошелёк',
@@ -134,7 +136,8 @@ const wallet: WalletMessages = {
   'wallet.vultisig.import.password.title': 'Требуется пароль Vault',
   'wallet.vultisig.import.password.description': 'Этот vault зашифрован. Пожалуйста, введите пароль.',
   'wallet.vultisig.export.password.title': 'Export Vault',
-  'wallet.vultisig.export.password.description': 'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
+  'wallet.vultisig.export.password.description':
+    'Set a password to encrypt the backup file, or leave blank to export unencrypted.',
   'wallet.vultisig.import.success': 'Vault успешно импортирован',
   'wallet.vultisig.import.error': 'Не удалось импортировать vault',
   'wallet.vultisig.import.error.invalidPassword': 'Неверный пароль',
@@ -189,7 +192,8 @@ const wallet: WalletMessages = {
   'wallet.vultisig.secureCreate.waitingMore': 'Ожидание подключения других устройств...',
   'wallet.vultisig.secureCreate.allJoined': 'Все устройства подключены! ({joined}/{required})',
   'wallet.vultisig.secureCreate.runningKeygen': 'Генерация MPC-ключей...',
-  'wallet.vultisig.secureCreate.keepActive': 'Это может занять некоторое время. Пожалуйста, держите оба устройства активными.',
+  'wallet.vultisig.secureCreate.keepActive':
+    'Это может занять некоторое время. Пожалуйста, держите оба устройства активными.',
   'wallet.vultisig.secureCreate.success': 'Безопасный Vault создан!',
   'wallet.vultisig.secureCreate.cancelling': 'Отмена...',
   'wallet.vultisig.notImplemented': 'Эта функция пока недоступна для кошельков Vultisig',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -465,6 +465,8 @@ type WalletMessageKey =
   | 'wallet.create.error.phrase'
   | 'wallet.create.error.phrase.empty'
   | 'wallet.create.copy.phrase'
+  | 'wallet.create.phrase.length'
+  | 'wallet.create.phrase.words'
   | 'wallet.create.words.click'
   | 'wallet.create.enter.phrase'
   | 'wallet.receive.address.error'

--- a/src/renderer/services/wallet/util.test.ts
+++ b/src/renderer/services/wallet/util.test.ts
@@ -16,7 +16,8 @@ import {
   getBalanceByAsset,
   getWalletName,
   getLockedData,
-  getInitialKeystoreData
+  getInitialKeystoreData,
+  generateKeystoreId
 } from './util'
 
 describe('services/wallet/util/', () => {
@@ -308,6 +309,34 @@ describe('services/wallet/util/', () => {
           })
         )
       ).toBeTruthy()
+    })
+  })
+
+  describe('generateKeystoreId', () => {
+    // 48-bit CSPRNG value (6 bytes) — upper bound is exclusive of 2^48
+    const MAX = 2 ** 48
+
+    it('returns a non-negative integer within the safe range', () => {
+      const id = generateKeystoreId()
+      expect(typeof id).toBe('number')
+      expect(Number.isInteger(id)).toBe(true)
+      expect(id).toBeGreaterThanOrEqual(0)
+      expect(id).toBeLessThan(MAX)
+      // must stay representable as an exact JS integer
+      expect(id).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER)
+    })
+
+    it('produces varying values across calls (not a fixed or timestamp-based id)', () => {
+      const ids = Array.from({ length: 1000 }, () => generateKeystoreId())
+      // every value must satisfy the range invariant
+      ids.forEach((id) => {
+        expect(Number.isInteger(id)).toBe(true)
+        expect(id).toBeGreaterThanOrEqual(0)
+        expect(id).toBeLessThan(MAX)
+      })
+      // randomness: the vast majority of 1000 draws are unique (collisions in a
+      // 48-bit space are astronomically unlikely, so this is not flaky)
+      expect(new Set(ids).size).toBeGreaterThan(990)
     })
   })
 })

--- a/src/renderer/services/wallet/util.ts
+++ b/src/renderer/services/wallet/util.ts
@@ -90,11 +90,18 @@ export const getKeystoreWalletName: (id: KeystoreId) => (wallets: KeystoreWallet
       A.head
     )
 
-export const generateKeystoreId = (): KeystoreId =>
-  // id for keystore is current time (ms) at the time of importing
-  // Note: An user can import one keystore at time only
-  // and a keystore with same id can't be overridden. That's no duplications.
-  new Date().getTime()
+export const generateKeystoreId = (): KeystoreId => {
+  // Random 48-bit id derived from the OS CSPRNG (Web Crypto).
+  // Previously a millisecond timestamp (`Date.getTime()`) was used, which is
+  // predictable. A random id avoids that while staying a `number` so existing
+  // timestamp-based ids in `wallets.json` keep loading and matching unchanged.
+  // 48 bits stays well within `Number.MAX_SAFE_INTEGER` (2^53) and makes
+  // collisions negligible, preserving the "no duplicate ids" guarantee that
+  // keeps one keystore from overriding another.
+  const bytes = new Uint8Array(6)
+  globalThis.crypto.getRandomValues(bytes)
+  return bytes.reduce((acc, b) => acc * 256 + b, 0)
+}
 
 export const hasImportedKeystore = (state: KeystoreState): boolean => O.isSome(state)
 


### PR DESCRIPTION
## Summary

Two backwards-compatible wallet key-generation improvements surfaced by a security review of the keystore/phrase flow.

### 1. 24-word recovery phrase option
- Adds a **12 / 24-word** segmented toggle to the new-phrase generation screen.
- **Default stays 12 words** — no change to existing UX; 24 (256-bit entropy) is opt-in.
- The phrase-confirm step and grid were already length-agnostic, so 24 words flows through unchanged.
- New i18n keys `wallet.create.phrase.length` / `wallet.create.phrase.words` across all 7 locales.

### 2. Randomized keystore id
- Replaces `new Date().getTime()` in `generateKeystoreId()` with a 48-bit CSPRNG value (`crypto.getRandomValues`).
- Stays a `number`, so existing timestamp-based ids in `wallets.json` keep loading and matching — **fully backwards compatible**. 48 bits keeps it under `Number.MAX_SAFE_INTEGER` while making collisions negligible.

## Testing
- `tsc --noEmit` clean (for files in this PR); `eslint`/`prettier` clean.
- Full vitest suite: 877 passed, 2 skipped.
- **Manual E2E:** created a 24-word wallet → unlocked → viewed phrase in wallet settings; the mnemonic round-tripped correctly (exercises generate → encrypt → save with the new random id → unlock → decrypt).

## Notes
- Related upstream `@xchainjs/xchain-crypto` findings from the same review were filed separately: xchainjs/xchainjs-lib#1720 (AES-128 vs AES-256) and xchainjs/xchainjs-lib#1721 (IV not in MAC). The PBKDF2 iteration concern is already resolved upstream in v1.0.7 (600k).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery phrase generation now lets you choose between 12 or 24 words.
  * Added translated text for the phrase length and word count across supported languages.

* **Bug Fixes**
  * Refreshing a recovery phrase now keeps the selected word count.
  * Keystore IDs are now generated randomly, improving uniqueness and reducing predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->