### PR TITLE
fix(swap): skip quote requests for trading-halted THOR/MAYA routes

### DIFF
--- a/src/renderer/helpers/protocolTradingHalt.test.ts
+++ b/src/renderer/helpers/protocolTradingHalt.test.ts
@@ -1,0 +1,103 @@
+import { BTCChain } from '@xchainjs/xchain-bitcoin'
+import { ETHChain } from '@xchainjs/xchain-ethereum'
+import { assetFromStringEx } from '@xchainjs/xchain-util'
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_MIMIR_HALT as DEFAULT_MIMIR_HALT_MAYA } from '../services/mayachain/const'
+import { DEFAULT_MIMIR_HALT } from '../services/thorchain/const'
+import { filterQuotableProtocols, isProtocolTradingHaltedForAssets } from './protocolTradingHalt'
+
+const ethUsdc = assetFromStringEx('ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48')
+const solNative = assetFromStringEx('SOL.SOL')
+
+const baseHaltState = {
+  thor: { haltedChains: [] as string[], mimirHalt: { ...DEFAULT_MIMIR_HALT } },
+  maya: { haltedChains: [] as string[], mimirHalt: { ...DEFAULT_MIMIR_HALT_MAYA } }
+}
+
+describe('protocolTradingHalt', () => {
+  it('does not filter Chainflip/OneClick when THOR trading is halted', () => {
+    const haltState = {
+      ...baseHaltState,
+      thor: {
+        haltedChains: [ETHChain],
+        mimirHalt: { ...DEFAULT_MIMIR_HALT, HALTETHTRADING: true }
+      }
+    }
+
+    expect(isProtocolTradingHaltedForAssets('Thorchain', ethUsdc, solNative, haltState)).toBe(true)
+    expect(isProtocolTradingHaltedForAssets('Chainflip', ethUsdc, solNative, haltState)).toBe(false)
+    expect(isProtocolTradingHaltedForAssets('OneClick', ethUsdc, solNative, haltState)).toBe(false)
+
+    expect(
+      filterQuotableProtocols(['Thorchain', 'Mayachain', 'Chainflip', 'OneClick'], ethUsdc, solNative, haltState)
+    ).toEqual(['Mayachain', 'Chainflip', 'OneClick'])
+  })
+
+  it('skips Thorchain when destination chain trading is halted on THOR', () => {
+    const haltState = {
+      ...baseHaltState,
+      thor: {
+        haltedChains: [],
+        mimirHalt: { ...DEFAULT_MIMIR_HALT, HALTSOLTRADING: true }
+      }
+    }
+
+    expect(isProtocolTradingHaltedForAssets('Thorchain', ethUsdc, solNative, haltState)).toBe(true)
+    expect(filterQuotableProtocols(['Thorchain', 'Chainflip'], ethUsdc, solNative, haltState)).toEqual(['Chainflip'])
+  })
+
+  it('skips Thorchain when inbound addresses mark source chain halted', () => {
+    const haltState = {
+      ...baseHaltState,
+      thor: {
+        haltedChains: [ETHChain],
+        mimirHalt: { ...DEFAULT_MIMIR_HALT }
+      }
+    }
+
+    expect(isProtocolTradingHaltedForAssets('Thorchain', ethUsdc, solNative, haltState)).toBe(true)
+  })
+
+  it('skips Thorchain when HALTTHORCHAIN is set', () => {
+    const haltState = {
+      ...baseHaltState,
+      thor: {
+        haltedChains: [],
+        mimirHalt: { ...DEFAULT_MIMIR_HALT, HALTTHORCHAIN: true }
+      }
+    }
+
+    expect(isProtocolTradingHaltedForAssets('Thorchain', ethUsdc, solNative, haltState)).toBe(true)
+  })
+
+  it('keeps Thorchain when only an unrelated chain is halted', () => {
+    const haltState = {
+      ...baseHaltState,
+      thor: {
+        haltedChains: [BTCChain],
+        mimirHalt: { ...DEFAULT_MIMIR_HALT, HALTBTCTRADING: true }
+      }
+    }
+
+    expect(isProtocolTradingHaltedForAssets('Thorchain', ethUsdc, solNative, haltState)).toBe(false)
+    expect(filterQuotableProtocols(['Thorchain', 'Chainflip'], ethUsdc, solNative, haltState)).toEqual([
+      'Thorchain',
+      'Chainflip'
+    ])
+  })
+
+  it('skips Mayachain when MAYA trading for a pair chain is halted', () => {
+    const ethMaya = assetFromStringEx('ETH.ETH')
+    const haltState = {
+      ...baseHaltState,
+      maya: {
+        haltedChains: [ETHChain],
+        mimirHalt: { ...DEFAULT_MIMIR_HALT_MAYA, HALTETHTRADING: true }
+      }
+    }
+
+    expect(isProtocolTradingHaltedForAssets('Mayachain', ethMaya, ethMaya, haltState)).toBe(true)
+    expect(isProtocolTradingHaltedForAssets('Thorchain', ethMaya, ethMaya, haltState)).toBe(false)
+  })
+})

