### PR TITLE
chore: CHANGELOG and version bump for 1.45.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@
   in-repo human changelog — keep it updated when cutting releases.
 -->
 
+# 1.45.2 (2026-08-13)
+
+PRs merged to `develop` since tag `v1.45.1` / release branch for 1.45.1.
+
+## Update/Fixes
+
+- fix(sol): floor Solana priority fee so OneClick token swaps can broadcast [#1168](https://github.com/asgardex/asgardex-desktop/pull/1168)
+- fix(thorchain): cut Liquify load from swap `tx/stages` polling (block-time floor, no pending double-fire, incomplete max-age) [#1164](https://github.com/asgardex/asgardex-desktop/pull/1164)
+- fix(flatpak): rename app id to `com.asgardex.Asgardex` (asgardex.com), harden host keystore/Vultisig migration, pin Windows NSIS guid [#1165](https://github.com/asgardex/asgardex-desktop/pull/1165)
+
+## Chores
+
+- chore(deps): bump `@xchainjs/*` packages to latest [#1157](https://github.com/asgardex/asgardex-desktop/pull/1157)
+- chore: drop direct `uuid` dependency; use `crypto.randomUUID()` for phrase-confirm keys [#1167](https://github.com/asgardex/asgardex-desktop/pull/1167)
+
 # 1.45.1 (2026-08-07)
 
 PRs merged to `develop` since tag `v1.45.0` ([#1138](https://github.com/asgardex/asgardex-desktop/pull/1138)), plus [#1158](https://github.com/asgardex/asgardex-desktop/pull/1158) (EVM Max send fix; merge with or before this release).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "asgardex",
   "productName": "ASGARDEX",
   "desktopName": "com.asgardex.Asgardex.desktop",
-  "version": "1.45.1",
+  "version": "1.45.2",
   "description": "WALLET AND EXCHANGE CLIENT FOR THORCHAIN, MAYACHAIN, CHAINFLIP",
   "main": "build/main/electron.js",
   "scripts": {

--- a/resources/linux/com.asgardex.Asgardex.metainfo.xml
+++ b/resources/linux/com.asgardex.Asgardex.metainfo.xml
@@ -57,6 +57,7 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="1.45.2" date="2026-08-13" />
     <release version="1.45.1" date="2026-08-07" />
   </releases>
 


### PR DESCRIPTION
## Summary
- Bump `package.json` version to **1.45.2**
- Add `CHANGELOG.md` entry for merges since 1.45.1 (Sol priority fee, THOR stages poll, Flatpak app id, xchainjs, uuid removal)
- List `1.45.2` in AppStream metainfo releases

## Test plan
- [ ] Confirm version is `1.45.2` in `package.json`
- [ ] Skim CHANGELOG for accuracy vs merged PRs
- [ ] After merge: cut `release/v1.45.2` when ready to ship

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana priority fee handling.
  * Fixed THORChain swap-stage status polling for more reliable progress updates.
  * Improved desktop packaging and keystore migration behavior.
* **Release**
  * Updated the application to version 1.45.2.
  * Added release metadata for Linux distribution channels.
* **Maintenance**
  * Updated supporting components and strengthened secure random identifier generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->