### PR TITLE
fix(sol): floor priority fee so OneClick token swaps can broadcast

### DIFF
--- a/src/main/api/url.ts
+++ b/src/main/api/url.ts
@@ -55,7 +55,11 @@ const EXTERNALS_WHITELIST = [
   'dashboard.radixdlt.com',
   'explorer.solana.com',
   'adastat.net',
-  'tronscan.org'
+  'tronscan.org',
+  'suiscan.xyz',
+  'basescan.org',
+  'x.com',
+  'livenet.xrpl.org'
 ]
 
 export const openExternal = (target: string) => {

--- a/src/renderer/services/solana/common.ts
+++ b/src/renderer/services/solana/common.ts
@@ -17,10 +17,12 @@ import { Client$, ClientState, ClientState$ } from './types'
 const solApiKey = envOrDefault(import.meta.env.VITE_SOL_API_KEY, '')
 
 const defaultClientUrls = (): Record<Network, string[]> => {
+  const heliusMain = solApiKey ? [`https://mainnet.helius-rpc.com/?api-key=${solApiKey}`] : []
+  const heliusDev = solApiKey ? [`https://devnet.helius-rpc.com/?api-key=${solApiKey}`] : []
   return {
     [Network.Testnet]: ['https://api.testnet.solana.com'],
-    [Network.Stagenet]: [`https://devnet.helius-rpc.com/?api-key=${solApiKey}`],
-    [Network.Mainnet]: [`https://mainnet.helius-rpc.com/?api-key=${solApiKey}`]
+    [Network.Stagenet]: ['https://api.devnet.solana.com', ...heliusDev],
+    [Network.Mainnet]: ['https://api.mainnet-beta.solana.com', ...heliusMain]
   }
 }
 

--- a/src/renderer/services/solana/solPriorityFee.test.ts
+++ b/src/renderer/services/solana/solPriorityFee.test.ts
@@ -1,0 +1,17 @@
+import { baseAmount } from '@xchainjs/xchain-util'
+import { describe, expect, it } from 'vitest'
+
+import { toIntegerSolPriorityFee } from './solPriorityFee'
+
+describe('toIntegerSolPriorityFee', () => {
+  it('floors a fee that is not divisible by 1000', () => {
+    const fee = toIntegerSolPriorityFee(baseAmount(2044280, 9))
+    expect(fee.amount().toNumber()).toBe(2044000)
+    expect(fee.amount().dividedBy(1000).isInteger()).toBe(true)
+  })
+
+  it('leaves a multiple of 1000 unchanged', () => {
+    const fee = toIntegerSolPriorityFee(baseAmount(5000, 9))
+    expect(fee.amount().toNumber()).toBe(5000)
+  })
+})

--- a/src/renderer/services/solana/solPriorityFee.ts
+++ b/src/renderer/services/solana/solPriorityFee.ts
@@ -1,0 +1,10 @@
+import { baseAmount, BaseAmount } from '@xchainjs/xchain-util'
+
+/**
+ * xchain-solana calls `setComputeUnitPrice({ microLamports: fee / 1000 })`.
+ * Floor to a multiple of 1000 so that value is an integer BigInt.
+ */
+export const toIntegerSolPriorityFee = (fee: BaseAmount): BaseAmount => {
+  const microLamports = fee.amount().dividedToIntegerBy(1000)
+  return baseAmount(microLamports.times(1000), fee.decimal)
+}

--- a/src/renderer/services/solana/transaction.ts
+++ b/src/renderer/services/solana/transaction.ts
@@ -1,7 +1,7 @@
 import * as RD from '@devexperts/remote-data-ts'
 import { Network, TxHash } from '@xchainjs/xchain-client'
 import { SOLChain, SOLAsset } from '@xchainjs/xchain-solana'
-import { either as E, function as FP } from 'fp-ts'
+import { either as E, function as FP, option as O } from 'fp-ts'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
 
@@ -11,6 +11,7 @@ import { isLedgerWallet, isVultisigWallet } from '../../../shared/utils/guard'
 import { Network$ } from '../app/types'
 import * as C from '../clients'
 import { TxHashLD, ErrorId } from '../wallet/types'
+import { toIntegerSolPriorityFee } from './solPriorityFee'
 import { Client$, SendTxParams, TransactionService } from './types'
 import { createVultisigSolanaTx } from './vultisigTx'
 
@@ -62,16 +63,59 @@ export const createTransactionService = (client$: Client$, network$: Network$): 
     )
   }
 
