### PR TITLE
fix(evm): EIP-1559 headroom for THOR/MAYA pool deposit txs

### DIFF
--- a/src/renderer/services/evm/factory/transaction.ts
+++ b/src/renderer/services/evm/factory/transaction.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../../shared/api/io'
 import { ApiUrls, LedgerError } from '../../../../shared/api/types'
 import { DEFAULT_EVM_GAS_MULTIPLIER } from '../../../../shared/const'
-import { applyGasMultiplier } from '../../../../shared/evm/gas'
+import { applyGasMultiplier, eip1559FeesFromGasPrices } from '../../../../shared/evm/gas'
 import { getBlocktime } from '../../../../shared/evm/provider'
 import { isError, isEvmHDMode, isLedgerWallet, isVultisigWallet } from '../../../../shared/utils/guard'
 import { getEVMAssetAddress, isChainAsset, isEVMTokenAsset } from '../../../helpers/assetHelper'
@@ -86,6 +86,8 @@ export const createEvmTransactionService = (
             }),
             RxOp.switchMap(({ gasPrices: rawGasPrices, blockTime }) => {
               const gasPrices = applyGasMultiplier(rawGasPrices, gasMultiplier)
+              // Prefer EIP-1559 tip + 2*baseFee maxFee (via xchain) over legacy gasPrice.
+              const { maxPriorityFeePerGas } = eip1559FeesFromGasPrices(gasPrices, params.feeOption)
               const isERC20 = isEVMTokenAsset(params.asset as TokenAsset)
               const checkSummedContractAddress = isERC20
                 ? getAddress(getContractAddressFromAsset(params.asset as TokenAsset))
@@ -114,7 +116,7 @@ export const createEvmTransactionService = (
                       amount: isERC20 ? baseAmount(0, nativeAsset.decimal) : params.amount,
                       memo: unsignedTx.data,
                       recipient: router,
-                      gasPrice: gasPrices[params.feeOption],
+                      maxPriorityFeePerGas,
                       isMemoEncoded: true,
                       walletIndex: params.walletIndex
                     }
@@ -137,7 +139,7 @@ export const createEvmTransactionService = (
                       amount: isERC20 ? baseAmount(0, nativeAsset.decimal) : params.amount,
                       memo: unsignedTx.data,
                       recipient: router,
-                      gasPrice: gasPrices[params.feeOption],
+                      maxPriorityFeePerGas,
                       isMemoEncoded: true,
                       gasLimit: new BigNumber(defaultGasLimit),
                       walletIndex: params.walletIndex

--- a/src/shared/evm/gas.test.ts
+++ b/src/shared/evm/gas.test.ts
@@ -1,0 +1,42 @@
+import { FeeOption } from '@xchainjs/xchain-client'
+import { baseAmount } from '@xchainjs/xchain-util'
+import { describe, expect, it } from 'vitest'
+
+import { applyGasMultiplier, eip1559FeesFromGasPrices } from './gas'
+
+describe('shared/evm/gas', () => {
+  const gasPrices = {
+    average: baseAmount(1_000_000_000, 18),
+    fast: baseAmount(1_500_000_000, 18),
+    fastest: baseAmount(2_000_000_000, 18)
+  }
+
+  it('applyGasMultiplier leaves prices unchanged at 1x', () => {
+    expect(applyGasMultiplier(gasPrices, 1)).toEqual(gasPrices)
+  })
+
+  it('applyGasMultiplier scales all tiers', () => {
+    const scaled = applyGasMultiplier(gasPrices, 2)
+    expect(scaled.average.amount().toNumber()).toBe(2_000_000_000)
+    expect(scaled.fast.amount().toNumber()).toBe(3_000_000_000)
+    expect(scaled.fastest.amount().toNumber()).toBe(4_000_000_000)
+  })
+
+  it('eip1559FeesFromGasPrices maps FeeOption to maxPriorityFeePerGas only', () => {
+    expect(eip1559FeesFromGasPrices(gasPrices, FeeOption.Fast)).toEqual({
+      maxPriorityFeePerGas: gasPrices.fast
+    })
+    expect(eip1559FeesFromGasPrices(gasPrices, FeeOption.Average)).toEqual({
+      maxPriorityFeePerGas: gasPrices.average
+    })
+    expect(eip1559FeesFromGasPrices(gasPrices, FeeOption.Fastest)).toEqual({
+      maxPriorityFeePerGas: gasPrices.fastest
+    })
+  })
+
+  it('defaults eip1559FeesFromGasPrices to Fast', () => {
+    expect(eip1559FeesFromGasPrices(gasPrices)).toEqual({
+      maxPriorityFeePerGas: gasPrices.fast
+    })
+  })
+})

--- a/src/shared/evm/gas.ts
+++ b/src/shared/evm/gas.ts
@@ -1,5 +1,6 @@
+import { FeeOption } from '@xchainjs/xchain-client'
 import { GasPrices } from '@xchainjs/xchain-evm'
-import { baseAmount } from '@xchainjs/xchain-util'
+import { BaseAmount, baseAmount } from '@xchainjs/xchain-util'
 import BigNumber from 'bignumber.js'
 
 /**
@@ -22,3 +23,25 @@ export const applyGasMultiplier = (gasPrices: GasPrices, multiplier: number): Ga
     fastest: multiplyAmount(gasPrices.fastest)
   }
 }
+
+/**
+ * Fee fields for `@xchainjs/xchain-evm` `transfer()` on EIP-1559 networks.
+ *
+ * Passing `gasPrice` makes xchain upgrade type-1 → type-2 by setting
+ * `maxFeePerGas = maxPriorityFeePerGas = gasPrice` with **no base-fee headroom**.
+ * When base fee ticks up, `maxFee < baseFee` and the tx stalls (seen on ETH
+ * DAI→BTC `depositWithExpiry`).
+ *
+ * Passing only `maxPriorityFeePerGas` lets xchain set
+ * `maxFeePerGas = 2 * baseFee + tip`, which is the ethers v5-compatible path.
+ */
+export type Eip1559TransferFees = {
+  maxPriorityFeePerGas: BaseAmount
+}
+
+export const eip1559FeesFromGasPrices = (
+  gasPrices: GasPrices,
+  feeOption: FeeOption = FeeOption.Fast
+): Eip1559TransferFees => ({
+  maxPriorityFeePerGas: gasPrices[feeOption]
+})


### PR DESCRIPTION
## Summary

- ETH DAI→BTC \`depositWithExpiry\` was pricing fees via legacy \`gasPrice\`. On EIP-1559, xchain upgrades that to type-2 with \`maxFeePerGas = gasPrice\` (no base-fee headroom), so txs can stall when base fee rises above the signed max fee (e.g. [0xe2aa…9284](https://etherscan.io/tx/0xe2aa5112c4f26f8e0e58a8cfd438b700824da0a799bcac0d0851599185999284) at ~0.64 gwei while base fee was ~0.72 gwei).
- \`runSendPoolTx$\` now passes \`maxPriorityFeePerGas\` (from Fast/Average/Fastest estimate + gas multiplier) and lets xchain set \`maxFeePerGas = 2 * baseFee + tip\`.
- Scope: keystore EVM pool/swap deposit path only (not plain send / approve / Ledger IPC).

## Test plan

- [ ] ETH.DAI → BTC (THOR) swap: confirm broadcast tx is type-2 with \`maxFeePerGas > maxPriorityFeePerGas\` and \`maxFeePerGas >= ~2× current base fee\`
- [ ] Tx includes promptly under normal fee conditions (does not sit pending solely due to maxFee < baseFee)
- [ ] Other EVM pool deposits (e.g. USDC inbound) still work
- [x] \`yarn test --run src/shared/evm/gas.test.ts\`
- [x] \`yarn check:trunk\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EVM pool transfer fee handling by using EIP-1559 priority fees.
  * Applied the selected fee speed consistently to estimated-gas and fixed-gas transfers.
  * Defaulted fee selection to the Fast option when no preference is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->