### PR TITLE
fix(vultisig): don't re-prompt for vault password once unlocked

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -89,7 +89,8 @@ import {
   WalletBalances,
   isKeystoreMode,
   isStandaloneLedgerMode,
-  isVultisigMode
+  isVultisigMode,
+  isVultisigVaultPasswordRequired
 } from '../../services/wallet/types'
 import { useCoingecko } from '../../store/gecko/hooks'
 import { AssetWithAmount } from '../../types/asgardex'
@@ -1277,12 +1278,13 @@ export const Swap = ({
     return 'fast'
   }, [appWalletState])
 
-  const isVaultEncrypted: boolean = useMemo(() => {
-    if (appWalletState && isVultisigMode(appWalletState) && appWalletState.activeVault) {
-      return appWalletState.activeVault.isEncrypted
-    }
-    return true // Default to encrypted (safe fallback — will show password prompt)
-  }, [appWalletState])
+  // Whether the Vultisig modal must prompt for the vault password. Skips the
+  // redundant prompt once the vault is already unlocked for the session
+  // (see `isVultisigVaultPasswordRequired`).
+  const isVaultEncrypted: boolean = useMemo(
+    () => (appWalletState ? isVultisigVaultPasswordRequired(appWalletState) : true),
+    [appWalletState]
+  )
 
   // Password validation for Vultisig
   const validatePasswordForVultisig = useCallback(

--- a/src/renderer/components/wallet/txs/send/SendForm.tsx
+++ b/src/renderer/components/wallet/txs/send/SendForm.tsx
@@ -77,6 +77,7 @@ import {
 import { FeesWithRatesRD } from '../../../../services/utxo/types'
 import {
   isVultisigMode,
+  isVultisigVaultPasswordRequired,
   SelectedWalletAsset,
   ValidatePasswordHandler,
   VaultType,
@@ -171,12 +172,13 @@ export const SendForm = (props: Props): JSX.Element => {
     return 'fast'
   }, [appWalletState])
 
-  const isVaultEncrypted: boolean = useMemo(() => {
-    if (appWalletState && isVultisigMode(appWalletState) && appWalletState.activeVault) {
-      return appWalletState.activeVault.isEncrypted
-    }
-    return true
-  }, [appWalletState])
+  // Whether the Vultisig modal must prompt for the vault password. Skips the
+  // redundant prompt once a fast vault is already unlocked for the session
+  // (see `isVultisigVaultPasswordRequired`).
+  const isVaultEncrypted: boolean = useMemo(
+    () => (appWalletState ? isVultisigVaultPasswordRequired(appWalletState) : true),
+    [appWalletState]
+  )
 
   const { asset } = balance
 

--- a/src/renderer/services/wallet/types.test.ts
+++ b/src/renderer/services/wallet/types.test.ts
@@ -10,6 +10,7 @@ import {
   isKeystoreMode,
   isStandaloneLedgerMode,
   isVultisigVaultLocked,
+  isVultisigVaultPasswordRequired,
   getWalletTypeFromState,
   isKeystoreReloadTrigger
 } from './types'
@@ -107,6 +108,49 @@ describe('services/wallet/types', () => {
     })
     it('returns false when phase is vault-selection', () => {
       expect(isVultisigVaultLocked(vultisigSelection)).toBe(false)
+    })
+  })
+
+  describe('isVultisigVaultPasswordRequired', () => {
+    const fastActiveEncrypted: VultisigState = {
+      ...vultisigActive,
+      activeVault: { id: 'v', name: 'V', type: 'fast', isEncrypted: true, chains: [] }
+    }
+    const fastLockedEncrypted: VultisigState = {
+      mode: 'standalone-vultisig',
+      phase: VultisigPhase.VaultLocked,
+      availableVaults: [],
+      activeVault: { id: 'v', name: 'V', type: 'fast', isEncrypted: true, chains: [] },
+      addresses: {}
+    }
+    const secureActiveEncrypted: VultisigState = {
+      ...vultisigActive,
+      activeVault: { id: 'v', name: 'V', type: 'secure', isEncrypted: true, chains: [] }
+    }
+
+    it('skips the prompt for an already-active encrypted fast vault', () => {
+      expect(isVultisigVaultPasswordRequired(fastActiveEncrypted)).toBe(false)
+    })
+    it('skips the prompt for an already-active encrypted secure vault (co-signer authorizes)', () => {
+      expect(isVultisigVaultPasswordRequired(secureActiveEncrypted)).toBe(false)
+    })
+    it('prompts for a still-locked encrypted fast vault', () => {
+      expect(isVultisigVaultPasswordRequired(fastLockedEncrypted)).toBe(true)
+    })
+    it('prompts for a still-locked encrypted secure vault', () => {
+      // vultisigLocked is a secure, encrypted vault in the VaultLocked phase
+      expect(isVultisigVaultPasswordRequired(vultisigLocked)).toBe(true)
+    })
+    it('never prompts for an un-encrypted vault', () => {
+      // vultisigActive is a fast, un-encrypted vault
+      expect(isVultisigVaultPasswordRequired(vultisigActive)).toBe(false)
+    })
+    it('falls back to prompting when there is no active vault', () => {
+      expect(isVultisigVaultPasswordRequired(vultisigSelection)).toBe(true)
+    })
+    it('falls back to prompting for non-Vultisig states', () => {
+      expect(isVultisigVaultPasswordRequired(keystoreUnlocked)).toBe(true)
+      expect(isVultisigVaultPasswordRequired(ledgerState)).toBe(true)
     })
   })
 

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -79,6 +79,36 @@ export const isVultisigMode = (state: AppWalletState): state is VultisigState =>
 
 export const isVultisigVaultLocked = (state: VultisigState): boolean => state.phase === VultisigPhase.VaultLocked
 
