### PR TITLE
fix: source UTXO inbound fee rates from the node gas_rate

### DIFF
--- a/src/renderer/services/chain/fees/nodeapi.test.ts
+++ b/src/renderer/services/chain/fees/nodeapi.test.ts
@@ -1,0 +1,104 @@
+import { BCHChain } from '@xchainjs/xchain-bitcoincash'
+import { Chain } from '@xchainjs/xchain-util'
+import { option as O } from 'fp-ts'
+import { describe, expect, it } from 'vitest'
+
+import { ChainFeeData, getUtxoMinFeeRate, resolveUtxoFeeRate, UTXO_MAX_FEE_RATES, UTXO_MIN_FEE_RATES } from './nodeapi'
+
+const feeData = (chain: Chain, gas_rate: string): O.Option<ChainFeeData> =>
+  O.some({ chain, gas_rate, gas_rate_units: 'satsperbyte', outbound_fee: '0' })
+
+describe('resolveUtxoFeeRate', () => {
+  describe('inbounds (node gas_rate applies)', () => {
+    it('raises a provider estimate up to the node gas_rate', () => {
+      // the exact conditions of the 2026-07-17 stuck swap: BitGo said 0.986, THORNode said 3
+      expect(resolveUtxoFeeRate(BCHChain, 0.986, feeData(BCHChain, '3'))).toEqual(3)
+    })
+
+    it.each([
+      // chain, provider estimate, node gas_rate, expected  (live values, 2026-07-31)
+      ['BTC', 2.234, '3', 3],
+      ['BCH', 1.5, '3', 3],
+      ['LTC', 0.825, '27', 27],
+      ['DOGE', 37500, '750000', 750000],
+      ['DASH', 8.25, '12', 12]
+    ])('%s: raises %s to the node gas_rate %s', (chain, estimate, gasRate, expected) => {
+      expect(
+        resolveUtxoFeeRate(chain as Chain, estimate as number, feeData(chain as Chain, gasRate as string))
+      ).toEqual(expected)
+    })
+
+    it('keeps the provider estimate when it already exceeds the node gas_rate', () => {
+      expect(resolveUtxoFeeRate(BCHChain, 12, feeData(BCHChain, '6'))).toEqual(12)
+    })
+
+    it('falls back to the clamped estimate on an invalid gas_rate', () => {
+      for (const gasRate of ['0', '-1', 'not-a-number', '']) {
+        expect(resolveUtxoFeeRate(BCHChain, 0.986, feeData(BCHChain, gasRate))).toEqual(UTXO_MIN_FEE_RATES.BCH)
+      }
+    })
+  })
+
+  describe('ordinary sends (node gas_rate must NOT apply)', () => {
+    it('leaves a healthy estimate alone rather than padding it to gas_rate', () => {
+      // LTC gas_rate is 27; a plain send at 5 must not be raised 5x
+      expect(resolveUtxoFeeRate('LTC', 5, O.none)).toEqual(5)
+      expect(resolveUtxoFeeRate('DOGE', 37500, O.none)).toEqual(37500)
+    })
+
+    it('still enforces the per-chain relay floor', () => {
+      // LTC's provider estimate of 0.825 previously became 0 via Math.floor
+      expect(resolveUtxoFeeRate('LTC', 0.825, O.none)).toEqual(UTXO_MIN_FEE_RATES.LTC)
+      expect(resolveUtxoFeeRate('DOGE', 10, O.none)).toEqual(UTXO_MIN_FEE_RATES.DOGE)
+    })
+  })
+
+  describe('upper cap (plausibility gate on bad data)', () => {
+    it('ignores an implausible node gas_rate rather than paying it', () => {
+      // a decimal-shifted / wrong-unit BCH rate must not be paid, nor clamped to the ceiling
+      expect(resolveUtxoFeeRate(BCHChain, 1.5, feeData(BCHChain, '5000000'))).toEqual(2)
+      // ...and the local estimate is still honoured when it is the healthier number
+      expect(resolveUtxoFeeRate(BCHChain, 40, feeData(BCHChain, '5000000'))).toEqual(40)
+    })
+
+    it('still accepts large-but-plausible raises', () => {
+      // LTC legitimately runs 33x its provider estimate - the cap must not clamp this
+      expect(resolveUtxoFeeRate('LTC', 0.825, feeData('LTC', '27'))).toEqual(27)
+      expect(resolveUtxoFeeRate('DOGE', 37500, feeData('DOGE', '750000'))).toEqual(750000)
+    })
+
+    it('caps an implausible provider estimate', () => {
+      expect(resolveUtxoFeeRate(BCHChain, 1e9, O.none)).toEqual(UTXO_MAX_FEE_RATES.BCH)
+    })
+
+    it('holds BTC to a tighter ceiling, since its unit price makes the worst case ~300x costlier', () => {
+      expect(UTXO_MAX_FEE_RATES.BTC).toEqual(300)
+      // congestion-level but plausible - must still be honoured
+      expect(resolveUtxoFeeRate('BTC', 5, feeData('BTC', '250'))).toEqual(250)
+      // above the ceiling - treated as bad data, falls back to the estimate
+      expect(resolveUtxoFeeRate('BTC', 5, feeData('BTC', '500'))).toEqual(5)
+    })
+
+    it('never exceeds the chain ceiling for any input', () => {
+      for (const chain of ['BTC', 'BCH', 'LTC', 'DOGE', 'DASH']) {
+        for (const estimate of [0, 1e9, Number.POSITIVE_INFINITY]) {
+          for (const gasRate of ['1', '1e12', '999999999999']) {
+            expect(resolveUtxoFeeRate(chain, estimate, feeData(chain, gasRate))).toBeLessThanOrEqual(
+              UTXO_MAX_FEE_RATES[chain]
+            )
+          }
+        }
+      }
+    })
+  })
+
+  it('always returns a whole number at or above the chain floor', () => {
+    for (const chain of ['BTC', 'BCH', 'LTC', 'DOGE', 'DASH']) {
+      for (const estimate of [Number.NaN, -5, 0, 0.4, 3.2]) {
+        const rate = resolveUtxoFeeRate(chain, estimate, O.none)
+        expect(Number.isInteger(rate)).toBe(true)
+        expect(rate).toBeGreaterThanOrEqual(getUtxoMinFeeRate(chain))
+      }
+    }
+  })
+})

