### PR TITLE
chore(deps): bump axios to 1.18.1 (match xchainjs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@xchainjs/xchain-utxo-providers": "2.1.1",
     "@xchainjs/xchain-wallet": "2.0.33",
     "@xchainjs/xchain-zcash": "1.3.10",
-    "axios": "1.16.1",
+    "axios": "1.18.1",
     "bignumber.js": "^10.0.1",
     "clsx": "^2.1.1",
     "electron-debug": "^3.2.0",
@@ -209,7 +209,7 @@
     "pbkdf2": "3.1.2",
     "browserify-sign": "4.2.1",
     "keyv": "5.6.0",
-    "axios": "1.16.1"
+    "axios": "1.18.1"
   },
   "packageManager": "yarn@4.17.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7629,7 +7629,7 @@ __metadata:
     "@xchainjs/xchain-wallet": "npm:2.0.33"
     "@xchainjs/xchain-zcash": "npm:1.3.10"
     assert: "npm:^2.1.0"
-    axios: "npm:1.16.1"
+    axios: "npm:1.18.1"
     bignumber.js: "npm:^10.0.1"
     buffer: "npm:^6.0.3"
     clsx: "npm:^2.1.1"
@@ -7804,15 +7804,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.16.1":
-  version: 1.16.1
-  resolution: "axios@npm:1.16.1"
+"axios@npm:1.18.1":
+  version: 1.18.1
+  resolution: "axios@npm:1.18.1"
   dependencies:
     follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10/9b6218cf96321cfbbf8f160658d695367114bcf4fb62492bdc1ccd647f184b5c71ae400e5ecaaf41079bc561de2ecbaf1fec63f398b3ec53389beff7694df64c
+  checksum: 10/c4cdced3ee0a9bf7dcae189fbc74a124aa079d4f04dbd995e602d39c1419476e8d021f87ee39ac8d8398e5a55e6d0b986238b3645f0d9177ac80de87c2a73f18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bump `axios` **1.16.1 → 1.18.1** in both `dependencies` and `resolutions`
- Matches what `@xchainjs/*` already declares (`1.18.1`); the resolution pin was forcing the whole tree down to 1.16.1
- Prefer **1.18.1** over Dependabot **#1163** (1.19.0) so Asgardex stays aligned with xchainjs

## Test plan
- [x] `yarn install` resolves a single `axios@1.18.1` for xchain/vultisig/etc.
- [ ] CI tests + production build green
- [ ] Optional: close or supercede #1163 after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Axios dependency to version 1.18.1.
  * Applied the corresponding dependency resolution update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->