### PR TITLE
fix(tron): resolve swap fees for Vultisig/Ledger wallets

### DIFF
--- a/src/renderer/services/tron/fees.ts
+++ b/src/renderer/services/tron/fees.ts
@@ -1,8 +1,66 @@
+import * as RD from '@devexperts/remote-data-ts'
 import { TRONChain } from '@xchainjs/xchain-tron'
+import { Address } from '@xchainjs/xchain-util'
+import { function as FP, option as O } from 'fp-ts'
+import * as Rx from 'rxjs'
+import * as RxOp from 'rxjs/operators'
 
-import * as C from '../clients'
+import { triggerStream } from '../../helpers/stateHelper'
+import { FeesLD, FeesService } from '../clients'
+import { appWalletService } from '../wallet/appWallet'
 import { Client$ } from './types'
 
-export const createFeesService = (client$: Client$) => {
-  return C.createFeesService({ client$, chain: TRONChain })
+/**
+ * TRON `FeesService`.
+ *
+ * Unlike most chains, TRON fees are dynamic and sender-dependent (bandwidth,
+ * energy and a one-time account-activation fee), so `getFees` needs a sender
+ * address. The generic `clients/fees.ts` derives that address from the keystore
+ * phrase via `client.getAddressAsync()` — which throws `"Phrase must be
+ * provided"` for phrase-less wallets (Vultisig, standalone Ledger), tearing
+ * down the whole `fees$` stream and leaving the swap fee unresolved (the Swap
+ * button then stays disabled).
+ *
+ * Instead we resolve the sender in a wallet-type-aware way: prefer the
+ * wallet-derived address from `appWalletService.getAddressForChain$` (populated
+ * for Vultisig / standalone Ledger; `O.none` for keystore) and only fall back
+ * to `client.getAddressAsync()` for keystore wallets. Any lookup failure
+ * degrades to `RD.failure` rather than killing the stream.
+ */
+export const createFeesService = (client$: Client$): FeesService => {
+  const { stream$: reloadFees$, trigger: reloadFees } = triggerStream()
+
+  // Derived address for phrase-less modes (Vultisig / standalone Ledger).
+  // `O.none` in keystore mode, where the client derives it from the phrase.
+  const walletAddress$ = appWalletService.getAddressForChain$(TRONChain)
+
+  const fees$ = (): FeesLD =>
+    Rx.combineLatest([reloadFees$, client$, walletAddress$]).pipe(
+      RxOp.switchMap(([_, oClient, oWalletAddress]) =>
+        FP.pipe(
+          oClient,
+          O.fold(
+            () => Rx.of(RD.failure(new Error('Client not found'))),
+            (client) =>
+              FP.pipe(
+                oWalletAddress,
+                O.fold(
+                  // Keystore: derive from the phrase via the client
+                  () => Rx.defer(() => Rx.from(client.getAddressAsync())),
+                  // Vultisig / standalone Ledger: use the already-derived address
+                  (address: Address) => Rx.of(address)
+                ),
+                RxOp.switchMap((sender: Address) => Rx.from(client.getFees({ sender })).pipe(RxOp.map(RD.success))),
+                RxOp.catchError((error) => Rx.of(RD.failure(error)))
+              )
+          )
+        )
+      ),
+      RxOp.startWith(RD.pending)
+    )
+
+  return {
+    fees$,
+    reloadFees
+  }
 }


### PR DESCRIPTION
## Summary

Swapping **from TRON** with a **Vultisig vault** (or a standalone Ledger) leaves the **Swap button permanently disabled**, even with a valid THORChain quote. Root cause is source-chain **fee estimation**, not routing.

## Root cause

TRON fees are **dynamic and sender-dependent** (bandwidth, energy, one-time account-activation), so `getFees` requires a sender address. The shared `clients/fees.ts` derived that address via:

```js
Rx.from(client.getAddressAsync())   // derives address FROM the keystore phrase
```

Phrase-less wallets (Vultisig, standalone Ledger) use the read-only client, which has **no mnemonic**, so `getAddressAsync()` throws `"Phrase must be provided"`. Because that call sits **outside** the `catchError`, the throw tears down the entire `fees$` stream → `swapFeesRD` never resolves → `disableSubmit` stays `true` → button greyed out.

Swapping **from RUNE** was unaffected: THORChain's fee service calls `getFees()` with **no sender** and never derives an address.

## Fix

Add a TRON-specific `createFeesService` that resolves the sender in a **wallet-type-aware** way:

- **Vultisig / standalone Ledger** → use the already-derived address from `appWalletService.getAddressForChain$(TRONChain)` (the same source PR #1118 used for balances).
- **Keystore** → `getAddressForChain$` returns `O.none`, so fall back to `client.getAddressAsync()` — unchanged behavior.

The `catchError` now wraps the whole address+fee chain, so any future lookup failure degrades to `RD.failure` instead of killing the stream.

## Test plan

- [x] `tsc --noEmit` clean (0 errors)
- [x] Lint clean
- [x] **Vultisig vault, TRON → RUNE**: Swap button now **enabled**; no `"Phrase must be provided"` in console; source-chain fee resolves (tested live in dev)
- [ ] Keystore wallet, TRON → RUNE: still works (regression check)
- [ ] Standalone Ledger, TRON → RUNE: fee resolves

## Notes

The underlying gap (unguarded `getAddressAsync()` in the shared `clients/fees.ts`) could affect any chain with sender-dependent fees used in a phrase-less mode. This PR fixes TRON specifically, mirroring the existing per-chain fee-service override pattern (see `thorchain/fees.ts`, `ethereum/fees.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TRON fee loading to use the correct sender address in more wallet setups, including keystore and standalone Ledger flows.
  * Fee updates now handle errors more gracefully and continue refreshing instead of stopping the fee stream.
  * Users should see more reliable and accurate fee estimates when preparing TRON transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->