--- a/src/renderer/services/chain/fees/nodeapi.ts
+++ b/src/renderer/services/chain/fees/nodeapi.ts
@@ -246,3 +246,137 @@ export const getChainGasPrices$ = (chain: Chain, decimals: number = 18) => {
   const protocol = getChainNodeProtocol(chain)
   return getNodeGasPrices$(chain, protocol, decimals)
 }
+
+/**
+ * Absolute per-chain fee-rate floors, in each chain's native rate unit (sats/duffs/koinu per byte).
+ *
+ * These are conservative multiples of each chain's minimum relay fee. A tx paying at or below the
+ * relay minimum under-propagates and is never mined; for a THORChain inbound that is silent, because
+ * only *confirmed* inbounds are observed - the swap never starts and the funds sit until mempool
+ * expiry (~14d on BCH). Applied to every UTXO tx, pool or plain send.
+ */
+export const UTXO_MIN_FEE_RATES: Record<string, number> = {
+  BTC: 2, // relay min ~1 sat/vB
+  BCH: 2, // relay min ~1 sat/vB - the 2026-07-17 stuck swap paid 0.986
+  LTC: 2, // relay min ~1 lit/byte
+  DASH: 2, // relay min ~1 duff/byte
+  DOGE: 1000 // relay min 0.01 DOGE/kB = 1000 koinu/byte
+}
+
+const DEFAULT_UTXO_MIN_FEE_RATE = 2
+
+export const getUtxoMinFeeRate = (chain: Chain): number => UTXO_MIN_FEE_RATES[chain] ?? DEFAULT_UTXO_MIN_FEE_RATE
+
+/**
+ * Absolute per-chain fee-rate ceilings, in the same native units as `UTXO_MIN_FEE_RATES`.
+ *
+ * A plausibility gate on *upstream* numbers, not a target: no legitimate rate reaches these, so a
+ * value above one means the source is wrong (bad units, a decimal shift, a broken endpoint) rather
+ * than the network being busy. Live rates on 2026-07-31 were BTC 3, BCH 3, LTC 27, DASH 12,
+ * DOGE 750000, so ordinary congestion never trips them.
+ *
+ * Sized by the worst case each permits *in fiat*, not in native units - unit price differs ~300x
+ * across these chains, so one shared number would mean wildly different exposure. At a 300 byte tx
+ * (a typical inbound with its OP_RETURN) a ceiling-rate fee costs roughly $57 on BTC (@ $63k) and
+ * under $1 on BCH/LTC/DASH.
+ *
+ * Tripping a ceiling is not catastrophic: the fallback is the provider estimate, which during real
+ * congestion is itself elevated, so what is forfeited is the node's padding rather than the fee.
+ * That makes a tighter BTC bound close to free - it sits above nearly all sustained historical
+ * rates (the 2023 ordinals congestion ran mostly under 300 sat/vB, spiking past 500 only briefly).
+ */
+export const UTXO_MAX_FEE_RATES: Record<string, number> = {
+  BTC: 300, // ~$57 on a 300 vB tx @ $63k - the only chain where the ceiling is a meaningful loss
+  BCH: 1000,
+  LTC: 1000,
+  DASH: 1000,
+  DOGE: 20_000_000 // ~26x the current 750000
+}
+
+const DEFAULT_UTXO_MAX_FEE_RATE = 1000
+
+export const getUtxoMaxFeeRate = (chain: Chain): number => UTXO_MAX_FEE_RATES[chain] ?? DEFAULT_UTXO_MAX_FEE_RATE
+
+/**
+ * Resolves the fee rate to use for a UTXO tx.
+ *
+ * Chain data providers estimate from generic network conditions and can return rates below a chain's
+ * own relay minimum. For BCH the first provider is BitGo, whose `feeByBlockTarget` is empty, so it
+ * derives `fast` as 75% of `fastest` - which produced 0.986 sat/vB on 2026-07-17, below BCH's ~1
+ * sat/vB floor. LTC currently reports 0.825 the same way.
+ *
+ * Pass `oFeeData` as `O.some` for THORChain/MAYAChain **inbounds**, where the vault's `gas_rate` is
+ * the authoritative figure and must not be undercut. Pass `O.none` for ordinary sends - `gas_rate`
+ * is padded for inbounds (27 vs a 0.825 estimate on LTC) and would badly overpay a plain transfer.
+ *
+ * Bounded on both sides by `UTXO_MIN_FEE_RATES` / `UTXO_MAX_FEE_RATES`. An implausibly high
+ * `gas_rate` is treated as bad data and ignored in favour of the local estimate - clamping to the
+ * ceiling instead would still overpay by orders of magnitude on a decimal-shifted value.
+ *
+ * Never fails, and always returns a whole number: rates are integral in each chain's native unit,
+ * and rounding up can only ever help a tx propagate.
+ *
+ * Pure: takes already-resolved fee data so the arithmetic is testable without observables.
+ */
+export const resolveUtxoFeeRate = (chain: Chain, estimatedRate: number, oFeeData: O.Option<ChainFeeData>): number => {
+  const minRate = getUtxoMinFeeRate(chain)
+  const maxRate = getUtxoMaxFeeRate(chain)
+  // guards against the provider returning a sub-relay-fee estimate, or an implausible one
+  const safeEstimate = Math.min(Math.max(Number.isFinite(estimatedRate) ? estimatedRate : 0, minRate), maxRate)
+  if (estimatedRate > maxRate) {
+    logger.warn(`Implausible ${chain} provider estimate ${estimatedRate} (max ${maxRate}) - using ${safeEstimate}`)
+  }
+
+  const rate = FP.pipe(
+    oFeeData,
+    O.fold(
+      () => safeEstimate,
+      ({ gas_rate, gas_rate_units }) => {
+        const nodeRate = convertNodeGasRate(chain, Number(gas_rate), gas_rate_units)
+        if (!Number.isFinite(nodeRate) || nodeRate <= 0) {
+          logger.warn(`Invalid node gas_rate "${gas_rate}" for ${chain} - using ${safeEstimate}`)
+          return safeEstimate
+        }
+        if (nodeRate > maxRate) {
+          // bad data, not a busy network - trust the local estimate rather than pay this
+          logger.warn(`Implausible ${chain} node gas_rate ${nodeRate} (max ${maxRate}) - using ${safeEstimate}`)
+          return safeEstimate
+        }
+        return Math.max(safeEstimate, nodeRate)
+      }
+    )
+  )
+
+  const feeRate = Math.ceil(rate)
+  if (feeRate > estimatedRate) {
+    logger.info(`${chain} fee rate raised ${estimatedRate} -> ${feeRate} (min ${minRate}, max ${maxRate})`)
+  }
+  return feeRate
+}
+
+/**
+ * Resolves the fee rate for a UTXO tx, sourcing `gas_rate` from inbound addresses when
+ * `useNodeFeeRate` is set (i.e. the tx is a THORChain/MAYAChain inbound).
+ *
+ * Never fails: if node fee data is unavailable the local estimate is used, clamped to the chain's
+ * minimum, so an outage can neither block a send nor let a sub-relay-fee rate through.
+ */
+export const utxoFeeRate$ = (chain: Chain, estimatedRate: number, useNodeFeeRate: boolean): LiveData<Error, number> => {
+  if (!useNodeFeeRate) return liveData.right(resolveUtxoFeeRate(chain, estimatedRate, O.none))
+
+  const protocol = getChainNodeProtocol(chain)
+  const inboundAddresses$ = (
+    protocol === NodeProtocol.THORCHAIN ? thorInboundAddresses$ : mayaInboundAddresses$
+  ) as LiveData<Error, InboundAddress[]>
+
+  return FP.pipe(
+    inboundAddresses$,
+    liveData.map((inboundAddresses) =>
+      resolveUtxoFeeRate(chain, estimatedRate, getChainFeeData(inboundAddresses, chain))
+    ),
+    liveData.altOnError((error) => {
+      logger.warn(`Failed to load ${protocol} inbound addresses for ${chain}`, error)
+      return resolveUtxoFeeRate(chain, estimatedRate, O.none)
+    })
+  )
+}

