### PR TITLE
style(header): add hover feedback to mobile drawer menu rows

### DIFF
--- a/src/renderer/components/header/HeaderComponent.tsx
+++ b/src/renderer/components/header/HeaderComponent.tsx
@@ -197,7 +197,7 @@ export const HeaderComponent = (props: Props): JSX.Element => {
         <Link key={key} to={path} onClick={closeMenu}>
           <div
             className={clsx(
-              'flex h-[60px] items-center border-b border-solid border-bg2 dark:border-bg2d',
+              'flex h-[60px] cursor-pointer items-center border-b border-solid border-bg2 transition-colors hover:bg-turquoise/10 dark:border-bg2d',
               activeKey === key ? 'text-turquoise' : 'text-text1 dark:text-text1d',
               { 'border-t': index === 0 }
             )}>
@@ -336,13 +336,13 @@ export const HeaderComponent = (props: Props): JSX.Element => {
           isOpen={menuVisible}
           onClose={() => setMenuVisible(false)}>
           {links}
-          <div className="flex h-[60px] items-center border-b border-solid border-bg2 dark:border-bg2d">
+          <div className="flex h-[60px] cursor-pointer items-center border-b border-solid border-bg2 transition-colors hover:bg-turquoise/10 dark:border-bg2d">
             {renderHeaderCurrency}
           </div>
-          <div className="flex h-[60px] items-center border-b border-solid border-bg2 dark:border-bg2d">
+          <div className="flex h-[60px] cursor-pointer items-center border-b border-solid border-bg2 transition-colors hover:bg-turquoise/10 dark:border-bg2d">
             <HeaderTheme isDesktopView={isDesktopView} />
           </div>
-          <div className="flex h-[60px] items-center border-b border-solid border-bg2 dark:border-bg2d">
+          <div className="flex h-[60px] cursor-pointer items-center border-b border-solid border-bg2 transition-colors hover:bg-turquoise/10 dark:border-bg2d">
             <HeaderLockMobile
               hasWallet={allWallets.length > 0}
               isLocked={isLocked}
@@ -350,7 +350,7 @@ export const HeaderComponent = (props: Props): JSX.Element => {
               activeWallet={activeWallet}
             />
           </div>
-          <div className="flex h-[60px] items-center border-b border-solid border-bg2 dark:border-bg2d">
+          <div className="flex h-[60px] cursor-pointer items-center border-b border-solid border-bg2 transition-colors hover:bg-turquoise/10 dark:border-bg2d">
             {renderHeaderSettings}
           </div>
           {renderHeaderNetStatus}


### PR DESCRIPTION
## Summary

In the mobile header drawer, the menu rows had inconsistent hover feedback: **POOLS / WALLET** are `<Link>` anchors so they got a pointer cursor for free, while **CURRENCY / DAY MODE / LOCK WALLET / SETTINGS** were plain `<div>`s with no cursor change and no hover shade — hovering them gave no visual response.

This gives every row in the drawer the same feedback:
- `cursor-pointer` → finger cursor on hover
- `hover:bg-turquoise/10` → subtle on-brand shade
- `transition-colors` → smooth fade

POOLS/WALLET keep their active-state `text-turquoise` on top (merged via `clsx`).

## Testing
- `tsc --noEmit` clean, `eslint`/`prettier` clean.
- Visual-only change to the mobile drawer; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)