### PR TITLE
fix(vultisig): re-prompt on expired password cache + center confirm m…

### DIFF
--- a/src/main/api/mpc/index.ts
+++ b/src/main/api/mpc/index.ts
@@ -481,6 +481,25 @@ export function registerMpcIpcHandlers(ipcMain: IpcMain): void {
     }
   })
 
+  // Whether the vault can currently sign without a fresh password prompt, i.e.
+  // its password is still cached and not expired. `getUnlockTimeRemaining()`
+  // tracks exactly the password-cache TTL, so `> 0` means a signing request
+  // won't hit an `onPasswordRequired` cache miss. Fails safe to `false` (prompt).
+  ipcMain.handle(MpcIPCMessages.MPC_IS_VAULT_UNLOCKED, async (_event, vaultId: string) => {
+    try {
+      assertString(vaultId, 'vaultId')
+      if (!isSDKInitialized()) return false
+      const sdk = getSDK()
+      const vault = await sdk.getVaultById(vaultId)
+      if (!vault) return false
+      const remaining = vault.getUnlockTimeRemaining()
+      return typeof remaining === 'number' && remaining > 0
+    } catch (error) {
+      log.warn(`[MPC IPC] isVaultUnlocked check failed for ${vaultId}:`, errorMsg(error))
+      return false
+    }
+  })
+
   // ============================================
   // Transaction Signing
   // ============================================

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -124,6 +124,7 @@ const apiMpc: ApiMpc = {
   // Vault Lock/Unlock
   lockVault: (vaultId) => ipcRenderer.invoke(MpcIPCMessages.MPC_LOCK_VAULT, vaultId),
   unlockVault: (vaultId, password) => ipcRenderer.invoke(MpcIPCMessages.MPC_UNLOCK_VAULT, vaultId, password),
+  isVaultUnlocked: (vaultId) => ipcRenderer.invoke(MpcIPCMessages.MPC_IS_VAULT_UNLOCKED, vaultId),
 
   // Transaction Signing
   signBytes: (params) => ipcRenderer.invoke(MpcIPCMessages.MPC_SIGN_BYTES, params),

--- a/src/renderer/components/modal/confirmation/VultisigConfirmationModal.tsx
+++ b/src/renderer/components/modal/confirmation/VultisigConfirmationModal.tsx
@@ -21,7 +21,7 @@ import { Label } from '../../uielements/label'
 import { QRCode } from '../../uielements/qrCode/QRCode'
 
 type VaultType = 'fast' | 'secure'
-type Phase = 'password' | 'waiting-qr' | 'qr-ready' | 'device-joined' | 'signing' | 'error'
+type Phase = 'checking' | 'password' | 'waiting-qr' | 'qr-ready' | 'device-joined' | 'signing' | 'error'
 
 type Props = {
   visible: boolean
@@ -89,26 +89,51 @@ export const VultisigConfirmationModal = ({
 
   // Reset state when modal opens
   useEffect(() => {
-    if (visible) {
-      setPassword('')
-      setPasswordError(null)
-      setQrPayload(null)
-      setDevicesJoined(0)
-      setIsValidating(false)
-      setIsCancelling(false)
-      setTxErrorMsg(null)
-      signingStartedRef.current = false
-      closedRef.current = false
+    if (!visible) return
 
-      if (!isEncrypted) {
-        // No password needed — skip straight to signing
-        // Secure: modal stays open for QR/device flow
-        // Fast: parent closes modal immediately via onSuccess callback
-        setPhase(vaultType === 'secure' ? 'waiting-qr' : 'signing')
-        onSuccess()
+    setPassword('')
+    setPasswordError(null)
+    setQrPayload(null)
+    setDevicesJoined(0)
+    setIsValidating(false)
+    setIsCancelling(false)
+    setTxErrorMsg(null)
+    signingStartedRef.current = false
+    closedRef.current = false
+
+    // Skip straight to signing without asking for the password.
+    // Secure: modal stays open for the QR/device flow. Fast: parent closes the
+    // modal immediately via onSuccess.
+    const skipToSigning = () => {
+      setPhase(vaultType === 'secure' ? 'waiting-qr' : 'signing')
+      onSuccess()
+    }
+
+    if (!isEncrypted) {
+      // Un-encrypted vault — no password ever needed.
+      skipToSigning()
+      return
+    }
+
+    // Encrypted vault: only prompt when the SDK's password cache has actually
+    // expired (idle > TTL). While it's still cached, re-entering the password is
+    // redundant; skipping it also avoids the "Password required" cache-miss that
+    // occurs when signing after the app has sat idle. `phase` alone can't tell us
+    // this — only the SDK knows the live cache state.
+    setPhase('checking')
+    let cancelled = false
+    const vaultId = getActiveVaultId()
+    ;(async () => {
+      const stillUnlocked = vaultId ? await window.apiMpc.isVaultUnlocked(vaultId).catch(() => false) : false
+      if (cancelled) return
+      if (stillUnlocked) {
+        skipToSigning()
       } else {
         setPhase('password')
       }
+    })()
+    return () => {
+      cancelled = true
     }
   }, [visible]) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -220,8 +245,8 @@ export const VultisigConfirmationModal = ({
   const [isCancelling, setIsCancelling] = useState(false)
 
   const handleCancel = useCallback(async () => {
-    if (phase === 'password' || phase === 'error') {
-      // Password phase or failed tx - nothing to abort, just close
+    if (phase === 'checking' || phase === 'password' || phase === 'error') {
+      // Cache check, password phase, or failed tx - nothing to abort, just close
       onCancel?.()
       onClose()
       return
@@ -264,6 +289,15 @@ export const VultisigConfirmationModal = ({
 
   // Render content based on phase
   const renderContent = () => {
+    if (phase === 'checking') {
+      // Brief state while we ask the SDK whether the password is still cached.
+      return (
+        <div className="flex flex-col items-center gap-4">
+          <div className="h-12 w-12 animate-spin rounded-full border-4 border-turquoise border-t-transparent" />
+        </div>
+      )
+    }
+
     if (phase === 'password') {
       return (
         <div className="flex flex-col items-center gap-4">
@@ -357,7 +391,9 @@ export const VultisigConfirmationModal = ({
     // The handleCancel callback controls when closing is allowed
     <Dialog static as="div" className="relative z-10" open={visible} onClose={handleCancel}>
       <DialogBackdrop className="fixed inset-0 bg-bg0/40 dark:bg-bg0d/40" />
-      <div className="fixed inset-0 flex items-center justify-center p-4">
+      {/* `lg:pl-[240px]` offsets the sidebar so the panel centers within the
+          content area, matching `UnifiedTxModal` (the tx-tracking modal). */}
+      <div className="fixed inset-0 flex items-center justify-center p-4 lg:pl-[240px]">
         <DialogPanel
           className={clsx(
             'mx-auto flex flex-col items-center p-6',

--- a/src/renderer/services/wallet/types.test.ts
+++ b/src/renderer/services/wallet/types.test.ts
@@ -112,43 +112,28 @@ describe('services/wallet/types', () => {
   })
 
   describe('isVultisigVaultPasswordRequired', () => {
-    const fastActiveEncrypted: VultisigState = {
-      ...vultisigActive,
-      activeVault: { id: 'v', name: 'V', type: 'fast', isEncrypted: true, chains: [] }
-    }
-    const fastLockedEncrypted: VultisigState = {
-      mode: 'standalone-vultisig',
-      phase: VultisigPhase.VaultLocked,
-      availableVaults: [],
-      activeVault: { id: 'v', name: 'V', type: 'fast', isEncrypted: true, chains: [] },
-      addresses: {}
-    }
-    const secureActiveEncrypted: VultisigState = {
+    // Reports whether the vault is password-protected (encrypted), independent of
+    // phase. The live "is the cache still warm?" decision lives in the modal.
+    const encryptedActive: VultisigState = {
       ...vultisigActive,
       activeVault: { id: 'v', name: 'V', type: 'secure', isEncrypted: true, chains: [] }
     }
 
-    it('skips the prompt for an already-active encrypted fast vault', () => {
-      expect(isVultisigVaultPasswordRequired(fastActiveEncrypted)).toBe(false)
+    it('is true for an encrypted vault (Active)', () => {
+      expect(isVultisigVaultPasswordRequired(encryptedActive)).toBe(true)
     })
-    it('skips the prompt for an already-active encrypted secure vault (co-signer authorizes)', () => {
-      expect(isVultisigVaultPasswordRequired(secureActiveEncrypted)).toBe(false)
-    })
-    it('prompts for a still-locked encrypted fast vault', () => {
-      expect(isVultisigVaultPasswordRequired(fastLockedEncrypted)).toBe(true)
-    })
-    it('prompts for a still-locked encrypted secure vault', () => {
+    it('is true for an encrypted vault (VaultLocked)', () => {
       // vultisigLocked is a secure, encrypted vault in the VaultLocked phase
       expect(isVultisigVaultPasswordRequired(vultisigLocked)).toBe(true)
     })
-    it('never prompts for an un-encrypted vault', () => {
+    it('is false for an un-encrypted vault', () => {
       // vultisigActive is a fast, un-encrypted vault
       expect(isVultisigVaultPasswordRequired(vultisigActive)).toBe(false)
     })
-    it('falls back to prompting when there is no active vault', () => {
+    it('falls back to true when there is no active vault', () => {
       expect(isVultisigVaultPasswordRequired(vultisigSelection)).toBe(true)
     })
-    it('falls back to prompting for non-Vultisig states', () => {
+    it('falls back to true for non-Vultisig states', () => {
       expect(isVultisigVaultPasswordRequired(keystoreUnlocked)).toBe(true)
       expect(isVultisigVaultPasswordRequired(ledgerState)).toBe(true)
     })

--- a/src/renderer/services/wallet/types.ts
+++ b/src/renderer/services/wallet/types.ts
@@ -80,33 +80,26 @@ export const isVultisigMode = (state: AppWalletState): state is VultisigState =>
 export const isVultisigVaultLocked = (state: VultisigState): boolean => state.phase === VultisigPhase.VaultLocked
 
 /**
- * Whether the Vultisig confirmation modal should ask for the vault password
- * before signing.
+ * Whether the active Vultisig vault is password-protected (encrypted) — i.e.
+ * a password is required *in principle* before it can sign.
  *
- * The vault's static `isEncrypted` flag over-prompts on its own: it stays `true`
- * for the whole life of a password-protected vault, so every swap/send re-shows
- * the password field even when the vault is already unlocked for the session.
- *
- * Once a vault is unlocked (`phase === Active`) we should never ask for the
- * password again on a transaction — regardless of vault type:
- * - Fast vaults (1-of-1) already have the key share loaded, so re-entry is pure
- *   theatre (`validatePassword` short-circuits to a non-empty check without even
- *   calling the SDK).
- * - Secure vaults (multi-device) cannot submit anything without the co-signer
- *   device (e.g. phone) completing the MPC ceremony, which is the real
- *   authorization — so the desktop password re-entry is redundant there too.
+ * This is intentionally NOT the "should we show the prompt right now?" decision.
+ * A password-protected vault stays encrypted for its whole life, but the SDK
+ * caches the password with a TTL after an unlock, so re-prompting on every tx is
+ * redundant while the cache is warm. The *live* decision — skip while the SDK's
+ * password cache is valid, prompt once it has expired — is made in
+ * `VultisigConfirmationModal` via `window.apiMpc.isVaultUnlocked`, because only
+ * the SDK knows the true cache state (the renderer's `phase` does not track the
+ * TTL).
  *
  * - Not Vultisig / no active vault → `true` (safe default; callers only render
  *   the Vultisig modal in Vultisig mode anyway).
- * - Un-encrypted vault → `false` (nothing to unlock).
- * - Vault already `Active` (unlocked this session) → `false`.
- * - Encrypted vault not yet unlocked → `true` (password needed to unlock).
+ * - Un-encrypted vault → `false` (no password ever needed).
+ * - Encrypted vault → `true`.
  */
 export const isVultisigVaultPasswordRequired = (state: AppWalletState): boolean => {
   if (!isVultisigMode(state) || !state.activeVault) return true
-  if (!state.activeVault.isEncrypted) return false
-  if (state.phase === VultisigPhase.Active) return false
-  return true
+  return state.activeVault.isEncrypted
 }
 
 export const isKeystoreMode = (state: AppWalletState): state is KeystoreState =>

--- a/src/shared/api/mpcTypes.ts
+++ b/src/shared/api/mpcTypes.ts
@@ -196,6 +196,7 @@ export enum MpcIPCMessages {
   // Vault Lock/Unlock
   MPC_LOCK_VAULT = 'mpc:lockVault',
   MPC_UNLOCK_VAULT = 'mpc:unlockVault',
+  MPC_IS_VAULT_UNLOCKED = 'mpc:isVaultUnlocked',
 
   // Events (main -> renderer)
   MPC_CREATION_PROGRESS = 'mpc:creationProgress',
@@ -250,6 +251,9 @@ export type ApiMpc = {
   // Vault Lock/Unlock
   lockVault: (vaultId: string) => Promise<void>
   unlockVault: (vaultId: string, password: string) => Promise<void>
+  // Whether the vault's password is currently cached & not expired (i.e. it can
+  // sign without a fresh password prompt). Reflects the SDK's password-cache TTL.
+  isVaultUnlocked: (vaultId: string) => Promise<boolean>
 
   // Transaction Signing
   signBytes: (params: SignBytesParams) => Promise<SignBytesResult>


### PR DESCRIPTION
…odal

Two fixes to the Vultisig confirmation modal:

1. Password-cache TTL (crash fix): #1134 skipped the password prompt whenever the vault phase was Active, but phase never tracks the SDK's 5-minute password-cache TTL. After idle > 5 min, signing hit an expired cache → "VaultError: Password required". The modal now asks the SDK for its live cache state (new isVaultUnlocked IPC → vault.getUnlockTimeRemaining()): it skips the prompt while the cache is warm and re-prompts only once expired.

2. Centering: the confirm modal now uses the same lg:pl-[240px] sidebar offset as UnifiedTxModal, so it centers within the content area, not the full viewport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Encrypted vaults now remember an active unlock session, allowing signing flows to skip unnecessary password prompts.
  * Added a brief loading state while the app checks whether a vault is already unlocked.
* **Bug Fixes**
  * Vault unlock checks now fail safely without interrupting the signing flow.
  * Password requirements are handled consistently for encrypted and unencrypted vaults.
* **Style**
  * Improved modal alignment on large screens for a more centered layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->