--- a/src/renderer/services/chain/transaction/common.ts
+++ b/src/renderer/services/chain/transaction/common.ts
@@ -51,7 +51,14 @@ import * as THOR from '../../thorchain'
 import * as TRON from '../../tron'
 import { ApiError, ErrorId, TxHashLD, TxLD } from '../../wallet/types'
 import * as ZEC from '../../zcash'
+import { utxoFeeRate$ } from '../fees/nodeapi'
 import { SendPoolTxParams, SendTxParams } from '../types'
+
+// shared error mapper for UTXO fee-rate resolution
+const feeRateError = (error: Error): ApiError => ({
+  errorId: ErrorId.GET_FEES,
+  msg: error?.message ?? error.toString()
+})
 
 // helper to create `RemoteData<ApiError, never>` observable
 const txFailure$ = (msg: string): LiveData<ApiError, never> =>
@@ -77,7 +84,8 @@ export const sendTx$ = ({
   destinationTag,
   sendMax,
   selectedUtxos,
-  utxoSelectionPreferences
+  utxoSelectionPreferences,
+  useNodeFeeRate = false
 }: SendTxParams): TxHashLD => {
   const { chain } =
     asset.type === AssetType.SYNTH ? AssetCacao : asset.type === AssetType.SECURED ? { chain: THORChain } : asset
@@ -90,24 +98,30 @@ export const sendTx$ = ({
           errorId: ErrorId.GET_FEES,
           msg: error?.message ?? error.toString()
         })),
