### PR TITLE
chore: release v1.45.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "asgardex",
   "productName": "ASGARDEX",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "description": "WALLET AND EXCHANGE CLIENT FOR THORCHAIN, MAYACHAIN, CHAINFLIP",
   "main": "build/main/electron.js",
   "scripts": {


### PR DESCRIPTION
Bumps `version` **1.44.0 → 1.45.0**.

Once merged, cut `release/1.45.0` from develop and push it to trigger the draft release + mac/win/linux builds (per RELEASE.md). Version bump is minor because the delta since v1.44.0 includes new features.

### Highlights since v1.44.0

**Features**
- Chainflip: add Tron support + bump `@chainflip/sdk` 2.2.1 (#1112)
- 24-word seed phrase option + randomized keystore id (#1120)
- Flatpak Linux build target + native keystore auto-import

**Fixes**
- Vultisig: re-prompt on expired password cache + center confirm modal (#1137)
- Swap fees: don't hang fee estimation for phrase-less wallets — TRON/XRP (#1135)
- Vultisig: don't re-prompt for vault password once unlocked (#1134); add TRON to balance observables (#1118)
- Keystore: `crypto.timingSafeEqual` polyfill for renderer unlock (#1115)
- Flatpak: scope home access, license path, lint fixes

**Chore / CI / docs**
- xchainjs bump (#1114), RUNE ticker + icon refresh (#1113), mobile drawer hover (#1121), workflow hardening (#1122), Ledger/Flatpak docs

Note: `CHANGELOG.md` intentionally not updated — release notes are auto-generated from PR labels (as of v1.44.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version from 1.44.0 to 1.45.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->