### PR TITLE
fix(fees): don't hang fee estimation for phrase-less wallets

### DIFF
--- a/src/renderer/services/clients/fees.test.ts
+++ b/src/renderer/services/clients/fees.test.ts
@@ -1,0 +1,82 @@
+import * as RD from '@devexperts/remote-data-ts'
+import { FeeType, singleFee, XChainClient } from '@xchainjs/xchain-client'
+import { BTCChain } from '@xchainjs/xchain-bitcoin'
+import { baseAmount } from '@xchainjs/xchain-util'
+import { option as O } from 'fp-ts'
+import * as Rx from 'rxjs'
+import * as RxOp from 'rxjs/operators'
+
+import { createFeesService } from './fees'
+import { XChainClient$ } from './types'
+
+const FEES = singleFee(FeeType.FlatFee, baseAmount(1000))
+
+// Collect the pending emission + the first resolved (non-pending) emission.
+const resolve = (client$: XChainClient$) => {
+  const { fees$ } = createFeesService({ client$, chain: BTCChain })
+  return Rx.firstValueFrom(
+    fees$().pipe(
+      RxOp.filter((rd) => !RD.isPending(rd)),
+      RxOp.take(1)
+    )
+  )
+}
+
+describe('services/clients/fees', () => {
+  it('resolves fees for a keystore client (address derived, passed as sender)', async () => {
+    const getFees = vi.fn().mockResolvedValue(FEES)
+    const client = {
+      getAddressAsync: vi.fn().mockResolvedValue('addr-1'),
+      getFees
+    } as unknown as XChainClient
+
+    const result = await resolve(Rx.of(O.some(client)))
+
+    expect(result).toEqual(RD.success(FEES))
+    expect(getFees).toHaveBeenCalledWith({ sender: 'addr-1' })
+  })
+
+  it('falls back to a sender-less getFees when the client has no phrase (XRP-like)', async () => {
+    // Phrase-less read-only client (Vultisig / standalone Ledger): getAddressAsync
+    // throws, but getFees does not need a sender and still returns a real fee.
+    const getFees = vi.fn().mockResolvedValue(FEES)
+    const client = {
+      getAddressAsync: vi.fn().mockRejectedValue(new Error('Phrase must be provided')),
+      getFees
+    } as unknown as XChainClient
+
+    const result = await resolve(Rx.of(O.some(client)))
+
+    expect(result).toEqual(RD.success(FEES))
+    // called with no sender, NOT with { sender: ... }
+    expect(getFees).toHaveBeenCalledWith()
+  })
+
+  it('degrades to RD.failure (not stuck pending) when the fee itself needs a sender (TRON-like)', async () => {
+    // Phrase-less client AND a fee that cannot be computed without a signer:
+    // must surface a Failure — never leave the stream hanging on `pending`.
+    const client = {
+      getAddressAsync: vi.fn().mockRejectedValue(new Error('Phrase must be provided')),
+      getFees: vi.fn().mockRejectedValue(new Error('Params need to be passed'))
+    } as unknown as XChainClient
+
+    const result = await resolve(Rx.of(O.some(client)))
+
+    expect(RD.isFailure(result)).toBe(true)
+  })
+
+  it('emits RD.failure when no client is available', async () => {
+    const result = await resolve(Rx.of(O.none))
+    expect(RD.isFailure(result)).toBe(true)
+  })
+
+  it('starts with RD.pending', async () => {
+    const client = {
+      getAddressAsync: vi.fn().mockResolvedValue('addr-1'),
+      getFees: vi.fn().mockResolvedValue(FEES)
+    } as unknown as XChainClient
+    const { fees$ } = createFeesService({ client$: Rx.of(O.some(client)), chain: BTCChain })
+    const first = await Rx.firstValueFrom(fees$())
+    expect(RD.isPending(first)).toBe(true)
+  })
+})

--- a/src/renderer/services/clients/fees.test.ts
+++ b/src/renderer/services/clients/fees.test.ts
@@ -1,6 +1,6 @@
 import * as RD from '@devexperts/remote-data-ts'
-import { FeeType, singleFee, XChainClient } from '@xchainjs/xchain-client'
 import { BTCChain } from '@xchainjs/xchain-bitcoin'
+import { FeeType, singleFee, XChainClient } from '@xchainjs/xchain-client'
 import { baseAmount } from '@xchainjs/xchain-util'
 import { option as O } from 'fp-ts'
 import * as Rx from 'rxjs'