-        liveData.chain(({ rates }) => {
-          return BTC.sendTx({
-            walletType,
-            recipient,
-            asset,
-            amount,
-            feeOption,
-            feeRate: rates[feeOption],
-            memo,
-            walletAccount,
-            walletIndex,
-            hdMode,
-            sender,
-            sendMax,
-            selectedUtxos,
-            utxoSelectionPreferences
-          })
-        })
+        liveData.chain(({ rates }) =>
+          FP.pipe(
+            utxoFeeRate$(BTCChain, rates[feeOption], useNodeFeeRate),
+            liveData.mapLeft(feeRateError),
+            liveData.chain((feeRate) =>
+              BTC.sendTx({
+                walletType,
+                recipient,
+                asset,
+                amount,
+                feeOption,
+                feeRate,
+                memo,
+                walletAccount,
+                walletIndex,
+                hdMode,
+                sender,
+                sendMax,
+                selectedUtxos,
+                utxoSelectionPreferences
+              })
+            )
+          )
+        )
       )
 
     case ETHChain:
@@ -206,22 +220,28 @@ export const sendTx$ = ({
           msg: error?.message ?? error.toString()
         })),
         liveData.chain(({ rates }) =>
-          DOGE.sendTx({
-            walletType,
-            recipient,
-            asset,
-            amount,
-            feeOption,
-            feeRate: rates[feeOption],
-            memo,
-            walletAccount,
-            walletIndex,
-            hdMode,
-            sender,
-            sendMax,
-            selectedUtxos,
-            utxoSelectionPreferences
-          })
+          FP.pipe(
+            utxoFeeRate$(DOGEChain, rates[feeOption], useNodeFeeRate),
+            liveData.mapLeft(feeRateError),
+            liveData.chain((feeRate) =>
+              DOGE.sendTx({
+                walletType,
+                recipient,
+                asset,
+                amount,
+                feeOption,
+                feeRate,
+                memo,
+                walletAccount,
+                walletIndex,
+                hdMode,
+                sender,
+                sendMax,
+                selectedUtxos,
+                utxoSelectionPreferences
+              })
+            )
+          )
         )
       )
 