--- a/src/renderer/helpers/protocolTradingHalt.ts
+++ b/src/renderer/helpers/protocolTradingHalt.ts
@@ -1,0 +1,68 @@
+import { Protocol } from '@xchainjs/xchain-aggregator/lib/types'
+import { AnyAsset, Chain } from '@xchainjs/xchain-util'
+
+import { MimirHalt as MimirHaltMaya } from '../services/mayachain/types'
+import { MimirHalt } from '../services/thorchain/types'
+import * as PoolHelpers from './poolHelper'
+import * as PoolHelpersMaya from './poolHelperMaya'
+
+export type ProtocolTradingHaltState = {
+  thor: {
+    haltedChains: Chain[]
+    mimirHalt: MimirHalt
+  }
+  maya: {
+    haltedChains: Chain[]
+    mimirHalt: MimirHaltMaya
+  }
+}
+
+const isThorUnquotableForChain = (chain: Chain, haltedChains: Chain[], mimirHalt: MimirHalt): boolean =>
+  PoolHelpers.disableAllActions({ chain, haltedChains, mimirHalt }) ||
+  PoolHelpers.disableTradingActions({ chain, haltedChains, mimirHalt })
+
+const isMayaUnquotableForChain = (chain: Chain, haltedChains: Chain[], mimirHalt: MimirHaltMaya): boolean =>
+  PoolHelpersMaya.disableAllActions({ chain, haltedChains, mimirHalt }) ||
+  PoolHelpersMaya.disableTradingActions({ chain, haltedChains, mimirHalt })
+
+/**
+ * True when THOR/MAYA cannot quote a swap for this asset pair because trading
+ * (or the whole chain/protocol) is halted for the source or destination chain.
+ * Chainflip / OneClick are never filtered here.
+ */
+export const isProtocolTradingHaltedForAssets = (
+  protocol: Protocol,
+  sourceAsset: AnyAsset,
+  targetAsset: AnyAsset,
+  haltState: ProtocolTradingHaltState
+): boolean => {
+  if (protocol === 'Thorchain') {
+    const { haltedChains, mimirHalt } = haltState.thor
+    return (
+      isThorUnquotableForChain(sourceAsset.chain, haltedChains, mimirHalt) ||
+      isThorUnquotableForChain(targetAsset.chain, haltedChains, mimirHalt)
+    )
+  }
+
+  if (protocol === 'Mayachain') {
+    const { haltedChains, mimirHalt } = haltState.maya
+    return (
+      isMayaUnquotableForChain(sourceAsset.chain, haltedChains, mimirHalt) ||
+      isMayaUnquotableForChain(targetAsset.chain, haltedChains, mimirHalt)
+    )
+  }
+
+  return false
+}
+
+/**
+ * Drop THOR/MAYA from the aggregator protocol list when the pair is trading-halted
+ * on that protocol, so estimateSwap never calls a known-dead route.
+ */
+export const filterQuotableProtocols = (
+  protocols: Protocol[],
+  sourceAsset: AnyAsset,
+  targetAsset: AnyAsset,
+  haltState: ProtocolTradingHaltState
+): Protocol[] =>
+  protocols.filter((protocol) => !isProtocolTradingHaltedForAssets(protocol, sourceAsset, targetAsset, haltState))

--- a/src/renderer/hooks/useSwapQuote.ts
+++ b/src/renderer/hooks/useSwapQuote.ts
@@ -16,9 +16,9 @@ import { convertBaseAmountDecimal } from '../helpers/assetHelper'
 import { createProtocolErrorMessage, validateProtocolsForAssets } from '../helpers/assetProtocolHelper'
 import { logger } from '../helpers/logger'
 import { filterQuotableProtocols } from '../helpers/protocolTradingHalt'
