### PR TITLE
fix(swap): surface routing protocol in chart panel + track OneClick swaps

### DIFF
--- a/src/renderer/components/modal/tx/TxModal.tsx
+++ b/src/renderer/components/modal/tx/TxModal.tsx
@@ -4,8 +4,10 @@ import * as RD from '@devexperts/remote-data-ts'
 import { function as FP, option as O } from 'fp-ts'
 import { useIntl } from 'react-intl'
 
+import { protocolMapping } from '../../../helpers/protocolHelper'
 import { ApiError } from '../../../services/wallet/types'
 import { ErrorView } from '../../shared/error'
+import { ProviderIcon } from '../../swap/ProviderIcon'
 import { Button, ButtonProps } from '../../uielements/button'
 import { Modal } from '../../uielements/modal'
 import { TxTimer } from '../../uielements/txTimer'
@@ -151,6 +153,20 @@ export const UnifiedTxModal = (props: TxModalProps): JSX.Element => {
 
       {/* Asset display */}
       <TxAssetDisplay txConfig={txConfig} network={network} />
+
+      {/* Protocol — surface which protocol executed the swap (was only used for tracking before) */}
+      {FP.pipe(
+        protocol,
+        O.fold(
+          () => <></>,
+          (p) => (
+            <div className="text-12 flex w-full items-center justify-center gap-1.5 pt-2 font-main text-text2 dark:text-text2d">
+              <ProviderIcon protocol={p} className="!h-4 !w-4" />
+              <span>{protocolMapping[p as keyof typeof protocolMapping] ?? p}</span>
+            </div>
+          )
+        )
+      )}
 
       {/* Escape hatch for custom content */}
       {extraContent && <div className="flex w-full items-center justify-center px-6 pt-3">{extraContent}</div>}

--- a/src/renderer/helpers/protocolHelper.ts
+++ b/src/renderer/helpers/protocolHelper.ts
@@ -9,5 +9,6 @@ export const chainToProtocol = {
 export const protocolMapping = {
   Thorchain: 'THORChain',
   Mayachain: 'MAYAChain',
-  Chainflip: 'Chainflip'
+  Chainflip: 'Chainflip',
+  OneClick: 'NEAR Intents'
 }

--- a/src/renderer/views/pools/detail/TradingPanel.tsx
+++ b/src/renderer/views/pools/detail/TradingPanel.tsx
@@ -29,6 +29,7 @@ import { useEvmContext } from '../../../contexts/EvmContext'
 import { useMayachainContext } from '../../../contexts/MayachainContext'
 import { useMidgardContext } from '../../../contexts/MidgardContext'
 import { useMidgardMayaContext } from '../../../contexts/MidgardMayaContext'
+import { useOneClickContext } from '../../../contexts/OneClickContext'
 import { usePriceLevelContext } from '../../../contexts/PriceLevelContext'
 import { useThorchainContext } from '../../../contexts/ThorchainContext'
 import { useWalletContext } from '../../../contexts/WalletContext'
@@ -36,6 +37,7 @@ import { isUSDAsset } from '../../../helpers/assetHelper'
 import { addChainflipSwapToTrackerFromQuote } from '../../../helpers/chainflipTransactionTracker'
 import { isEvmChainToken } from '../../../helpers/evmHelper'
 import { eqAsset } from '../../../helpers/fp/eq'
+import { addOneClickSwapToTrackerFromQuote } from '../../../helpers/oneClickTransactionTracker'
 import { addSwapToTracker } from '../../../helpers/transactionTracker'
 import { useERC20Approval } from '../../../hooks/useERC20Approval'
 import { useOpenExplorerTxUrl } from '../../../hooks/useOpenExplorerTxUrl'
@@ -93,6 +95,7 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
   const { transactionTrackingService } = useThorchainContext()
   const { transactionTrackingService: mayaTransactionTrackingService } = useMayachainContext()
   const { transactionTrackingService: chainflipTransactionTrackingService } = useChainflipContext()
+  const { transactionTrackingService: oneClickTransactionTrackingService } = useOneClickContext()
 
   const {
     service: {
@@ -672,6 +675,16 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
             depositAmount: amountToSwap.amount().toString()
           })
           lastTrackedTxHashRef.current = txHash
+        } else if (quoteProtocol.protocol === 'OneClick') {
+          // 1Click (NEAR Intents) keys swap status by deposit address (`toAddress` in the quote),
+          // not the on-chain tx hash. Mirrors the main Swap screen; the global TransactionQuickDial
+          // (AppView) polls GET /v0/status?depositAddress=… and renders it.
+          addOneClickSwapToTrackerFromQuote(oneClickTransactionTrackingService, quoteProtocol.toAddress, {
+            srcAsset: { chain: safeSourceAsset.chain, symbol: safeSourceAsset.symbol },
+            destAsset: { chain: safeTargetAsset.chain, symbol: safeTargetAsset.symbol },
+            depositAmount: amountToSwap.amount().toString()
+          })
+          lastTrackedTxHashRef.current = txHash
         }
       })
     )