@@ -233,22 +253,28 @@ export const sendTx$ = ({
           msg: error?.message ?? error.toString()
         })),
         liveData.chain(({ rates }) =>
-          BCH.sendTx({
-            walletType,
-            recipient,
-            asset,
-            amount,
-            feeOption,
-            feeRate: rates[feeOption],
-            memo,
-            walletAccount,
-            walletIndex,
-            hdMode,
-            sender,
-            sendMax,
-            selectedUtxos,
-            utxoSelectionPreferences
-          })
+          FP.pipe(
+            utxoFeeRate$(BCHChain, rates[feeOption], useNodeFeeRate),
+            liveData.mapLeft(feeRateError),
+            liveData.chain((feeRate) =>
+              BCH.sendTx({
+                walletType,
+                recipient,
+                asset,
+                amount,
+                feeOption,
+                feeRate,
+                memo,
+                walletAccount,
+                walletIndex,
+                hdMode,
+                sender,
+                sendMax,
+                selectedUtxos,
+                utxoSelectionPreferences
+              })
+            )
+          )
         )
       )
     case LTCChain:
@@ -258,25 +284,31 @@ export const sendTx$ = ({
           errorId: ErrorId.GET_FEES,
           msg: error?.message ?? error.toString()
         })),
-        liveData.chain(({ rates }) => {
-          const feeRate = Math.floor(rates[feeOption])
-          return LTC.sendTx({
-            walletType,
-            recipient,
-            asset,
-            amount,
-            feeOption,
-            feeRate,
-            memo,
-            walletAccount,
-            walletIndex,
-            hdMode,
-            sender,
-            sendMax,
-            selectedUtxos,
-            utxoSelectionPreferences
-          })
-        })
+        liveData.chain(({ rates }) =>
+          FP.pipe(
+            // replaces `Math.floor`, which turned LTC's sub-1 estimates into a 0 fee rate
+            utxoFeeRate$(LTCChain, rates[feeOption], useNodeFeeRate),
+            liveData.mapLeft(feeRateError),
+            liveData.chain((feeRate) =>
+              LTC.sendTx({
+                walletType,
+                recipient,
+                asset,
+                amount,
+                feeOption,
+                feeRate,
+                memo,
+                walletAccount,
+                walletIndex,
+                hdMode,
+                sender,
+                sendMax,
+                selectedUtxos,
+                utxoSelectionPreferences
+              })
+            )
+          )
+        )
       )
     case DASHChain:
       return FP.pipe(
@@ -285,24 +317,30 @@ export const sendTx$ = ({
           errorId: ErrorId.GET_FEES,
           msg: error?.message ?? error.toString()
         })),
