### PR TITLE
fix(thorchain): cut tx/stages poll load on Liquify

### DIFF
--- a/src/renderer/services/thorchain/transactionTracking.test.ts
+++ b/src/renderer/services/thorchain/transactionTracking.test.ts
@@ -1,0 +1,232 @@
+import * as RD from '@devexperts/remote-data-ts'
+import * as Rx from 'rxjs'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+import {
+  createTransactionTrackingService,
+  getTxStagesPollingInterval,
+  isTxStagesComplete,
+  TX_STAGES_ACTIVE_POLL_MS,
+  TX_STAGES_LONG_RUNNING_AFTER_MS,
+  TX_STAGES_LONG_RUNNING_POLL_MS,
+  TX_STAGES_MAX_INCOMPLETE_MS,
+  TX_STAGES_MIN_POLL_MS,
+  TX_STAGES_QUIET_POLL_MS,
+  TX_STAGES_UNKNOWN_POLL_MS
+} from './transactionTracking'
+import { TxStages } from './types'
+
+const baseStages = (
+  overrides: Partial<{
+    inboundObserved: boolean
+    inboundFinalised: boolean
+    swapFinalised: boolean
+    outboundSigned?: boolean
+    pending: boolean
+    remainingConfirmationSeconds?: number
+    remainDelaySeconds?: number
+    streamCount?: number
+    streamQuantity?: number
+  }>
+): TxStages => ({
+  inboundObserved: {
+    finalCount: 1,
+    completed: overrides.inboundObserved ?? false
+  },
+  inboundConfirmationCounted: {
+    remainingConfirmationSeconds: overrides.remainingConfirmationSeconds,
+    completed: !(overrides.remainingConfirmationSeconds && overrides.remainingConfirmationSeconds > 0)
+  },
+  inboundFinalised: {
+    completed: overrides.inboundFinalised ?? false
+  },
+  outBoundDelay: {
+    remainDelaySeconds: overrides.remainDelaySeconds,
+    remainingDelayBlocks: undefined,
+    completed: !(overrides.remainDelaySeconds && overrides.remainDelaySeconds > 0)
+  },
+  outboundSigned: {
+    scheduledOutboundHeight: undefined,
+    blocksSinceScheduled: undefined,
+    completed: overrides.outboundSigned
+  },
+  swapStatus: {
+    pending: overrides.pending ?? false,
+    streaming: {
+      interval: 1,
+      quantity: overrides.streamQuantity,
+      count: overrides.streamCount
+    }
+  },
+  swapFinalised: overrides.swapFinalised ?? false
+})
+
+describe('getTxStagesPollingInterval', () => {
+  it('uses unknown interval when stages are null', () => {
+    expect(getTxStagesPollingInterval(null)).toBe(TX_STAGES_UNKNOWN_POLL_MS)
+  })
+
+  it('never polls faster than one THOR block (~6s) during confirmations', () => {
+    const stages = baseStages({ remainingConfirmationSeconds: 30 })
+    expect(getTxStagesPollingInterval(stages)).toBe(TX_STAGES_MIN_POLL_MS)
+    expect(getTxStagesPollingInterval(stages)).toBeGreaterThanOrEqual(6000)
+  })
+
+  it('uses min interval during outbound delay', () => {
+    expect(getTxStagesPollingInterval(baseStages({ remainDelaySeconds: 12 }))).toBe(TX_STAGES_MIN_POLL_MS)
+  })
+
+  it('uses active interval while streaming', () => {
+    expect(getTxStagesPollingInterval(baseStages({ streamCount: 1, streamQuantity: 10, inboundObserved: true }))).toBe(
+      TX_STAGES_ACTIVE_POLL_MS
+    )
+  })
+
+  it('uses quiet interval near completion', () => {
+    expect(
+      getTxStagesPollingInterval(
+        baseStages({
+          inboundObserved: true,
+          inboundFinalised: true,
+          swapFinalised: true,
+          outboundSigned: false
+        })
+      )
+    ).toBe(TX_STAGES_QUIET_POLL_MS)
+  })
+
+  it('backs off for long-running incomplete tracking', () => {
+    expect(getTxStagesPollingInterval(baseStages({ pending: true }), TX_STAGES_LONG_RUNNING_AFTER_MS)).toBe(
+      TX_STAGES_LONG_RUNNING_POLL_MS
+    )
+  })
+})
+
+describe('isTxStagesComplete', () => {
+  it('returns false for null stages', () => {
+    expect(isTxStagesComplete(null)).toBe(false)
+  })
+
+  it('returns true when all required stages complete and no outbound needed', () => {
+    expect(
+      isTxStagesComplete(
+        baseStages({
+          inboundObserved: true,
+          inboundFinalised: true,
+          swapFinalised: true,
+          outboundSigned: undefined
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('requires outbound when outboundSigned.completed is defined', () => {
+    expect(
+      isTxStagesComplete(
+        baseStages({
+          inboundObserved: true,
+          inboundFinalised: true,
+          swapFinalised: true,
+          outboundSigned: false
+        })
+      )
+    ).toBe(false)
+
+    expect(
+      isTxStagesComplete(
+        baseStages({
+          inboundObserved: true,
+          inboundFinalised: true,
+          swapFinalised: true,
+          outboundSigned: true
+        })
+      )
+    ).toBe(true)
+  })
+})
+
+describe('createTransactionTrackingService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('polls only terminal RD values (ignores pending) and respects min interval', async () => {
+    let calls = 0
+    const getTxStatus$ = (_txHash: string) => {
+      calls++
+      return Rx.concat(
+        Rx.of(RD.pending),
+        Rx.of(
+          RD.success(
+            baseStages({
+              inboundObserved: false,
+              remainingConfirmationSeconds: 20
+            })
+          )
+        )
+      )
+    }
+
+    const service = createTransactionTrackingService(getTxStatus$, 30, TX_STAGES_MAX_INCOMPLETE_MS)
+    const sub = service.getTransactions$.subscribe()
+
+    service.addTransaction({
+      txHash: 'abc',
+      startTime: Date.now(),
+      fromAsset: 'BTC.BTC',
+      toAsset: 'THOR.RUNE',
+      amount: '1'
+    })
+
+    // First poll is immediate
+    await vi.advanceTimersByTimeAsync(0)
+    expect(calls).toBe(1)
+
+    // Pending must not schedule an extra immediate poll — next wait is min 6s
+    await vi.advanceTimersByTimeAsync(TX_STAGES_MIN_POLL_MS - 1)
+    expect(calls).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(calls).toBe(2)
+
+    sub.unsubscribe()
+  })
+
+  it('stops polling after max incomplete age', async () => {
+    let calls = 0
+    const getTxStatus$ = (_txHash: string) => {
+      calls++
+      return Rx.of(RD.success(baseStages({ inboundObserved: false })))
+    }
+
+    const maxIncomplete = 60_000
+    const service = createTransactionTrackingService(getTxStatus$, 30, maxIncomplete)
+    const sub = service.getTransactions$.subscribe()
+
+    const start = Date.now()
+    service.addTransaction({
+      txHash: 'stuck',
+      startTime: start,
+      fromAsset: 'BTC.BTC',
+      toAsset: 'THOR.RUNE',
+      amount: '1'
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    const afterFirst = calls
+    expect(afterFirst).toBeGreaterThanOrEqual(1)
+
+    // Run past max incomplete window
+    await vi.advanceTimersByTimeAsync(maxIncomplete + TX_STAGES_UNKNOWN_POLL_MS)
+    const callsAtStop = calls
+
+    await vi.advanceTimersByTimeAsync(TX_STAGES_UNKNOWN_POLL_MS * 3)
+    expect(calls).toBe(callsAtStop)
+
+    sub.unsubscribe()
+  })
+})

--- a/src/renderer/services/thorchain/transactionTracking.ts
+++ b/src/renderer/services/thorchain/transactionTracking.ts
@@ -7,6 +7,26 @@ import { LiveData } from '../../helpers/rx/liveData'
 import { triggerStream } from '../../helpers/stateHelper'
 import { TxStages, TxStagesLD } from './types'
 
+/**
+ * Poll cadence for THORNode `GET /thorchain/tx/stages/{hash}` (Liquify-heavy).
+ * THOR/MAYA block time is ~6s — polling faster cannot surface new stage data.
+ */
+export const TX_STAGES_MIN_POLL_MS = 6_000
+/** Not yet observed / null stages — back off harder */
+export const TX_STAGES_UNKNOWN_POLL_MS = 15_000
+/** Active processing / streaming */
+export const TX_STAGES_ACTIVE_POLL_MS = 10_000
+/** Near completion / quiet stages */
+export const TX_STAGES_QUIET_POLL_MS = 12_000
+/** After this tracking age, slow incomplete txs further (long streaming / stuck) */
+export const TX_STAGES_LONG_RUNNING_AFTER_MS = 30 * 60 * 1000
+export const TX_STAGES_LONG_RUNNING_POLL_MS = 30_000
+/**
+ * Stop polling incomplete txs after this age (keeps last known stages in the UI).
+ * 2h covers large streaming swaps without unbounded Liquify spend.
+ */
+export const TX_STAGES_MAX_INCOMPLETE_MS = 2 * 60 * 60 * 1000
+
 export type TrackedTransaction = {
   id: string
   txHash: string
@@ -17,6 +37,8 @@ export type TrackedTransaction = {
   stages: TxStages | null
   isComplete: boolean
   completedAt?: number
+  /** Set when we stop polling an incomplete tx (max age) — still shown until retention cleanup */
+  pollingStopped?: boolean
 }
 
 export type TransactionTrackingState = {
@@ -24,175 +46,186 @@ export type TransactionTrackingState = {
 }
 
 export type TransactionTrackingService = {
-  addTransaction: (tx: Omit<TrackedTransaction, 'id' | 'stages' | 'isComplete' | 'completedAt'>) => void
+  addTransaction: (
+    tx: Omit<TrackedTransaction, 'id' | 'stages' | 'isComplete' | 'completedAt' | 'pollingStopped'>
+  ) => void
   removeTransaction: (id: string) => void
   getTransactions$: LiveData<Error, TrackedTransaction[]>
   reloadTransactions: () => void
 }
 
+/** Pure: next delay between stage polls. Exported for unit tests. */
+export const getTxStagesPollingInterval = (stages: TxStages | null, trackingAgeMs = 0): number => {
+  if (trackingAgeMs >= TX_STAGES_LONG_RUNNING_AFTER_MS) {
+    return TX_STAGES_LONG_RUNNING_POLL_MS
+  }
+
+  if (!stages) return TX_STAGES_UNKNOWN_POLL_MS
+
+  // Confirmations / outbound delay: one poll per ~block is enough for countdown UI
+  if (
+    (stages.inboundConfirmationCounted.remainingConfirmationSeconds &&
+      stages.inboundConfirmationCounted.remainingConfirmationSeconds > 0) ||
+    (stages.outBoundDelay.remainDelaySeconds && stages.outBoundDelay.remainDelaySeconds > 0)
+  ) {
+    return TX_STAGES_MIN_POLL_MS
+  }
+
+  // Streaming sub-swaps
+  if (
+    stages.swapStatus.streaming.count &&
+    stages.swapStatus.streaming.quantity &&
+    stages.swapStatus.streaming.count < stages.swapStatus.streaming.quantity
+  ) {
+    return TX_STAGES_ACTIVE_POLL_MS
+  }
+
+  // Pending swap or early inbound stages
+  if (stages.swapStatus.pending || !stages.inboundObserved.completed || !stages.inboundFinalised.completed) {
+    return TX_STAGES_ACTIVE_POLL_MS
+  }
+
+  return TX_STAGES_QUIET_POLL_MS
+}
+
+export const isTxStagesComplete = (stages: TxStages | null): boolean => {
+  if (!stages) return false
+
+  const basicStagesComplete =
+    stages.inboundObserved.completed && stages.inboundFinalised.completed && stages.swapFinalised
+
+  // outboundSigned.completed undefined => no L1 outbound required
+  const outboundRequired = stages.outboundSigned.completed !== undefined
+  const outboundComplete = outboundRequired ? (stages.outboundSigned.completed ?? false) : true
+
+  const allStagesComplete = basicStagesComplete && outboundComplete
+
+  const noActiveProcessing =
+    !stages.swapStatus.pending &&
+    (!stages.swapStatus.streaming.count ||
+      stages.swapStatus.streaming.count >= (stages.swapStatus.streaming.quantity ?? 1))
+
+  const noRemainingDelays =
+    (!stages.inboundConfirmationCounted.remainingConfirmationSeconds ||
+      stages.inboundConfirmationCounted.remainingConfirmationSeconds <= 0) &&
+    (!stages.outBoundDelay.remainDelaySeconds || stages.outBoundDelay.remainDelaySeconds <= 0)
+
+  return allStagesComplete && noActiveProcessing && noRemainingDelays
+}
+
 export const createTransactionTrackingService = (
   getTxStatus$: (txHash: string) => TxStagesLD,
-  completedTransactionRetentionMinutes = 30
+  completedTransactionRetentionMinutes = 30,
+  maxIncompleteTrackingMs = TX_STAGES_MAX_INCOMPLETE_MS
 ): TransactionTrackingService => {
-  // Internal state
   const transactionsMap = new Map<string, TrackedTransaction>()
 
-  // Trigger stream for reloading
   const { stream$: reloadTransactions$, trigger: reloadTransactions } = triggerStream()
 
-  // Generate unique ID for transactions
   const generateId = () => `tx_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`
 
-  // Add a new transaction to track
-  const addTransaction = (tx: Omit<TrackedTransaction, 'id' | 'stages' | 'isComplete' | 'completedAt'>) => {
+  const addTransaction = (
+    tx: Omit<TrackedTransaction, 'id' | 'stages' | 'isComplete' | 'completedAt' | 'pollingStopped'>
+  ) => {
     const id = generateId()
     const newTransaction: TrackedTransaction = {
       ...tx,
       id,
       stages: null,
       isComplete: false,
-      completedAt: undefined
+      completedAt: undefined,
+      pollingStopped: false
     }
     transactionsMap.set(id, newTransaction)
     reloadTransactions()
   }
 
-  // Remove a transaction from tracking
   const removeTransaction = (id: string) => {
     transactionsMap.delete(id)
     reloadTransactions()
   }
 
-  // Check if transaction is complete based on stages
-  const isTransactionComplete = (stages: TxStages | null): boolean => {
-    if (!stages) return false
-
-    // More comprehensive completion check
-    const basicStagesComplete =
-      stages.inboundObserved.completed && stages.inboundFinalised.completed && stages.swapFinalised
-
-    // Check if outbound is required - if outboundSigned.completed is undefined,
-    // it means this is not an L1 swap and no outbound transaction is needed
-    const outboundRequired = stages.outboundSigned.completed !== undefined
-    const outboundComplete = outboundRequired ? (stages.outboundSigned.completed ?? false) : true
-
-    const allStagesComplete = basicStagesComplete && outboundComplete
-
-    // Additional checks for truly final state
-    const noActiveProcessing =
-      !stages.swapStatus.pending &&
-      (!stages.swapStatus.streaming.count ||
-        stages.swapStatus.streaming.count >= (stages.swapStatus.streaming.quantity ?? 1))
-
-    // No remaining delays or confirmations
-    const noRemainingDelays =
-      (!stages.inboundConfirmationCounted.remainingConfirmationSeconds ||
-        stages.inboundConfirmationCounted.remainingConfirmationSeconds <= 0) &&
-      (!stages.outBoundDelay.remainDelaySeconds || stages.outBoundDelay.remainDelaySeconds <= 0)
-
-    const isComplete = allStagesComplete && noActiveProcessing && noRemainingDelays
-
-    return isComplete
-  }
-
-  // Update transaction with latest stages
   const updateTransactionStages = (id: string, stages: TxStages) => {
     const transaction = transactionsMap.get(id)
-    if (transaction) {
-      const wasComplete = transaction.isComplete
-      const isComplete = isTransactionComplete(stages)
+    if (!transaction) return
 
-      const updatedTransaction = {
-        ...transaction,
-        stages,
-        isComplete,
-        // Set completedAt timestamp when transaction first becomes complete
-        completedAt: !wasComplete && isComplete ? Date.now() : transaction.completedAt
-      }
-      transactionsMap.set(id, updatedTransaction)
+    const wasComplete = transaction.isComplete
+    const isComplete = isTxStagesComplete(stages)
 
-      // Trigger UI update only when completion state changes
-      if (wasComplete !== isComplete) {
-        reloadTransactions()
-      }
+    transactionsMap.set(id, {
+      ...transaction,
+      stages,
+      isComplete,
+      completedAt: !wasComplete && isComplete ? Date.now() : transaction.completedAt
+    })
+
+    if (wasComplete !== isComplete) {
+      reloadTransactions()
     }
   }
 
-  // Get dynamic polling interval based on transaction stage
-  const getPollingInterval = (stages: TxStages | null): number => {
-    if (!stages) return 10000 // Default 10s for unknown state
-
-    // Fast polling during active confirmation counting
-    if (
-      stages.inboundConfirmationCounted.remainingConfirmationSeconds &&
-      stages.inboundConfirmationCounted.remainingConfirmationSeconds > 0
-    ) {
-      return 2000 // 2s - confirmation countdown
-    }
-
-    // Fast polling during outbound delay countdown
-    if (stages.outBoundDelay.remainDelaySeconds && stages.outBoundDelay.remainDelaySeconds > 0) {
-      return 3000 // 3s - delay countdown
-    }
-
-    // Medium polling during streaming swaps
-    if (
-      stages.swapStatus.streaming.count &&
-      stages.swapStatus.streaming.quantity &&
-      stages.swapStatus.streaming.count < stages.swapStatus.streaming.quantity
-    ) {
-      return 5000 // 5s - streaming progress
-    }
-
-    // Medium polling for pending swaps or early stages
-    if (stages.swapStatus.pending || !stages.inboundObserved.completed || !stages.inboundFinalised.completed) {
-      return 5000 // 5s - active processing
-    }
-
-    // Slow polling for final stages
-    return 8000 // 8s - near completion
+  const markPollingStopped = (id: string) => {
+    const transaction = transactionsMap.get(id)
+    if (!transaction || transaction.pollingStopped) return
+    transactionsMap.set(id, { ...transaction, pollingStopped: true })
+    reloadTransactions()
   }
 
-  // Create a self-rescheduling polling observable for a single transaction
-  const createTransactionPoll$ = (tx: TrackedTransaction) => {
-    return FP.pipe(
-      // Start with immediate poll (0 delay)
+  const shouldStopPolling = (tx: TrackedTransaction, now = Date.now()): boolean => {
+    if (tx.isComplete || tx.pollingStopped) return true
+    if (now - tx.startTime >= maxIncompleteTrackingMs) return true
+    return false
+  }
+
+  /**
+   * One terminal stages fetch (success or failure). Ignores RD.pending/initial so
+   * expand does not fork a second poll branch per request.
+   */
+  const fetchStagesOnce$ = (txHash: string) =>
+    getTxStatus$(txHash).pipe(
+      RxOp.filter((rd) => RD.isSuccess(rd) || RD.isFailure(rd)),
+      RxOp.take(1)
+    )
+
+  // Self-rescheduling poller for a single incomplete transaction
+  const createTransactionPoll$ = (tx: TrackedTransaction) =>
+    FP.pipe(
+      // First poll immediately (0 delay)
       Rx.of(0),
       RxOp.expand((delay: number) => {
-        // Read the latest transaction from the map
         const currentTx = transactionsMap.get(tx.id)
-
-        // Stop if transaction is missing or complete
-        if (!currentTx || currentTx.isComplete) {
-          return Rx.EMPTY // Complete the stream
+        if (!currentTx || shouldStopPolling(currentTx)) {
+          if (currentTx && !currentTx.isComplete && !currentTx.pollingStopped) {
+            markPollingStopped(tx.id)
+          }
+          return Rx.EMPTY
         }
 
         return FP.pipe(
-          // Delay by the computed interval (0 for first emission)
           Rx.timer(delay),
-          RxOp.switchMap(() => getTxStatus$(tx.txHash)),
+          RxOp.switchMap(() => fetchStagesOnce$(tx.txHash)),
           RxOp.tap((stagesRD) => {
-            // Update stages on success
             if (RD.isSuccess(stagesRD)) {
               updateTransactionStages(tx.id, stagesRD.value)
             }
           }),
           RxOp.map(() => {
-            // Read the updated transaction and compute next interval
             const updatedTx = transactionsMap.get(tx.id)
-            if (!updatedTx || updatedTx.isComplete) {
-              return -1 // Signal to complete in next expand iteration
+            if (!updatedTx || shouldStopPolling(updatedTx)) {
+              if (updatedTx && !updatedTx.isComplete && !updatedTx.pollingStopped) {
+                markPollingStopped(tx.id)
+              }
+              return -1
             }
-            return getPollingInterval(updatedTx.stages)
+            const ageMs = Date.now() - updatedTx.startTime
+            return getTxStagesPollingInterval(updatedTx.stages, ageMs)
           }),
-          RxOp.filter((nextDelay) => nextDelay >= 0) // Filter out completion signals
+          RxOp.filter((nextDelay) => nextDelay >= 0)
         )
       }),
-      RxOp.map(() => tx.id) // Return ID for combination
+      RxOp.map(() => tx.id)
     )
-  }
 
-  // Observable that polls all tracked transactions with dynamic intervals
   const getTransactions$: LiveData<Error, TrackedTransaction[]> = FP.pipe(
     reloadTransactions$,
     RxOp.switchMap(() => {
@@ -202,21 +235,21 @@ export const createTransactionTrackingService = (
         return Rx.of(RD.success([]))
       }
 
-      // Create dynamic polling observables for each active transaction
-      const transactionObservables = transactions.filter((tx) => !tx.isComplete).map(createTransactionPoll$)
+      const transactionObservables = transactions
+        .filter((t) => !t.isComplete && !t.pollingStopped)
+        .map(createTransactionPoll$)
 
       if (transactionObservables.length === 0) {
         return Rx.of(RD.success(transactions))
       }
 
-      // Combine all transaction status polls + manual updates
       const manualUpdates$ = reloadTransactions$.pipe(
         RxOp.map(() => Array.from(transactionsMap.values())),
         RxOp.map(RD.success)
       )
 
       const pollingUpdates$ = FP.pipe(
-        Rx.merge(...transactionObservables), // Use merge instead of combineLatest for independent polling
+        Rx.merge(...transactionObservables),
         RxOp.map(() => Array.from(transactionsMap.values())),
         RxOp.map(RD.success),
         RxOp.catchError((error: Error) => Rx.of(RD.failure(error)))
@@ -228,25 +261,36 @@ export const createTransactionTrackingService = (
     RxOp.shareReplay(1)
   )
 
-  // Auto-cleanup completed transactions after configured retention time
+  // Cleanup: drop completed (retention) and long-stopped incomplete rows
   FP.pipe(
     getTransactions$,
-    RxOp.debounceTime(5000), // Debounce to avoid excessive cleanup
+    RxOp.debounceTime(5000),
     RxOp.tap((transactionsRD) => {
-      if (RD.isSuccess(transactionsRD)) {
-        const now = Date.now()
-        const retentionMs = completedTransactionRetentionMinutes * 60 * 1000
+      if (!RD.isSuccess(transactionsRD)) return
 
-        transactionsRD.value.forEach((tx) => {
-          // Use completedAt timestamp if available, otherwise fall back to startTime
+      const now = Date.now()
+      const retentionMs = completedTransactionRetentionMinutes * 60 * 1000
+
+      transactionsRD.value.forEach((tx) => {
+        if (tx.isComplete) {
           const completionTime = tx.completedAt || tx.startTime
-          if (tx.isComplete && now - completionTime > retentionMs) {
+          if (now - completionTime > retentionMs) {
             removeTransaction(tx.id)
           }
-        })
-      }
+          return
+        }
+
+        // Incomplete past max age: stop polling if still active, then drop after retention
+        if (now - tx.startTime >= maxIncompleteTrackingMs) {
+          if (!tx.pollingStopped) {
+            markPollingStopped(tx.id)
+          } else if (now - tx.startTime > maxIncompleteTrackingMs + retentionMs) {
+            removeTransaction(tx.id)
+          }
+        }
+      })
     })
-  ).subscribe() // Subscribe to activate the cleanup
+  ).subscribe()
 
   return {
     addTransaction,


### PR DESCRIPTION
## Summary
- Swap status tracking was the main driver of Liquify `/thorchain_api/thorchain/tx` volume (app hits `/thorchain/tx/stages/{hash}` via `getTxStatus$`).
- Stop double-firing polls from `RD.pending` in the `expand` loop (`filter` success/failure + `take(1)`).
- Floor poll intervals at ~THOR block time (6s+), back off long-running incomplete swaps (30s after 30m), and stop polling after 2h while keeping last known stages in the UI.
- Shared by THOR and MAYA trackers; unit tests cover intervals, completion, pending-not-doubling, and max-age stop.

## Test plan
- [x] `yarn test src/renderer/services/thorchain/transactionTracking.test.ts`
- [ ] Manual: run a THOR swap, confirm History progress still updates (slower countdown is expected)
- [ ] Manual: leave an incomplete tracked swap open; after age cap, polling stops without crashing UI
- [ ] Optional: compare Liquify `/thorchain/tx*` counts before/after for similar swap volume

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - THORChain transaction tracking now adjusts polling frequency based on transaction progress and age, improving responsiveness while reducing unnecessary checks.
  - Completed transactions are detected more reliably, including transactions requiring outbound confirmation.
  - Long-running incomplete transactions now stop tracking after a configurable time limit.
  - Stopped and completed transactions are handled more cleanly in transaction updates and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->