### PR TITLE
ci: pass VITE_ASGARDEX_ONECLICK_AFFILIATES into production builds

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -65,6 +65,12 @@ VITE_ANKR_API_KEY=XXX
 VITE_ASGARDEX_THORNAME=dx
 VITE_ASGARDEX_BROKER_URL=XXX
 VITE_ASGARDEX_AFFILIATE_BROKERS_ADDRESS=XXX
+# OneClick (NEAR Intents) — JSON map of destination chain → native affiliate address
+# VITE_ASGARDEX_ONECLICK_AFFILIATES={"BTC":"bc1...","ETH":"0x..."}
+VITE_ASGARDEX_ONECLICK_AFFILIATES=
+# Optional API key (anonymous works; keyed requests are rate-limited less aggressively)
+# VITE_ASGARDEX_ONECLICK_API_KEY=XXX
+
 
 #SOL
 VITE_SOL_API_KEY=XXX

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -57,6 +57,7 @@ jobs:
           VITE_NOWNODES_API_KEY: ${{ secrets.REACT_APP_NOWNODES_API_KEY }}
           VITE_ASGARDEX_BROKER_URL: ${{secrets.VITE_ASGARDEX_BROKER_URL}}
           VITE_ASGARDEX_AFFILIATE_BROKERS_ADDRESS: ${{secrets.VITE_ASGARDEX_AFFILIATE_BROKERS_ADDRESS}}
+          VITE_ASGARDEX_ONECLICK_AFFILIATES: ${{ secrets.VITE_ASGARDEX_ONECLICK_AFFILIATES }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -65,6 +65,7 @@ jobs:
           VITE_NOWNODES_API_KEY: ${{ secrets.REACT_APP_NOWNODES_API_KEY }}
           VITE_ASGARDEX_BROKER_URL: ${{secrets.VITE_ASGARDEX_BROKER_URL}}
           VITE_ASGARDEX_AFFILIATE_BROKERS_ADDRESS: ${{secrets.VITE_ASGARDEX_AFFILIATE_BROKERS_ADDRESS}}
+          VITE_ASGARDEX_ONECLICK_AFFILIATES: ${{ secrets.VITE_ASGARDEX_ONECLICK_AFFILIATES }}
           OS_NAME: ${{ matrix.os-name }}
           OS_VERSION: ${{ matrix.os-version }}
           OS_VERSION_SUFFIX: '${{ matrix.os-version }}-${{ matrix.os-name }}'

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -51,6 +51,7 @@ jobs:
           VITE_NOWNODES_API_KEY: ${{ secrets.REACT_APP_NOWNODES_API_KEY }}
           VITE_ASGARDEX_BROKER_URL: ${{secrets.VITE_ASGARDEX_BROKER_URL}}
           VITE_ASGARDEX_AFFILIATE_BROKERS_ADDRESS: ${{secrets.VITE_ASGARDEX_AFFILIATE_BROKERS_ADDRESS}}
+          VITE_ASGARDEX_ONECLICK_AFFILIATES: ${{ secrets.VITE_ASGARDEX_ONECLICK_AFFILIATES }}
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:


### PR DESCRIPTION
Wire the OneClick destination-chain affiliate map into linux/mac/win package workflows so release binaries can collect affiliate fees. Also document the env var in .env.sample.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Added optional OneClick affiliate settings and API key configuration.
  - Enabled affiliate settings to be included in Linux, macOS, and Windows packaged builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->