### PR TITLE
chore: replace uuid with crypto.randomUUID()

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,8 +137,7 @@
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.6.1",
     "redux-logger": "^3.0.6",
-    "rxjs": "^7.8.2",
-    "uuid": "^8.3.2"
+    "rxjs": "^7.8.2"
   },
   "devDependencies": {
     "@electron/notarize": "^2.5.0",

--- a/src/renderer/components/wallet/phrase/NewPhraseConfirm.tsx
+++ b/src/renderer/components/wallet/phrase/NewPhraseConfirm.tsx
@@ -4,7 +4,6 @@ import { TrashIcon as DeleteOutlined, ArrowUturnRightIcon as RedoOutlined } from
 import shuffleArray from 'lodash/shuffle'
 import { useIntl } from 'react-intl'
 import { useNavigate } from 'react-router-dom'
-import { v4 as uuidv4 } from 'uuid'
 
 import { isError } from '../../../../shared/utils/guard'
 import { isSelectedFactory, sortedSelected } from '../../../helpers/array'
@@ -36,8 +35,7 @@ export const NewPhraseConfirm = ({ mnemonic, onConfirm }: { mnemonic: string; on
     const words = mnemonic.split(' ')
     if (words && !initialized) {
       const res = words.map((e: string) => {
-        const uniqueId = uuidv4()
-        return { text: e, _id: uniqueId }
+        return { text: e, _id: crypto.randomUUID() }
       })
       updateWordList(res)
       setShuffledWordsList(shuffledWords(res))

--- a/yarn.lock
+++ b/yarn.lock
@@ -7616,7 +7616,6 @@ __metadata:
     tailwindcss: "npm:^4.3.1"
     ts-node: "npm:10.9.2"
     typescript: "npm:5.8.3"
-    uuid: "npm:^8.3.2"
     vite: "npm:^6.3.5"
     vite-plugin-svgr: "npm:^5.2.0"
     vite-plugin-wasm: "npm:^3.6.0"


### PR DESCRIPTION
## Summary
- `uuid` was only used in `NewPhraseConfirm` for React word list keys (`v4()`).
- Switch to built-in `crypto.randomUUID()` (same UUID v4) and remove the direct dependency.
- Closes the need for Dependabot’s `uuid` 8.3.2 → 14.0.1 bump ([#1129](https://github.com/asgardex/asgardex-desktop/pull/1129)) for our own code. Transitive `uuid` from `@vultisig/sdk` / xchain / jayson remains in the lockfile.

## Test plan
- [ ] Create new keystore wallet and complete phrase confirmation (shuffle / select words)
- [ ] `yarn test` / CI green on this PR
- [ ] Optional: close or supercede Dependabot PR #1129 after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Streamlined the wallet phrase confirmation experience by using the platform’s built-in secure identifier generation.
  * Removed an unnecessary third-party package, reducing application overhead.
  * No changes to the wallet phrase confirmation workflow or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->