--- a/src/renderer/services/clients/fees.ts
+++ b/src/renderer/services/clients/fees.ts
@@ -1,5 +1,5 @@
 import * as RD from '@devexperts/remote-data-ts'
-import { Chain } from '@xchainjs/xchain-util'
+import { Address, Chain } from '@xchainjs/xchain-util'
 import { function as FP, option as O } from 'fp-ts'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
@@ -25,16 +25,34 @@ export const createFeesService = ({ client$ }: { client$: XChainClient$; chain: 
           oClient,
           O.fold(
             () => Rx.of(RD.failure(new Error('Client not found'))),
-            (client) => {
-              return Rx.from(client.getAddressAsync()).pipe(
-                RxOp.switchMap((address) =>
-                  Rx.from(client.getFees({ sender: address })).pipe(
+            (client) =>
+              // Derive the sender address used for fee estimation. Phrase-less
+              // clients (the read-only client used in Vultisig / standalone-Ledger
+              // mode) throw `'Phrase must be provided'` here. Catch it instead of
+              // letting the throw tear down the whole `fees$` stream — otherwise
+              // `fees$` never advances past `pending` and fee-gated UI (e.g. the
+              // swap "Swap" button) stays disabled. When no sender is available we
+              // fall back to a sender-less `getFees()`: chains whose fee is not
+              // sender-dependent (e.g. XRP) still return a real fee; sender-
+              // dependent chains surface `RD.failure` rather than hanging.
+              Rx.from(client.getAddressAsync()).pipe(
+                RxOp.map((address): O.Option<Address> => O.some(address)),
+                RxOp.catchError(() => Rx.of(O.none as O.Option<Address>)),
+                RxOp.switchMap((oSender) =>
+                  Rx.from(
+                    FP.pipe(
+                      oSender,
+                      O.fold(
+                        () => client.getFees(),
+                        (sender) => client.getFees({ sender })
+                      )
+                    )
+                  ).pipe(
                     RxOp.map(RD.success),
                     RxOp.catchError((error) => Rx.of(RD.failure(error)))
                   )
                 )
               )
-            }
           )
         )
       ),


### PR DESCRIPTION
## Summary

Swapping **from TRON or XRP** with a **Vultisig vault** (or a standalone Ledger) left the **Swap button permanently disabled**, even with a valid quote. The root cause is source-chain **fee estimation**, not routing.

## Root cause

The shared fee service (`services/clients/fees.ts`) called `client.getAddressAsync()` **unconditionally** before fetching fees. Phrase-less wallets (Vultisig / standalone Ledger) use a read-only client with no mnemonic, so that call throws `"Phrase must be provided"`. Because the throw sat **outside** any `catchError`, it tore down the whole `fees$` stream — so `fees$` never advanced past `pending`, and `RD.isPending(swapFeesRD)` kept the Swap button disabled forever.

Swapping **from RUNE** was unaffected: THORChain's fee service calls `getFees()` with no sender and never derives an address.

## Fix

Guard the address derivation in the shared service: if `getAddressAsync()` throws, fall back to a **sender-less** `getFees()` instead of killing the stream.

- Chains whose fee is **not** sender-dependent (e.g. **XRP**) still return a real fee.
- Sender-dependent chains (e.g. **TRON**) surface `RD.failure` rather than hanging, so the button enables.
- **Keystore mode is unchanged** — the address derives normally and is passed as `sender`.

Because the fix lives in the shared service, it covers **TRON and XRP** together (and any future chain wired with `enhancedClient$`) rather than patching a single chain.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Lint clean (Trunk)
- [x] New unit tests in `services/clients/fees.test.ts`: keystore success (sender passed), sender-less fallback (XRP-like → real fee), `RD.failure` not stuck `pending` (TRON-like), no-client failure, starts-`pending`
- [x] Manual: Vultisig vault, **TRON → RUNE** and **XRP → RUNE** — Swap button enables

## Relation to #1133

#1133 targets the same bug for **TRON only**, by passing the wallet address as `sender`. The TRON SDK's `getFees` ignores `sender` and re-derives the address internally via `getAddressAsync`, so that approach still throws for phrase-less clients and doesn't yield a real fee. This PR fixes the root cause in the shared service and additionally covers XRP, so it supersedes #1133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fee estimation when a sender address cannot be derived.
  * Fee estimation now uses a sender-less fallback when supported.
  * Prevented fee requests from staying pending or failing when address lookup or fee computation encounters errors.
* **Tests**
  * Added coverage for success, fallback behavior, initial pending state, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->