-        liveData.chain(({ rates }) => {
-          return DASH.sendTx({
-            walletType,
-            recipient,
-            asset,
-            amount,
-            feeOption,
-            feeRate: rates[feeOption],
-            memo,
-            walletAccount,
-            walletIndex,
-            hdMode,
-            sender,
-            sendMax,
-            selectedUtxos,
-            utxoSelectionPreferences
-          })
-        })
+        liveData.chain(({ rates }) =>
+          FP.pipe(
+            utxoFeeRate$(DASHChain, rates[feeOption], useNodeFeeRate),
+            liveData.mapLeft(feeRateError),
+            liveData.chain((feeRate) =>
+              DASH.sendTx({
+                walletType,
+                recipient,
+                asset,
+                amount,
+                feeOption,
+                feeRate,
+                memo,
+                walletAccount,
+                walletIndex,
+                hdMode,
+                sender,
+                sendMax,
+                selectedUtxos,
+                utxoSelectionPreferences
+              })
+            )
+          )
+        )
       )
     case ZECChain:
       return FP.pipe(
@@ -472,7 +510,9 @@ export const sendPoolTx$ = ({
         walletAccount,
         walletIndex,
         hdMode,
-        sendMax
+        sendMax,
+        // inbounds must not be sent below the vault's recommended `gas_rate`
+        useNodeFeeRate: true
       })
     default:
       return txFailure$(`${chain} is not supported for 'sendPoolTx$'`)

--- a/src/renderer/services/chain/types.ts
+++ b/src/renderer/services/chain/types.ts
@@ -112,6 +112,12 @@ export type SendTxParams = {
   sendMax?: boolean
   selectedUtxos?: UTXO[]
   utxoSelectionPreferences?: UtxoSelectionPreferences
+  /**
+   * UTXO chains only. Floors the fee rate at the inbound vault's `gas_rate`.
+   * Set for THORChain/MAYAChain inbounds; leave unset for ordinary sends, where `gas_rate`
+   * is padded well above what a plain transfer needs.
+   */
+  useNodeFeeRate?: boolean
 }
 
 export type SendPoolTxParams = SendTxParams & {


### PR DESCRIPTION
# fix: source UTXO inbound fee rates from the node gas_rate

## The problem

UTXO inbounds are sent at whatever the chain data provider estimates. That number is unrelated to what THORChain/MAYAChain expects an inbound to pay, and nothing clamps it — `feeBounds` is configured for EVM chains only (`src/shared/{eth,bsc,arb,avax,base}/const.ts`), so the UTXO branches in `sendTx$` pass `rates[feeOption]` straight through.

BitGo is the first data provider for BTC/BCH/LTC/DOGE. Its `feeByBlockTarget` comes back empty, so it takes its fallback path and derives `fast` as **75% of `fastest`**:

```js
// @xchainjs/xchain-utxo-providers — BitgoProvider.getFeeRates()
const fastestRate = gasFeeEstimateResponse.feePerKb / 1000
{
  [FeeOption.Average]: feeByBlockTarget?.['6'] ? … : fastestRate * 0.5,
  [FeeOption.Fast]:    feeByBlockTarget?.['3'] ? … : fastestRate * 0.75,
  [FeeOption.Fastest]: fastestRate
}
```

Multiplying *down* from an already-low estimate crosses below the relay minimum whenever `feePerKb < 1333`, which happens routinely on the low-fee chains.

### Observed failures

**BCH — silent, funds stranded 14 days.** A swap on 2026-07-17 paid **0.986 sat/vB** (`feePerKb ≈ 1315`), below BCH's ~1 sat/vB relay floor. The tx under-propagated and was never mined. Because THORChain only observes *confirmed* inbounds, the swap never started — no error surfaced in the app, on-chain, or in Midgard. ~0.4 BCH sat unconfirmed until mempool expiry evicted it 14 days later, at which point the UTXOs became spendable again.

It's a knife-edge rather than a constant failure, which is likely why it hasn't been reported:

| Date | BCH `feePerKb` | Rate used | Outcome |
|---|---|---|---|
| 2026-07-17 | ~1,315 | 0.986 | stranded |
| 2026-07-31 | 2,000 | 1.500 | fine |

**LTC — currently broken.** BitGo reports **0.825** today, and `sendTx$` does `const feeRate = Math.floor(rates[feeOption])` (`common.ts:262`) → **0**. A zero-fee transaction.

### Why the existing safety net doesn't fire

`xchain-utxo` already exposes the correct source:

```js
getFeeRates(protocol) {
    if (!protocol) {
        try { return yield this.roundRobinGetFeeRates() }   // ← BitGo
        catch { console.warn('Can not retrieve fee rates from provider') }
    }
    if (!protocol || protocol === Protocol.THORCHAIN) {
        try { return standardFeeRates(yield this.getFeeRateFromThorchain()) }
        …
```

ASGARDEX calls `getFeesWithRates({ memo, sender })`, which invokes `getFeeRates()` with no protocol — so the THORChain branch is reachable **only when the provider throws**. BitGo returning 0.986 is a successful HTTP 200, so the fallback never deploys.

`getNodeGasPrices$` in `services/chain/fees/nodeapi.ts` already derives rates from `inbound_addresses` and has no callers; the EVM half of that work landed in #882.

## The fix

Route UTXO fee rates through a new `resolveUtxoFeeRate()` for **BTC, BCH, LTC, DOGE, DASH**:

- **Inbounds** floor at the vault's live `gas_rate`. It moves — BCH read 6 then 3 within the same hour on 2026-07-31 — so it's read per-transaction, never cached or assumed.
- **Ordinary sends do not.** `gas_rate` is padded for inbounds and would badly overpay a plain transfer (LTC `gas_rate` 27 against a 0.825 estimate). `sendPoolTx$` opts in via a new `SendTxParams.useNodeFeeRate`; `transfer.ts`, which serves wallet sends through the same `sendTx$`, does not.
- **Bounded on both sides.** Per-chain relay-minimum floors and plausibility ceilings, so neither a sub-relay-fee nor a decimal-shifted rate can be broadcast.
- A rate **above** the ceiling is treated as bad data and ignored in favour of the local estimate. Clamping to the ceiling would still overpay by orders of magnitude on a wrong-unit value.
- Ceilings are sized by **fiat exposure, not native units** — unit price differs ~300× across these chains, so BTC gets a tighter 300 sat/vB bound (~$57 on a 300 vB tx) where 1000 would permit ~$190.
- Results round up. Rates are integral in each chain's native unit and rounding up only helps propagation. This also replaces LTC's `Math.floor`.
- Falls back to the clamped local estimate when node fee data is unavailable, so an outage can neither block a send nor let a sub-relay-fee rate through.

### Behaviour on live values (2026-07-31)

| Chain | Provider est. | Node `gas_rate` | Inbound | Plain send |
|---|---|---|---|---|
| BTC | 2.234 | 3 | **3** | 3 |
| BCH | 1.5 | 3 | **3** | 2 |
| LTC | 0.825 | 27 | **27** | 2 (was **0**) |
| DOGE | 37,500 | 750,000 | **750,000** | 37,500 |
| DASH | 8.25 | 12 (MAYANode) | **12** | 9 |

## Testing

- **16 new unit tests** on the pure `resolveUtxoFeeRate()`: the incident's exact inputs (0.986 → 3), live per-chain values, the send/inbound distinction, ceiling gating, and an exhaustive sweep asserting no input on any chain can exceed its ceiling (incl. `Infinity`, `1e12`).
- Full suite: **905 passed**, 2 skipped, no regressions.
- `eslint` and `prettier --check` clean on all four files.
- `tsc --noEmit` introduces no new errors. (`src/renderer/services/chainflip/utils.ts:42` fails identically on pristine `develop` in my environment — a `@chainflip/sdk` version mismatch, unrelated to this PR.)

The arithmetic is deliberately split into a pure function so it's testable without mocking observables, matching the existing pure-util test style.

## Notes for reviewers

**A simpler alternative exists and I'd welcome direction.** Passing `Protocol.THORCHAIN` into `getFeeRates()` would fix the sourcing in one line. I didn't take it because `feesWithRates$` also backs fee *display* and ordinary sends, so it would apply the inbound-padded rate everywhere — the overpay problem above. If you'd prefer that route, the floors/ceilings here are still worth keeping as the bad-data guard.

**Not covered:** Chainflip (`swapCF$`) and 1Click (`swapOneClick$`) call `sendTx$` directly and so get the relay-minimum floor but no node floor — their deposit addresses aren't THORChain vaults, so `gas_rate` isn't the right target for them. ZEC is excluded because its provider throws `Zcash has flat fees`.

**Constants worth a second opinion:** `UTXO_MIN_FEE_RATES` and `UTXO_MAX_FEE_RATES` are judgement calls documented inline with their reasoning. The DOGE ceiling (20,000,000) has the least headroom over its live value (~27×).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved fee-rate selection for UTXO-based transactions using node-provided rates when applicable.
  * Added chain-specific minimum and maximum fee-rate safeguards.
  * Pool transactions now automatically use inbound node fee rates.

* **Bug Fixes**
  * Invalid, excessive, or unavailable node fee rates now fall back safely to local estimates.
  * Fee rates are rounded to valid integer values and handled consistently across supported UTXO chains.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->