-  // Vultisig transaction handler - MPC signing for SOL
   const sendVultisigTx = createVultisigSolanaTx()
+
+  const sendKeystoreTx = (params: SendTxParams): TxHashLD =>
+    FP.pipe(
+      client$,
+      RxOp.take(1),
+      RxOp.switchMap((oClient) =>
+        FP.pipe(
+          oClient,
+          O.fold(
+            () =>
+              Rx.of(
+                RD.failure({
+                  errorId: ErrorId.SEND_TX,
+                  msg: 'SOL client not ready'
+                })
+              ),
+            (client) =>
+              Rx.from(
+                client.transfer({
+                  walletIndex: params.walletIndex,
+                  asset: params.asset as Parameters<typeof client.transfer>[0]['asset'],
+                  amount: params.amount,
+                  recipient: params.recipient,
+                  memo: params.memo,
+                  priorityFee: toIntegerSolPriorityFee(params.priorityFee),
+                  allowOwnerOffCurve: params.allowOwnerOffCurve
+                })
+              ).pipe(
+                RxOp.map(RD.success),
+                RxOp.catchError((error) =>
+                  Rx.of(
+                    RD.failure({
+                      errorId: ErrorId.SEND_TX,
+                      msg: error?.message ?? error?.toString?.() ?? String(error)
+                    })
+                  )
+                )
+              )
+          )
+        )
+      ),
+      RxOp.startWith(RD.pending)
+    )
 
   const sendTx = (params: SendTxParams) =>
     FP.pipe(
-      Rx.combineLatest([network$]),
-      RxOp.switchMap(([network]) => {
+      network$,
+      RxOp.take(1),
+      RxOp.switchMap((network) => {
         if (isLedgerWallet(params.walletType)) return sendLedgerTx({ network, params })
         if (isVultisigWallet(params.walletType)) return sendVultisigTx({ network, params })
-        return common.sendTx(params)
+        return sendKeystoreTx(params)
       })
     )
 


### PR DESCRIPTION
## Summary

SOL → SOL sends worked; DEX / OneClick **SPL token** swaps failed with `No provider able to transfer`.

xchain-solana does `setComputeUnitPrice({ microLamports: fee / 1000 })`. A fee like `2044280` becomes `2044.28`, `BigInt()` throws, and the real `RangeError` is swallowed.

### Changes
- Floor SOL priority fee to a multiple of 1000 lamports
- If a 1Click deposit address is already an ATA, pass its owner into xchain
- Use public Solana RPC when Helius is missing/down (keystore)
- Allowlist explorer hosts: `suiscan.xyz`, `basescan.org`, `x.com`, `livenet.xrpl.org`

Verified locally: USDC → SUI OneClick broadcast succeeded after the fee floor.

## Test plan
- [x] `yarn test src/renderer/services/solana/solPriorityFee.test.ts --run`
- [x] Manual USDC → SUI OneClick send
- [ ] Smoke SOL native send
- [ ] Click SUI / Base / X / XRP explorer links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional external links, including Suiscan, Basescan, X, and XRPL Livenet.
  * Improved Solana transaction handling for token-account recipients.
  * Added Solana priority-fee normalization for more consistent transaction processing.
  * Solana mainnet and stagenet now use official RPC endpoints by default, with optional Helius support.

* **Bug Fixes**
  * Improved error handling and transaction readiness reporting for Solana transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->