+/**
+ * Whether the Vultisig confirmation modal should ask for the vault password
+ * before signing.
+ *
+ * The vault's static `isEncrypted` flag over-prompts on its own: it stays `true`
+ * for the whole life of a password-protected vault, so every swap/send re-shows
+ * the password field even when the vault is already unlocked for the session.
+ *
+ * Once a vault is unlocked (`phase === Active`) we should never ask for the
+ * password again on a transaction — regardless of vault type:
+ * - Fast vaults (1-of-1) already have the key share loaded, so re-entry is pure
+ *   theatre (`validatePassword` short-circuits to a non-empty check without even
+ *   calling the SDK).
+ * - Secure vaults (multi-device) cannot submit anything without the co-signer
+ *   device (e.g. phone) completing the MPC ceremony, which is the real
+ *   authorization — so the desktop password re-entry is redundant there too.
+ *
+ * - Not Vultisig / no active vault → `true` (safe default; callers only render
+ *   the Vultisig modal in Vultisig mode anyway).
+ * - Un-encrypted vault → `false` (nothing to unlock).
+ * - Vault already `Active` (unlocked this session) → `false`.
+ * - Encrypted vault not yet unlocked → `true` (password needed to unlock).
+ */
+export const isVultisigVaultPasswordRequired = (state: AppWalletState): boolean => {
+  if (!isVultisigMode(state) || !state.activeVault) return true
+  if (!state.activeVault.isEncrypted) return false
+  if (state.phase === VultisigPhase.Active) return false
+  return true
+}
+
 export const isKeystoreMode = (state: AppWalletState): state is KeystoreState =>
   !isStandaloneLedgerMode(state) && !isVultisigMode(state)
 

--- a/src/renderer/views/pools/detail/TradingPanel.tsx
+++ b/src/renderer/views/pools/detail/TradingPanel.tsx
@@ -50,7 +50,7 @@ import { getPoolDetail as getPoolDetailMaya } from '../../../services/midgard/ma
 import { PoolsState, PoolDetails } from '../../../services/midgard/midgardTypes'
 import { getPoolDetail } from '../../../services/midgard/thorMidgard/utils'
 import type { PriceLevel } from '../../../services/priceLevel/types'
-import { isStandaloneLedgerMode, isVultisigMode } from '../../../services/wallet/types'
+import { isStandaloneLedgerMode, isVultisigMode, isVultisigVaultPasswordRequired } from '../../../services/wallet/types'
 import type { VaultType } from '../../../services/wallet/types'
 import { hasImportedKeystore } from '../../../services/wallet/util'
 import { TradingPanelBar, type TradeMode } from './TradingPanelBar'
@@ -501,12 +501,13 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
     return 'fast'
   }, [appWalletState])
 
-  const isVaultEncrypted: boolean = useMemo(() => {
-    if (appWalletState && isVultisigMode(appWalletState) && appWalletState.activeVault) {
-      return appWalletState.activeVault.isEncrypted
-    }
-    return true
-  }, [appWalletState])
+  // Whether the Vultisig modal must prompt for the vault password. Skips the
+  // redundant prompt once a fast vault is already unlocked for the session
+  // (see `isVultisigVaultPasswordRequired`).
+  const isVaultEncrypted: boolean = useMemo(
+    () => (appWalletState ? isVultisigVaultPasswordRequired(appWalletState) : true),
+    [appWalletState]
+  )
 
   const validatePasswordForVultisig = useCallback(
     async (password: string): Promise<boolean> => {


### PR DESCRIPTION
The confirmation modal gated the password prompt on the vault's static `isEncrypted` flag, which stays true for the whole life of a password-protected vault. So every swap/send re-showed the password field even though the vault was already unlocked for the session — redundant for fast vaults (share already loaded; the prompt didn't even re-validate) and for secure vaults (the co-signer device authorizes the MPC ceremony regardless).

Add `isVultisigVaultPasswordRequired`: prompt only when the vault is encrypted AND not yet unlocked (phase !== Active). Once Active, any vault type skips the prompt and goes straight to signing. Centralizes the logic used by Swap, Send and the pool TradingPanel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vault password prompts during swaps, sends, and pool trades.
  * Fast vaults that are already unlocked no longer show a redundant password prompt.
  * Locked encrypted vaults continue to require password confirmation.
  * Unencrypted vaults can proceed without an unnecessary prompt.

* **Tests**
  * Added coverage for password prompt behavior across supported wallet and vault states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->