-import { useMayachainMimirHalt } from './useMimirHaltMaya'
-import { useThorchainMimirHalt } from './useMimirHalt'
 import { useAggregator } from '../store/aggregator/hooks'
+import { useThorchainMimirHalt } from './useMimirHalt'
+import { useMayachainMimirHalt } from './useMimirHaltMaya'
 
 type UseSwapQuoteParams = {
   sourceAsset: AnyAsset

--- a/src/renderer/hooks/useSwapQuote.ts
+++ b/src/renderer/hooks/useSwapQuote.ts
@@ -1,14 +1,23 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 
-import { AnyAsset, BaseAmount, baseAmount, CryptoAmount, isSecuredAsset } from '@xchainjs/xchain-util'
+import * as RD from '@devexperts/remote-data-ts'
+import { Protocol } from '@xchainjs/xchain-aggregator/lib/types'
+import { AnyAsset, BaseAmount, baseAmount, Chain, CryptoAmount, isSecuredAsset } from '@xchainjs/xchain-util'
 import { function as FP, option as O } from 'fp-ts'
+import { useObservableState } from 'observable-hooks'
+import * as RxOp from 'rxjs/operators'
 
 import type { ExtendedQuoteSwap } from '../components/swap/Swap.types'
 import { useChainflipContext } from '../contexts/ChainflipContext'
+import { useMidgardContext } from '../contexts/MidgardContext'
+import { useMidgardMayaContext } from '../contexts/MidgardMayaContext'
 import { useOneClickContext } from '../contexts/OneClickContext'
 import { convertBaseAmountDecimal } from '../helpers/assetHelper'
 import { createProtocolErrorMessage, validateProtocolsForAssets } from '../helpers/assetProtocolHelper'
 import { logger } from '../helpers/logger'
+import { filterQuotableProtocols } from '../helpers/protocolTradingHalt'
+import { useMayachainMimirHalt } from './useMimirHaltMaya'
+import { useThorchainMimirHalt } from './useMimirHalt'
 import { useAggregator } from '../store/aggregator/hooks'
 
 type UseSwapQuoteParams = {
@@ -52,6 +61,40 @@ export const useSwapQuote = ({
   const { estimateSwap, protocols, isBoostEnabled } = useAggregator()
   const { isOneClickSupportedAsset } = useOneClickContext()
   const { isChainflipSupportedAssetSync } = useChainflipContext()
+  const { mimirHalt: mimirHaltThor } = useThorchainMimirHalt()
+  const { mimirHalt: mimirHaltMaya } = useMayachainMimirHalt()
+  const {
+    service: {
+      pools: { haltedChains$: haltedChainsThor$ }
+    }
+  } = useMidgardContext()
+  const {
+    service: {
+      pools: { haltedChains$: haltedChainsMaya$ }
+    }
+  } = useMidgardMayaContext()
+
+  const [haltedChainsThor] = useObservableState(
+    () => FP.pipe(haltedChainsThor$, RxOp.map(RD.getOrElse((): Chain[] => []))),
+    [] as Chain[]
+  )
+  const [haltedChainsMaya] = useObservableState(
+    () => FP.pipe(haltedChainsMaya$, RxOp.map(RD.getOrElse((): Chain[] => []))),
+    [] as Chain[]
+  )
+
+  const haltState = useMemo(
+    () => ({
+      thor: { haltedChains: haltedChainsThor, mimirHalt: mimirHaltThor },
+      maya: { haltedChains: haltedChainsMaya, mimirHalt: mimirHaltMaya }
+    }),
+    [haltedChainsThor, mimirHaltThor, haltedChainsMaya, mimirHaltMaya]
+  )
+
+  const quotableProtocols: Protocol[] = useMemo(
+    () => filterQuotableProtocols(protocols, sourceAsset, targetAsset, haltState),
+    [protocols, sourceAsset, targetAsset, haltState]
+  )
 
   const requestIdRef = useRef(0)
   const [quotes, setQuotes] = useState<O.Option<ExtendedQuoteSwap[]>>(O.none)
@@ -74,12 +117,12 @@ export const useSwapQuote = ({
         O.getOrElse(() => false)
       )
 
-      // Validate protocols — both checks are backed by the protocols' fetched
-      // asset lists (with chain-level fallbacks), so picker and quote agree.
+      // Validate against halt-filtered protocols so a halted THOR/MAYA route is not
+      // treated as a usable enabled protocol for this pair.
       const protocolValidation = validateProtocolsForAssets(
         sourceAsset,
         targetAsset,
-        protocols,
+        quotableProtocols,
         isChainflipSupportedAssetSync,
         isOneClickSupportedAsset
       )
@@ -97,6 +140,13 @@ export const useSwapQuote = ({
         return
       }
 
+      if (quotableProtocols.length === 0) {
+        setQuoteError(O.some(new Error('No valid swap routes available')))
+        setSelectedQuote(O.none)
+        setIsFetching(false)
+        return
+      }
+
       setSelectedQuote(O.none)
       setIsFetching(true)
 
@@ -106,7 +156,8 @@ export const useSwapQuote = ({
         logger.debug('[useSwapQuote] fetchQuote amount:', {
           amountBase: amount.amount().toString(),
           amountDecimal: amount.decimal,
-          sourceAsset: `${sourceAsset.chain}.${sourceAsset.symbol}`
+          sourceAsset: `${sourceAsset.chain}.${sourceAsset.symbol}`,
+          protocols: quotableProtocols
         })
 
         const swapParams = {
@@ -124,7 +175,7 @@ export const useSwapQuote = ({
           toleranceBps: undefined
         }
 
-        const result = await estimateSwap({ ...swapParams, enableBoost: isBoostEnabled }, applyBps)
+        const result = await estimateSwap({ ...swapParams, enableBoost: isBoostEnabled }, applyBps, quotableProtocols)
 
         // Discard stale response if a newer request was fired
         if (currentRequestId !== requestIdRef.current) return
@@ -195,7 +246,7 @@ export const useSwapQuote = ({
       sourceAsset,
       sourceAssetDecimal,
       targetAsset,
-      protocols,
+      quotableProtocols,
       estimateSwap,
       sourceWalletAddress,
       quoteOnly,

--- a/src/renderer/store/aggregator/hooks.ts
+++ b/src/renderer/store/aggregator/hooks.ts
@@ -34,12 +34,19 @@ export const useAggregator = () => {
   /**
    * Estimate swap function
    * Dispatches `getEstimate` thunk and returns the result.
+   * `protocolsOverride` lets callers drop halted THOR/MAYA routes before the aggregator request.
    */
   const estimateSwap = useCallback(
-    async (params: QuoteSwapParams, useAffiliate: boolean) => {
+    async (params: QuoteSwapParams, useAffiliate: boolean, protocolsOverride?: Protocol[]) => {
       try {
         const result = await dispatch(
-          xchainActions.getEstimate({ aggregator, protocols, params, useAffiliate, network })
+          xchainActions.getEstimate({
+            aggregator,
+            protocols: protocolsOverride ?? protocols,
+            params,
+            useAffiliate,
+            network
+          })
         ).unwrap()
         return result
       } catch (error) {


### PR DESCRIPTION
## Summary

- Filter THOR/MAYA out of the aggregator protocol list before `estimateSwap` when source or destination trading is halted on that protocol (mimir `HALT*TRADING` / global halt / inbound `halted` / full chain halt).
- Stops noisy failures like `Error getting Thorchain quotes: Chain is halted` on pairs that still have viable Chainflip/OneClick routes (e.g. ETH → SOL while ETH trading is halted on THOR).
- Chainflip and OneClick are left untouched.

## Test plan

- [x] Unit tests in `protocolTradingHalt.test.ts`
- [ ] Quote ETH → SOL (or similar) while THOR shows a trading halt for ETH/SOL: confirm THOR is not requested and no THOR halt quote error appears
- [ ] Confirm Chainflip/OneClick quotes still return when available
- [ ] Confirm a non-halted THOR pair (e.g. BTC → ETH with no relevant halt) still requests THOR quotes
- [ ] Confirm MAYA is similarly skipped when MAYA trading is halted for the pair

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Swap quotes now automatically exclude THORChain and MAYAChain routes affected by protocol, source-chain, destination-chain, or global trading halts.
  - Prevents requests from being sent through unavailable routes.
  - Displays a clear error when no eligible swap routes remain.
  - Other supported protocols continue to be considered when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->