### PR TITLE
fix(swap): harden Chainflip stale-quote submit path (#1175)

### DIFF
--- a/src/renderer/components/modal/confirmation/WalletPasswordConfirmationModal.tsx
+++ b/src/renderer/components/modal/confirmation/WalletPasswordConfirmationModal.tsx
@@ -37,13 +37,18 @@ const PasswordModal = (props: PasswordModalProps) => {
   const intl = useIntl()
   const passwordRef = useRef<HTMLInputElement>(null)
 
-  /**
-   * Call onOk on success only
-   */
+  // Fire onOk exactly once per success cycle. Parent `onOk` identity can change
+  // (e.g. quote refresh recreating callbacks) while isSuccess stays true — without
+  // this guard that would re-invoke submit and can broadcast again (#1175).
+  const successHandledRef = useRef(false)
   useEffect(() => {
-    if (isSuccess) {
-      onOk()
+    if (!isSuccess) {
+      successHandledRef.current = false
+      return
     }
+    if (successHandledRef.current) return
+    successHandledRef.current = true
+    onOk()
   }, [isSuccess, onOk])
 
   useEffect(() => {

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -105,6 +105,7 @@ import { Tooltip } from '../uielements/tooltip'
 import { ErrorLabel } from './components/ErrorLabel'
 import { RecipientAddressSection } from './components/RecipientAddressSection'
 import { useSwapConfirmationModals } from './components/SwapConfirmationModals'
+import { SwapDepositConfirmation } from './components/SwapDepositConfirmation'
 import { SwapDestinationConfirmation } from './components/SwapDestinationConfirmation'
 import { SwapDetailsPanel } from './components/SwapDetailsPanel'
 import { SwapSettings } from './components/SwapSettings'
@@ -692,6 +693,47 @@ export const Swap = ({
       ),
     [oSwapParams]
   )
+
+  // Chainflip / OneClick: deposit address the source funds are transferred to.
+  const oDepositAddress: O.Option<Address> = useMemo(
+    () =>
+      FP.pipe(
+        oCFSwapParams,
+        O.map(({ recipient }) => recipient),
+        O.alt(() =>
+          FP.pipe(
+            oOneClickSwapParams,
+            O.map(({ recipient }) => recipient)
+          )
+        )
+      ),
+    [oCFSwapParams, oOneClickSwapParams]
+  )
+
+  const oDepositChannelId: O.Option<string> = useMemo(
+    () =>
+      FP.pipe(
+        oQuoteProtocol,
+        O.chain((quote) => (quote.depositChannelId ? O.some(quote.depositChannelId) : O.none))
+      ),
+    [oQuoteProtocol]
+  )
+
+  // Hard-gate submit when the selected quote's UI expiry has lapsed (#1175).
+  const [quoteExpired, setQuoteExpired] = useState(false)
+  const [quoteClock, setQuoteClock] = useState(() => new Date())
+  useEffect(() => {
+    if (O.isNone(oQuoteProtocol)) {
+      setQuoteExpired(false)
+      return
+    }
+    const timer = setInterval(() => setQuoteClock(new Date()), 1000)
+    return () => clearInterval(timer)
+  }, [oQuoteProtocol])
+  useEffect(() => {
+    const remainingMs = swapExpiry.getTime() - quoteClock.getTime()
+    setQuoteExpired(remainingMs < 60_000)
+  }, [swapExpiry, quoteClock])
 
   const setAmountToSwap = useCallback(
     (newAmountToSwap: BaseAmount) => {
@@ -1321,6 +1363,7 @@ export const Swap = ({
     oSwapParams,
     oCFSwapParams,
     oOneClickSwapParams,
+    quoteExpired,
     submitSwapTx,
     submitCFTx,
     submitOneClickTx,
@@ -1747,6 +1790,7 @@ export const Swap = ({
         RD.isPending(approveState) ||
         awaitingConfirmation ||
         isCausedSlippage ||
+        quoteExpired ||
         !swapResultAmountMax.baseAmount ||
         swapResultAmountMax.baseAmount.lte(zeroTargetBaseAmountMax) ||
         O.isNone(effectiveRecipientAddress) ||
@@ -1766,6 +1810,7 @@ export const Swap = ({
       approveState,
       awaitingConfirmation,
       isCausedSlippage,
+      quoteExpired,
       swapResultAmountMax.baseAmount,
       zeroTargetBaseAmountMax,
       effectiveRecipientAddress,
@@ -2104,6 +2149,15 @@ export const Swap = ({
         <SwapDestinationConfirmation
           outputDestination={oOutputDestination}
           intendedRecipient={effectiveRecipientAddress}
+          hidePrivateData={hidePrivateData}
+        />
+      )}
+      {!lockedWallet && (
+        <SwapDepositConfirmation
+          depositAddress={oDepositAddress}
+          depositChannelId={oDepositChannelId}
+          quoteExpiry={swapExpiry}
+          quoteExpired={quoteExpired}
           hidePrivateData={hidePrivateData}
         />
       )}

--- a/src/renderer/components/swap/TradeSwap.tsx
+++ b/src/renderer/components/swap/TradeSwap.tsx
@@ -1261,6 +1261,7 @@ export const TradeSwap = ({
     oSwapParams,
     oCFSwapParams: O.none,
     oOneClickSwapParams: O.none,
+    quoteExpired,
     submitSwapTx,
     submitCFTx: FP.constVoid,
     submitOneClickTx: FP.constVoid,

--- a/src/renderer/components/swap/components/SwapConfirmationModals.tsx
+++ b/src/renderer/components/swap/components/SwapConfirmationModals.tsx
@@ -32,6 +32,8 @@ type SwapConfirmationModalsProps = {
   oSwapParams: O.Option<SwapTxParams>
   oCFSwapParams: O.Option<SendTxParams>
   oOneClickSwapParams: O.Option<SendTxParams>
+  // When true, refuse to open confirm modals or submit (stale quote / expired channel window).
+  quoteExpired: boolean
   // Submit actions
   submitSwapTx: () => void
   submitCFTx: () => void
@@ -72,6 +74,7 @@ export const useSwapConfirmationModals = ({
   oSwapParams,
   oCFSwapParams,
   oOneClickSwapParams,
+  quoteExpired,
   submitSwapTx,
   submitCFTx,
   submitOneClickTx,
@@ -91,8 +94,77 @@ export const useSwapConfirmationModals = ({
   const [showLedgerModal, setShowLedgerModal] = useState(ModalState.None)
   const [showVultisigModal, setShowVultisigModal] = useState(ModalState.None)
 
+  // Keep latest params/actions in refs so confirm success handlers stay stable and
+  // cannot double-fire solely because a quote refresh recreated callback identities.
+  const oSwapParamsRef = useRef(oSwapParams)
+  const oCFSwapParamsRef = useRef(oCFSwapParams)
+  const oOneClickSwapParamsRef = useRef(oOneClickSwapParams)
+  const quoteExpiredRef = useRef(quoteExpired)
+  const submitSwapTxRef = useRef(submitSwapTx)
+  const submitCFTxRef = useRef(submitCFTx)
+  const submitOneClickTxRef = useRef(submitOneClickTx)
+  const submitApproveTxRef = useRef(submitApproveTx)
+  const passwordSubmitOnceRef = useRef(false)
+  const ledgerSubmitOnceRef = useRef(false)
+  const vultisigSubmitOnceRef = useRef(false)
+
+  useEffect(() => {
+    oSwapParamsRef.current = oSwapParams
+    oCFSwapParamsRef.current = oCFSwapParams
+    oOneClickSwapParamsRef.current = oOneClickSwapParams
+    quoteExpiredRef.current = quoteExpired
+    submitSwapTxRef.current = submitSwapTx
+    submitCFTxRef.current = submitCFTx
+    submitOneClickTxRef.current = submitOneClickTx
+    submitApproveTxRef.current = submitApproveTx
+  }, [
+    oSwapParams,
+    oCFSwapParams,
+    oOneClickSwapParams,
+    quoteExpired,
+    submitSwapTx,
+    submitCFTx,
+    submitOneClickTx,
+    submitApproveTx
+  ])
+
+  useEffect(() => {
+    if (showPasswordModal === ModalState.None) passwordSubmitOnceRef.current = false
+  }, [showPasswordModal])
+
+  useEffect(() => {
+    if (showLedgerModal === ModalState.None) ledgerSubmitOnceRef.current = false
+  }, [showLedgerModal])
+
+  useEffect(() => {
+    if (showVultisigModal === ModalState.None) vultisigSubmitOnceRef.current = false
+  }, [showVultisigModal])
+
+  const dispatchSwapSubmit = useCallback((mode: ModalState, onceRef: React.MutableRefObject<boolean>) => {
+    if (onceRef.current) return
+    if (mode === ModalState.Swap) {
+      if (quoteExpiredRef.current) {
+        logger.warn('Blocked swap submit: quote expired')
+        return
+      }
+      onceRef.current = true
+      if (O.isSome(oSwapParamsRef.current)) submitSwapTxRef.current()
+      else if (O.isSome(oCFSwapParamsRef.current)) submitCFTxRef.current()
+      else if (O.isSome(oOneClickSwapParamsRef.current)) submitOneClickTxRef.current()
+      return
+    }
+    if (mode === ModalState.Approve) {
+      onceRef.current = true
+      submitApproveTxRef.current()
+    }
+  }, [])
+
   // Dispatch to the correct modal based on wallet type
   const onSubmit = useCallback(() => {
+    if (quoteExpired) {
+      logger.warn('Blocked opening swap confirm: quote expired')
+      return
+    }
     if (useSourceAssetLedger) {
       setShowLedgerModal(ModalState.Swap)
     } else if (useSourceAssetVultisig) {
@@ -100,7 +172,7 @@ export const useSwapConfirmationModals = ({
     } else {
       setShowPasswordModal(ModalState.Swap)
     }
-  }, [useSourceAssetLedger, useSourceAssetVultisig])
+  }, [quoteExpired, useSourceAssetLedger, useSourceAssetVultisig])
 
   const onApprove = useCallback(() => {
     if (useSourceAssetLedger) {
@@ -113,58 +185,36 @@ export const useSwapConfirmationModals = ({
   }, [useSourceAssetLedger, useSourceAssetVultisig])
 
   // ─── Password Modal ──────────────────────────────────────────────────────
+  const onPasswordSuccess = useCallback(() => {
+    dispatchSwapSubmit(showPasswordModal, passwordSubmitOnceRef)
+    setShowPasswordModal(ModalState.None)
+  }, [dispatchSwapSubmit, showPasswordModal])
+
+  const onPasswordClose = useCallback(() => setShowPasswordModal(ModalState.None), [])
+
   const renderPasswordConfirmationModal = useMemo(() => {
-    const onSuccess = () => {
-      if (showPasswordModal === ModalState.Swap && O.isSome(oSwapParams)) {
-        submitSwapTx()
-      } else if (showPasswordModal === ModalState.Swap && O.isSome(oCFSwapParams)) {
-        submitCFTx()
-      } else if (showPasswordModal === ModalState.Swap && O.isSome(oOneClickSwapParams)) {
-        submitOneClickTx()
-      } else if (showPasswordModal === ModalState.Approve) {
-        submitApproveTx()
-      }
-      setShowPasswordModal(ModalState.None)
-    }
-    const onClose = () => setShowPasswordModal(ModalState.None)
     const render = showPasswordModal === ModalState.Swap || showPasswordModal === ModalState.Approve
     return (
       render && (
         <WalletPasswordConfirmationModal
-          onSuccess={onSuccess}
-          onClose={onClose}
+          onSuccess={onPasswordSuccess}
+          onClose={onPasswordClose}
           validatePassword$={validatePassword$}
         />
       )
     )
-  }, [
-    oCFSwapParams,
-    oOneClickSwapParams,
-    oSwapParams,
-    showPasswordModal,
-    submitApproveTx,
-    submitCFTx,
-    submitOneClickTx,
-    submitSwapTx,
-    validatePassword$
-  ])
+  }, [onPasswordClose, onPasswordSuccess, showPasswordModal, validatePassword$])
 
   // ─── Ledger Modal ─────────────────────────────────────────────────────────
+  const onLedgerSuccess = useCallback(() => {
+    dispatchSwapSubmit(showLedgerModal, ledgerSubmitOnceRef)
+    setShowLedgerModal(ModalState.None)
+  }, [dispatchSwapSubmit, showLedgerModal])
+
+  const onLedgerClose = useCallback(() => setShowLedgerModal(ModalState.None), [])
+
   const renderLedgerConfirmationModal = useMemo(() => {
     const visible = showLedgerModal === ModalState.Swap || showLedgerModal === ModalState.Approve
-    const onClose = () => setShowLedgerModal(ModalState.None)
-    const onSuccess = () => {
-      if (showLedgerModal === ModalState.Swap && O.isSome(oSwapParams)) {
-        submitSwapTx()
-      } else if (showLedgerModal === ModalState.Swap && O.isSome(oCFSwapParams)) {
-        submitCFTx()
-      } else if (showLedgerModal === ModalState.Swap && O.isSome(oOneClickSwapParams)) {
-        submitOneClickTx()
-      } else if (showLedgerModal === ModalState.Approve) {
-        submitApproveTx()
-      }
-      setShowLedgerModal(ModalState.None)
-    }
     const chainAsString = chainToString(sourceChain)
     const txtNeedsConnected = intl.formatMessage({ id: 'ledger.needsconnected' }, { chain: chainAsString })
     const description1 = isEvmChainToken(sourceAsset)
@@ -176,8 +226,8 @@ export const useSwapConfirmationModals = ({
       <LedgerConfirmationModal
         key="leder-conf-modal"
         network={network}
-        onSuccess={onSuccess}
-        onClose={onClose}
+        onSuccess={onLedgerSuccess}
+        onClose={onLedgerClose}
         visible={visible}
         chain={sourceChain}
         description1={description1}
@@ -199,12 +249,8 @@ export const useSwapConfirmationModals = ({
     sourceAsset,
     network,
     oSwapParams,
-    oCFSwapParams,
-    oOneClickSwapParams,
-    submitSwapTx,
-    submitCFTx,
-    submitOneClickTx,
-    submitApproveTx,
+    onLedgerSuccess,
+    onLedgerClose,
     useSourceAssetLedger
   ])
 
@@ -212,24 +258,8 @@ export const useSwapConfirmationModals = ({
   const onVultisigSuccess = useCallback(() => {
     logger.info('onVultisigSuccess', { vaultType })
     if (vaultType === 'fast') setShowVultisigModal(ModalState.None)
-    if (showVultisigModal === ModalState.Swap) {
-      if (O.isSome(oSwapParams)) submitSwapTx()
-      else if (O.isSome(oCFSwapParams)) submitCFTx()
-      else if (O.isSome(oOneClickSwapParams)) submitOneClickTx()
-    } else if (showVultisigModal === ModalState.Approve) {
-      submitApproveTx()
-    }
-  }, [
-    vaultType,
-    showVultisigModal,
-    oSwapParams,
-    oCFSwapParams,
-    oOneClickSwapParams,
-    submitSwapTx,
-    submitCFTx,
-    submitOneClickTx,
-    submitApproveTx
-  ])
+    dispatchSwapSubmit(showVultisigModal, vultisigSubmitOnceRef)
+  }, [dispatchSwapSubmit, showVultisigModal, vaultType])
 
   // Track Vultisig signing session
   const vultisigSessionRef = useRef(false)

--- a/src/renderer/components/swap/components/SwapDepositConfirmation.tsx
+++ b/src/renderer/components/swap/components/SwapDepositConfirmation.tsx
@@ -1,0 +1,93 @@
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+import { Address } from '@xchainjs/xchain-util'
+import clsx from 'clsx'
+import { function as FP, option as O } from 'fp-ts'
+import { useIntl } from 'react-intl'
+
+import { hiddenString } from '../../../helpers/stringHelper'
+
+type Props = {
+  // Chainflip / OneClick deposit address the source funds are transferred to.
+  depositAddress: O.Option<Address>
+  depositChannelId: O.Option<string>
+  quoteExpiry: Date
+  quoteExpired: boolean
+  hidePrivateData: boolean
+}
+
+/**
+ * Pre-sign summary for memo-less deposit protocols (Chainflip, OneClick).
+ * Makes the deposit address / channel id / quote expiry visible so a stale
+ * quote cannot be confirmed blindly (#1175).
+ */
+export const SwapDepositConfirmation = ({
+  depositAddress,
+  depositChannelId,
+  quoteExpiry,
+  quoteExpired,
+  hidePrivateData
+}: Props): JSX.Element | null => {
+  const intl = useIntl()
+
+  return FP.pipe(
+    depositAddress,
+    O.fold(
+      () => null,
+      (address) => (
+        <div className="mb-[14px] w-full rounded-lg border border-solid border-gray0 p-3 dark:border-gray0d">
+          <div className="mb-1 font-main text-[12px] text-gray2 uppercase dark:text-gray2d">
+            {intl.formatMessage({ id: 'swap.deposit.title' })}
+          </div>
+          <div className="font-main text-[13px] break-all text-text0 normal-case dark:text-text0d">
+            {hidePrivateData ? hiddenString : address}
+          </div>
+          <div className="mt-1 font-main text-[11px] text-gray1 dark:text-gray1d">
+            {intl.formatMessage({ id: 'swap.deposit.info' })}
+          </div>
+
+          {FP.pipe(
+            depositChannelId,
+            O.fold(
+              () => null,
+              (channelId) => (
+                <div className="mt-2">
+                  <div className="mb-1 font-main text-[12px] text-gray2 uppercase dark:text-gray2d">
+                    {intl.formatMessage({ id: 'swap.deposit.channelId' })}
+                  </div>
+                  <div className="font-main text-[12px] break-all text-text0 normal-case dark:text-text0d">
+                    {hidePrivateData ? hiddenString : channelId}
+                  </div>
+                </div>
+              )
+            )
+          )}
+
+          <div className="mt-2 font-main text-[11px] text-gray1 dark:text-gray1d">
+            {intl.formatMessage(
+              { id: 'swap.deposit.expiresAt' },
+              {
+                time: quoteExpiry
+                  .toISOString()
+                  .replace('T', ' ')
+                  .replace(/\.\d+Z$/, ' UTC')
+              }
+            )}
+          </div>
+
+          {quoteExpired && (
+            <div
+              className={clsx(
+                'mt-2 flex items-start gap-1 rounded-md p-2',
+                'font-main text-[12px] text-error0 dark:text-error0d',
+                'bg-error0/10 dark:bg-error0d/10'
+              )}
+              aria-live="polite">
+              <ExclamationTriangleIcon className="mt-[1px] h-[14px] w-[14px] shrink-0" />
+              <span>{intl.formatMessage({ id: 'swap.quote.expired' })}</span>
+            </div>
+          )}
+        </div>
+      )
+    )
+  )
+}

--- a/src/renderer/hooks/useSwapQuote.ts
+++ b/src/renderer/hooks/useSwapQuote.ts
@@ -59,6 +59,10 @@ export const useSwapQuote = ({
   const [quoteError, setQuoteError] = useState<O.Option<Error>>(O.none)
   const [isFetching, setIsFetching] = useState(false)
 
+  // NOTE (#1175): Chainflip estimates currently call requestDepositAddressV2 inside
+  // @xchainjs/xchain-aggregator, so every refresh opens a live deposit channel.
+  // Deferring channel open until final confirm requires an aggregator/SDK change;
+  // Asgardex hard-disables submit after quote UI expiry as the interim guard.
   const fetchQuote = useCallback(
     async (amount: BaseAmount) => {
       if (amount.amount().isZero()) {

--- a/src/renderer/i18n/de/swap.ts
+++ b/src/renderer/i18n/de/swap.ts
@@ -46,7 +46,14 @@ const swap: SwapMessages = {
   'swap.settings.subSwaps.auto': 'Auto Swap-Anzahl',
   'swap.destination.title': 'Ausgabeziel',
   'swap.destination.info': 'Die Swap-Ausgabe wird an diese Adresse gesendet. Überprüfe sie vor dem Signieren.',
-  'swap.destination.mismatch': 'Dies unterscheidet sich vom Empfänger, den du eingegeben hast ({recipient}). Fahre nur fort, wenn du dieses Ziel erkennst.'
+  'swap.destination.mismatch':
+    'Dies unterscheidet sich vom Empfänger, den du eingegeben hast ({recipient}). Fahre nur fort, wenn du dieses Ziel erkennst.',
+  'swap.quote.expired': 'Dieses Angebot ist abgelaufen. Aktualisiere das Angebot vor dem Swap.',
+  'swap.deposit.title': 'Einzahlungsadresse',
+  'swap.deposit.info':
+    'Deine Quellmittel werden an diese Einzahlungsadresse gesendet. Sende nicht nach Ablauf des Angebots.',
+  'swap.deposit.channelId': 'Einzahlungskanal',
+  'swap.deposit.expiresAt': 'Angebot läuft ab um {time}'
 }
 
 export default swap

--- a/src/renderer/i18n/en/swap.ts
+++ b/src/renderer/i18n/en/swap.ts
@@ -45,7 +45,14 @@ const swap: SwapMessages = {
   'swap.settings.subSwaps.auto': 'Auto swap count',
   'swap.destination.title': 'Output destination',
   'swap.destination.info': 'The swap output will be sent to this address. Verify it before signing.',
-  'swap.destination.mismatch': 'This differs from the recipient you entered ({recipient}). Only continue if you recognize this destination.'
+  'swap.destination.mismatch':
+    'This differs from the recipient you entered ({recipient}). Only continue if you recognize this destination.',
+  'swap.quote.expired': 'This quote has expired. Refresh the quote before swapping.',
+  'swap.deposit.title': 'Deposit address',
+  'swap.deposit.info':
+    'Your source funds will be transferred to this deposit address. Do not send after the quote expires.',
+  'swap.deposit.channelId': 'Deposit channel',
+  'swap.deposit.expiresAt': 'Quote expires at {time}'
 }
 
 export default swap

--- a/src/renderer/i18n/es/swap.ts
+++ b/src/renderer/i18n/es/swap.ts
@@ -47,7 +47,14 @@ const swap: SwapMessages = {
   'swap.settings.subSwaps.auto': 'Cantidad auto de swaps',
   'swap.destination.title': 'Destino de salida',
   'swap.destination.info': 'La salida del swap se enviará a esta dirección. Verifica antes de firmar.',
-  'swap.destination.mismatch': 'Esto difiere del destinatario que ingresaste ({recipient}). Solo continúa si reconoces este destino.'
+  'swap.destination.mismatch':
+    'Esto difiere del destinatario que ingresaste ({recipient}). Solo continúa si reconoces este destino.',
+  'swap.quote.expired': 'Esta cotización ha caducado. Actualiza la cotización antes de hacer el swap.',
+  'swap.deposit.title': 'Dirección de depósito',
+  'swap.deposit.info':
+    'Tus fondos de origen se transferirán a esta dirección de depósito. No envíes después de que caduque la cotización.',
+  'swap.deposit.channelId': 'Canal de depósito',
+  'swap.deposit.expiresAt': 'La cotización caduca a las {time}'
 }
 
 export default swap

--- a/src/renderer/i18n/fr/swap.ts
+++ b/src/renderer/i18n/fr/swap.ts
@@ -46,7 +46,14 @@ const swap: SwapMessages = {
   'swap.settings.subSwaps.auto': 'Nombre auto de swaps',
   'swap.destination.title': 'Destination de sortie',
   'swap.destination.info': 'La sortie du swap sera envoyée à cette adresse. Vérifiez-la avant de signer.',
-  'swap.destination.mismatch': 'Cela diffère du destinataire que vous avez entré ({recipient}). Continuez uniquement si vous reconnaissez cette destination.'
+  'swap.destination.mismatch':
+    'Cela diffère du destinataire que vous avez entré ({recipient}). Continuez uniquement si vous reconnaissez cette destination.',
+  'swap.quote.expired': 'Ce devis a expiré. Actualisez le devis avant de swapper.',
+  'swap.deposit.title': 'Adresse de dépôt',
+  'swap.deposit.info':
+    'Vos fonds source seront transférés à cette adresse de dépôt. N’envoyez pas après l’expiration du devis.',
+  'swap.deposit.channelId': 'Canal de dépôt',
+  'swap.deposit.expiresAt': 'Le devis expire à {time}'
 }
 
 export default swap

--- a/src/renderer/i18n/hi/swap.ts
+++ b/src/renderer/i18n/hi/swap.ts
@@ -45,6 +45,12 @@ const swap: SwapMessages = {
   'swap.settings.subSwaps.auto': 'ऑटो स्वैप संख्या',
   'swap.destination.title': 'आउटपुट गंतव्य',
   'swap.destination.info': 'स्वैप आउटपुट इस पते पर भेजा जाएगा। हस्ताक्षर करने से पहले इसे सत्यापित करें।',
-  'swap.destination.mismatch': 'यह आपके द्वारा दर्ज किए गए प्राप्तकर्ता ({recipient}) से भिन्न है। केवल तभी जारी रखें जब आप इस गंतव्य को पहचानते हों।'
+  'swap.destination.mismatch':
+    'यह आपके द्वारा दर्ज किए गए प्राप्तकर्ता ({recipient}) से भिन्न है। केवल तभी जारी रखें जब आप इस गंतव्य को पहचानते हों।',
+  'swap.quote.expired': 'यह कोट समाप्त हो गया है। स्वैप से पहले कोट रीफ़्रेश करें।',
+  'swap.deposit.title': 'जमा पता',
+  'swap.deposit.info': 'आपके स्रोत फंड इस जमा पते पर भेजे जाएंगे। कोट समाप्त होने के बाद न भेजें।',
+  'swap.deposit.channelId': 'जमा चैनल',
+  'swap.deposit.expiresAt': 'कोट समाप्ति समय {time}'
 }
 export default swap

--- a/src/renderer/i18n/ko/swap.ts
+++ b/src/renderer/i18n/ko/swap.ts
@@ -45,7 +45,12 @@ const swap: SwapMessages = {
   'swap.settings.subSwaps.auto': '자동 스왑 횟수',
   'swap.destination.title': '출력 대상',
   'swap.destination.info': '스왑 출력이 이 주소로 전송됩니다. 서명하기 전에 확인하세요.',
-  'swap.destination.mismatch': '이는 입력한 수신자({recipient})와 다릅니다. 이 대상을 인식하는 경우에만 계속하세요.'
+  'swap.destination.mismatch': '이는 입력한 수신자({recipient})와 다릅니다. 이 대상을 인식하는 경우에만 계속하세요.',
+  'swap.quote.expired': '이 견적이 만료되었습니다. 스왑하기 전에 견적을 새로고침하세요.',
+  'swap.deposit.title': '입금 주소',
+  'swap.deposit.info': '소스 자산이 이 입금 주소로 전송됩니다. 견적 만료 후에는 보내지 마세요.',
+  'swap.deposit.channelId': '입금 채널',
+  'swap.deposit.expiresAt': '견적 만료 시각 {time}'
 }
 
 export default swap

--- a/src/renderer/i18n/ru/swap.ts
+++ b/src/renderer/i18n/ru/swap.ts
@@ -46,7 +46,14 @@ const swap: SwapMessages = {
   'swap.settings.subSwaps.auto': 'Авто количество свопов',
   'swap.destination.title': 'Адрес вывода',
   'swap.destination.info': 'Результат обмена будет отправлен на этот адрес. Проверьте его перед подписанием.',
-  'swap.destination.mismatch': 'Это отличается от получателя, которого вы указали ({recipient}). Продолжайте только если вы узнаете этот адрес.'
+  'swap.destination.mismatch':
+    'Это отличается от получателя, которого вы указали ({recipient}). Продолжайте только если вы узнаете этот адрес.',
+  'swap.quote.expired': 'Этот котировочный запрос истёк. Обновите котировку перед обменом.',
+  'swap.deposit.title': 'Адрес депозита',
+  'swap.deposit.info':
+    'Исходные средства будут переведены на этот депозитный адрес. Не отправляйте после истечения котировки.',
+  'swap.deposit.channelId': 'Депозитный канал',
+  'swap.deposit.expiresAt': 'Котировка истекает в {time}'
 }
 
 export default swap

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -846,6 +846,11 @@ type SwapMessageKey =
   | 'swap.destination.title'
   | 'swap.destination.info'
   | 'swap.destination.mismatch'
+  | 'swap.quote.expired'
+  | 'swap.deposit.title'
+  | 'swap.deposit.info'
+  | 'swap.deposit.channelId'
+  | 'swap.deposit.expiresAt'
 
 export type SwapMessages = { [key in SwapMessageKey]: string }
 

--- a/src/renderer/views/pools/detail/TradingPanel.tsx
+++ b/src/renderer/views/pools/detail/TradingPanel.tsx
@@ -394,7 +394,14 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
   )
 
   // ── Hook 4: Swap quote ────────────────────────────────────────────────
-  const { selectedQuote, quoteError, isFetching, fetchQuote, resetQuote } = useSwapQuote({
+  const {
+    selectedQuote,
+    quoteError,
+    isFetching,
+    fetchQuote,
+    resetQuote,
+    expiry: swapExpiry
+  } = useSwapQuote({
     sourceAsset: safeSourceAsset,
     targetAsset: safeTargetAsset,
     sourceAssetDecimal: sourceDecimal,
@@ -408,6 +415,21 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
     slipTolerance,
     affiliateBps
   })
+
+  // Match main Swap: do not confirm/auto-submit an expired quote (#1175).
+  const [quoteExpired, setQuoteExpired] = useState(false)
+  const [quoteClock, setQuoteClock] = useState(() => new Date())
+  useEffect(() => {
+    if (O.isNone(selectedQuote)) {
+      setQuoteExpired(false)
+      return
+    }
+    const timer = setInterval(() => setQuoteClock(new Date()), 1000)
+    return () => clearInterval(timer)
+  }, [selectedQuote])
+  useEffect(() => {
+    setQuoteExpired(swapExpiry.getTime() - quoteClock.getTime() < 60_000)
+  }, [swapExpiry, quoteClock])
 
   // ── Hook 5: Swap execution ────────────────────────────────────────────
   const {
@@ -542,6 +564,7 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
     oSwapParams,
     oCFSwapParams,
     oOneClickSwapParams,
+    quoteExpired,
     submitSwapTx,
     submitCFTx,
     submitOneClickTx,
@@ -848,6 +871,18 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
       return
     }
 
+    if (quoteExpired) {
+      autoSubmitPendingRef.current = false
+      if (executingLevelRef.current) {
+        priceLevelService.updateLevel(assetKey, executingLevelRef.current, {
+          status: 'failed',
+          error: 'Quote expired'
+        })
+        executingLevelRef.current = null
+      }
+      return
+    }
+
     autoSubmitPendingRef.current = false
 
     if (!selectedQuote.value.canSwap) {
@@ -882,6 +917,7 @@ export const TradingPanel = ({ poolAsset, network, tradeMode, setTradeMode, hand
     isFetching,
     needsApproval,
     isApprovedState,
+    quoteExpired,
     onSubmit,
     priceLevelService,
     assetKey,


### PR DESCRIPTION
Block swap confirm/submit once quote UI expiry lapses, one-shot password confirm success so quote refreshes cannot re-fire submit, and surface Chainflip/OneClick deposit address + channel id before signing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deposit confirmation details for supported swaps, including deposit addresses, channel IDs, and quote expiration times.
  * Added countdown and expiry warnings for swap quotes.
  * Added localized messaging across supported languages.

* **Bug Fixes**
  * Prevented submissions using expired or nearly expired quotes.
  * Prevented duplicate swap confirmations and submissions.
  * Blocked expired limit orders from being submitted.
  * Ensured confirmation callbacks run only once per successful action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->