@@ -681,6 +694,7 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
     transactionTrackingService,
     mayaTransactionTrackingService,
     chainflipTransactionTrackingService,
+    oneClickTransactionTrackingService,
     safeSourceAsset,
     safeTargetAsset,
     amountToSwap,

--- a/src/renderer/views/pools/detail/TradingPanelOrderSection.tsx
+++ b/src/renderer/views/pools/detail/TradingPanelOrderSection.tsx
@@ -6,8 +6,10 @@ import { function as FP, option as O } from 'fp-ts'
 import { useIntl } from 'react-intl'
 
 import { SwapSettings } from '../../../components/swap/components/SwapSettings'
+import { ProviderIcon } from '../../../components/swap/ProviderIcon'
 import type { ExtendedQuoteSwap } from '../../../components/swap/Swap.types'
 import { Spin } from '../../../components/uielements/spin'
+import { protocolMapping } from '../../../helpers/protocolHelper'
 import type { StreamingMode } from '../../../hooks/useStreamingParams'
 import { IsApprovedRD } from '../../../services/evm/types'
 import type { TradeMode } from './TradingPanelBar'
@@ -216,12 +218,15 @@ const QuoteDetails = ({
       </span>
     </div>
 
-    {/* Protocol */}
+    {/* Protocol — emphasized (icon + humanized name) so the routing protocol is obvious */}
     <div className="flex items-center justify-between">
       <span className="font-main text-11 text-gray-500">
         {intl.formatMessage({ id: 'pools.chart.tradingPanel.quote.protocol' })}
       </span>
-      <span className="font-main text-11 text-gray-300">{quote.protocol}</span>
+      <span className="text-12 flex items-center gap-1.5 font-main font-semibold text-gray-200">
+        <ProviderIcon protocol={quote.protocol} className="!h-4 !w-4" />
+        {protocolMapping[quote.protocol as keyof typeof protocolMapping] ?? quote.protocol}
+      </span>
     </div>
 
     {/* Estimated time */}


### PR DESCRIPTION
## Problem
Submitting a swap from the **trading-chart panel** gave no clear indication of which protocol it routed through. A **NEAR Intents (OneClick)** swap looked like it was on THORChain — and afterwards **nothing showed up in transaction tracking**.

Two root causes, both fixed here.

## 1. The protocol was invisible / mislabeled
- `protocolMapping` was **missing an `OneClick` entry**, so it fell through to the raw id **"OneClick"** everywhere (including the main swap screen) — unrecognizable as NEAR Intents. Added `OneClick: 'NEAR Intents'`.
- In the chart panel's quote details, the protocol was one **muted gray `text-11` row** with no icon, buried between Fees and Time. Now renders with the **provider icon + humanized name**, emphasized.
- The tx-status modal (`UnifiedTxModal`) received the protocol but only used it to build the tracking URL — **never displayed it**. Now shows it (icon + name) under the assets. Applies to all swap flows.

## 2. OneClick swaps were never tracked from the chart panel
The trading panel's swap-tracking effect had branches for Thorchain/Mayachain/Chainflip but **no `OneClick` branch**, so NEAR Intents swaps executed but were never registered with the tracker — the global `TransactionQuickDial` (AppView, polling `1click.chaindefuser.com/v0/status`) had nothing to show.

**Fix:** added the missing branch, keyed by the deposit address (`toAddress` — 1Click tracks by deposit address, not tx hash), mirroring the main Swap screen.

## Testing
- Verified live: a NEAR Intents swap from the chart panel now shows "NEAR Intents" in the quote + tx modal, and appears in the tracker.
- `yarn lint` clean, `tsc --noEmit` 0 errors.

## Follow-ups (not in this PR)
- The tx-modal **"Track" button** (`TxActions.tsx`) has no OneClick case, so it silently no-ops for NEAR Intents (which has no external explorer) — should be hidden for OneClick.
- `TransactionTracker.tsx` labels any non-Maya protocol as "THORChain".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protocol icons and friendly protocol names to transaction modals and quote details.
  * Added support for displaying “NEAR Intents” as a recognized protocol.

* **Bug Fixes**
  * Improved successful swap tracking for swaps processed through NEAR Intents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->