### PR TITLE
chore(deps): bump xchain-aggregator to 3.0.1 (Chainflip broker expiry)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@reduxjs/toolkit": "^2.12.0",
     "@tanstack/react-table": "^8.21.3",
     "@vultisig/sdk": "2.19.19",
-    "@xchainjs/xchain-aggregator": "3.0.0",
+    "@xchainjs/xchain-aggregator": "3.0.1",
     "@xchainjs/xchain-arbitrum": "2.1.8",
     "@xchainjs/xchain-avax": "2.0.22",
     "@xchainjs/xchain-base": "1.0.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6412,9 +6412,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xchainjs/xchain-aggregator@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@xchainjs/xchain-aggregator@npm:3.0.0"
+"@xchainjs/xchain-aggregator@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@xchainjs/xchain-aggregator@npm:3.0.1"
   dependencies:
     "@chainflip/sdk": "npm:2.2.1"
     "@xchainjs/xchain-client": "npm:2.0.17"
@@ -6428,7 +6428,7 @@ __metadata:
     "@xchainjs/xchain-thorchain-query": "npm:3.1.3"
     "@xchainjs/xchain-util": "npm:2.0.7"
     "@xchainjs/xchain-wallet": "npm:2.0.34"
-  checksum: 10/2ba2b19481375d693c538613b72a58696d90f8581459128c0909e284af661d9a3e352ea1d58150cab7e85cb08107e0bf213644c5c359732228d26ff137673c98
+  checksum: 10/8dc9658183991cfc44b8e2420effa88f928e5227bdb81095e6cd4969da3b342c4ea2210976b7ff52b94b6adbb43785a58d90a93b058d2517fa6ecaedc1882760
   languageName: node
   linkType: hard
 
@@ -7593,7 +7593,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.4.1"
     "@vitest/ui": "npm:^4.1.9"
     "@vultisig/sdk": "npm:2.19.19"
-    "@xchainjs/xchain-aggregator": "npm:3.0.0"
+    "@xchainjs/xchain-aggregator": "npm:3.0.1"
     "@xchainjs/xchain-arbitrum": "npm:2.1.8"
     "@xchainjs/xchain-avax": "npm:2.0.22"
     "@xchainjs/xchain-base": "npm:1.0.22"


### PR DESCRIPTION
## Summary

- Bumps `@xchainjs/xchain-aggregator` **3.0.0 → 3.0.1**.
- Fixes Chainflip deposit-channel opens when Asgardex uses `brokerUrl` (`VITE_ASGARDEX_BROKER_URL`): the `@chainflip/sdk` broker path omits `estimatedDepositChannelExpiryTime`, and aggregator 3.0.0 threw **after** the channel was already opened.
- 3.0.1 falls back to a ~24h TTL (Chainflip channel lifetime) so broker-mode submits can proceed. Upstream: [xchainjs/xchainjs-lib#1759](https://github.com/xchainjs/xchainjs-lib/pull/1759).

No app code changes required — Asgardex already opens channels via `requestChainflipDepositAddress` and guards on `expiresAt` (`openChainflipChannelForSubmit`).

## Test plan

- [x] `yarn install` resolves aggregator 3.0.1
- [x] `yarn test` — Chainflip helper tests + full suite green (1005 passed)
- [ ] Manual: with broker URL configured, confirm a Chainflip swap opens a deposit channel and broadcasts (no `missing estimatedDepositChannelExpiryTime` abort)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the aggregator component to version 3.0.1 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->