### PR TITLE
fix(swap): show Chainflip channel-open wait in SwapTxModal

### DIFF
--- a/src/renderer/components/swap/SwapTxModal.tsx
+++ b/src/renderer/components/swap/SwapTxModal.tsx
@@ -46,21 +46,6 @@ export const SwapTxModal = ({
 
   const timerValue = useMemo(() => getTxTimerValue(swapTx), [swapTx])
 
-  const txModalTitle = useMemo(
-    () =>
-      FP.pipe(
-        swapTx,
-        RD.fold(
-          () => 'swap.state.sending',
-          () => 'swap.state.pending',
-          () => 'swap.state.error',
-          () => 'common.tx.success'
-        ),
-        (id) => intl.formatMessage({ id })
-      ),
-    [intl, swapTx]
-  )
-
   const protocol: O.Option<string> = FP.pipe(
     oQuoteProtocol,
     O.map((qp) => qp.protocol as string)
@@ -75,6 +60,31 @@ export const SwapTxModal = ({
         O.toUndefined
       )
     )
+  )
+
+  const isOpeningChainflipChannel =
+    RD.isPending(swapTx) &&
+    FP.pipe(
+      protocol,
+      O.exists((p) => p === 'Chainflip')
+    ) &&
+    O.isNone(channelId)
+
+  const txModalTitle = useMemo(
+    () =>
+      isOpeningChainflipChannel
+        ? intl.formatMessage({ id: 'swap.state.openingChannel' })
+        : FP.pipe(
+            swapTx,
+            RD.fold(
+              () => 'swap.state.sending',
+              () => 'swap.state.pending',
+              () => 'swap.state.error',
+              () => 'common.tx.success'
+            ),
+            (id) => intl.formatMessage({ id })
+          ),
+    [intl, isOpeningChainflipChannel, swapTx]
   )
 
   const oTxHash = useMemo(

--- a/src/renderer/components/swap/components/SwapConfirmationModals.tsx
+++ b/src/renderer/components/swap/components/SwapConfirmationModals.tsx
@@ -116,21 +116,23 @@ export const useSwapConfirmationModals = ({
   // ─── Password Modal ──────────────────────────────────────────────────────
   const renderPasswordConfirmationModal = useMemo(() => {
     const onSuccess = () => {
+      // Close immediately so Chainflip channel-open / broadcast wait lives in SwapTxModal,
+      // not in a blank gap after password confirm.
+      const mode = showPasswordModal
+      setShowPasswordModal(ModalState.None)
       void (async () => {
         try {
-          if (showPasswordModal === ModalState.Swap && O.isSome(oSwapParams)) {
+          if (mode === ModalState.Swap && O.isSome(oSwapParams)) {
             submitSwapTx()
-          } else if (showPasswordModal === ModalState.Swap && O.isSome(oCFSwapParams)) {
+          } else if (mode === ModalState.Swap && O.isSome(oCFSwapParams)) {
             await submitCFTx()
-          } else if (showPasswordModal === ModalState.Swap && O.isSome(oOneClickSwapParams)) {
+          } else if (mode === ModalState.Swap && O.isSome(oOneClickSwapParams)) {
             submitOneClickTx()
-          } else if (showPasswordModal === ModalState.Approve) {
+          } else if (mode === ModalState.Approve) {
             submitApproveTx()
           }
         } catch (error) {
           logger.error('Swap confirm failed after password', error)
-        } finally {
-          setShowPasswordModal(ModalState.None)
         }
       })()
     }
@@ -162,21 +164,21 @@ export const useSwapConfirmationModals = ({
     const visible = showLedgerModal === ModalState.Swap || showLedgerModal === ModalState.Approve
     const onClose = () => setShowLedgerModal(ModalState.None)
     const onSuccess = () => {
+      const mode = showLedgerModal
+      setShowLedgerModal(ModalState.None)
       void (async () => {
         try {
-          if (showLedgerModal === ModalState.Swap && O.isSome(oSwapParams)) {
+          if (mode === ModalState.Swap && O.isSome(oSwapParams)) {
             submitSwapTx()
-          } else if (showLedgerModal === ModalState.Swap && O.isSome(oCFSwapParams)) {
+          } else if (mode === ModalState.Swap && O.isSome(oCFSwapParams)) {
             await submitCFTx()
-          } else if (showLedgerModal === ModalState.Swap && O.isSome(oOneClickSwapParams)) {
+          } else if (mode === ModalState.Swap && O.isSome(oOneClickSwapParams)) {
             submitOneClickTx()
-          } else if (showLedgerModal === ModalState.Approve) {
+          } else if (mode === ModalState.Approve) {
             submitApproveTx()
           }
         } catch (error) {
           logger.error('Swap confirm failed after Ledger', error)
-        } finally {
-          setShowLedgerModal(ModalState.None)
         }
       })()
     }
@@ -226,14 +228,17 @@ export const useSwapConfirmationModals = ({
   // ─── Vultisig Modal ───────────────────────────────────────────────────────
   const onVultisigSuccess = useCallback(() => {
     logger.info('onVultisigSuccess', { vaultType })
+    const mode = showVultisigModal
+    // FastVault: close confirm modal immediately; SecureVault stays open for QR / device signing.
+    // Either way, Chainflip channel-open pending state is published by submitCFTx into swapState.
     if (vaultType === 'fast') setShowVultisigModal(ModalState.None)
     void (async () => {
       try {
-        if (showVultisigModal === ModalState.Swap) {
+        if (mode === ModalState.Swap) {
           if (O.isSome(oSwapParams)) submitSwapTx()
           else if (O.isSome(oCFSwapParams)) await submitCFTx()
           else if (O.isSome(oOneClickSwapParams)) submitOneClickTx()
-        } else if (showVultisigModal === ModalState.Approve) {
+        } else if (mode === ModalState.Approve) {
           submitApproveTx()
         }
       } catch (error) {

--- a/src/renderer/hooks/useSwapExecution.ts
+++ b/src/renderer/hooks/useSwapExecution.ts
@@ -346,6 +346,12 @@ export const useSwapExecution = ({
     const fromAsset = toChainflipQuoteAsset(sourceAsset)
     const destinationAsset = toChainflipQuoteAsset(targetAsset)
 
+    // Show SwapTxModal immediately (pending) while the deposit channel opens.
+    // Channel open can take seconds on the broker path — do not leave a blank gap
+    // after the password/Ledger confirm modal closes.
+    setSwapStartTime(Date.now())
+    subscribeSwapState(Rx.of({ swapTx: RD.pending }))
+
     logger.info('Opening Chainflip deposit channel before broadcast', {
       from: `${fromAsset.chain}.${fromAsset.symbol}`,
       to: `${destinationAsset.chain}.${destinationAsset.symbol}`,
@@ -377,7 +383,6 @@ export const useSwapExecution = ({
       expiresAt: channel.expiresAt.toISOString()
     })
 
-    setSwapStartTime(Date.now())
     subscribeSwapState(swapCF$(buildChainflipBroadcastParams(params, channel)))
   }, [
     cfSwapParams,

--- a/src/renderer/i18n/de/swap.ts
+++ b/src/renderer/i18n/de/swap.ts
@@ -3,6 +3,7 @@ import { SwapMessages } from '../types'
 const swap: SwapMessages = {
   'swap.state.sending': 'Transaktion wird gesendet',
   'swap.state.pending': 'Swappen',
+  'swap.state.openingChannel': 'Chainflip-Kanal wird geöffnet',
   'swap.state.error': 'Fehler beim Swap',
   'swap.state.success': 'Erfolgreich getauscht',
   'swap.input': 'Eingabe',

--- a/src/renderer/i18n/en/swap.ts
+++ b/src/renderer/i18n/en/swap.ts
@@ -3,6 +3,7 @@ import { SwapMessages } from '../types'
 const swap: SwapMessages = {
   'swap.state.sending': 'Sending Transaction',
   'swap.state.pending': 'Swapping',
+  'swap.state.openingChannel': 'Opening Chainflip channel',
   'swap.state.success': 'Successful swap',
   'swap.state.error': 'Swap error',
   'swap.input': 'Input',

--- a/src/renderer/i18n/es/swap.ts
+++ b/src/renderer/i18n/es/swap.ts
@@ -3,6 +3,7 @@ import { SwapMessages } from '../types'
 const swap: SwapMessages = {
   'swap.state.sending': 'Enviando transacción',
   'swap.state.pending': 'Intercambio',
+  'swap.state.openingChannel': 'Abriendo canal de Chainflip',
   'swap.state.success': 'Canje satisfactorio',
   'swap.state.error': 'Error de intercambio',
   'swap.input': 'Entrada',

--- a/src/renderer/i18n/fr/swap.ts
+++ b/src/renderer/i18n/fr/swap.ts
@@ -3,6 +3,7 @@ import { SwapMessages } from '../types'
 const swap: SwapMessages = {
   'swap.state.sending': 'Envoi de la transaction',
   'swap.state.pending': 'Échange en cours',
+  'swap.state.openingChannel': 'Ouverture du canal Chainflip',
   'swap.state.success': 'Échange réussi',
   'swap.state.error': "Erreur lors de l'échange",
   'swap.input': 'Entrée',

--- a/src/renderer/i18n/hi/swap.ts
+++ b/src/renderer/i18n/hi/swap.ts
@@ -3,6 +3,7 @@ import { SwapMessages } from '../types'
 const swap: SwapMessages = {
   'swap.state.sending': 'लेन-देन भेजा जा रहा है',
   'swap.state.pending': 'स्वैपिंग जारी है',
+  'swap.state.openingChannel': 'Chainflip चैनल खोला जा रहा है',
   'swap.state.success': 'सफल स्वैप',
   'swap.state.error': 'स्वैप में त्रुटि',
   'swap.input': 'इनपुट',

--- a/src/renderer/i18n/ko/swap.ts
+++ b/src/renderer/i18n/ko/swap.ts
@@ -3,6 +3,7 @@ import { SwapMessages } from '../types'
 const swap: SwapMessages = {
   'swap.state.sending': '트랜잭션 전송 중',
   'swap.state.pending': '스왑 중',
+  'swap.state.openingChannel': 'Chainflip 채널 여는 중',
   'swap.state.success': '스왑 성공',
   'swap.state.error': '스왑 오류',
   'swap.input': '입력',

--- a/src/renderer/i18n/ru/swap.ts
+++ b/src/renderer/i18n/ru/swap.ts
@@ -3,6 +3,7 @@ import { SwapMessages } from '../types'
 const swap: SwapMessages = {
   'swap.state.sending': 'Отправка транзакции',
   'swap.state.pending': 'Обмениваю',
+  'swap.state.openingChannel': 'Открытие канала Chainflip',
   'swap.state.success': 'Обмен совершён',
   'swap.state.error': 'Ошибка при обмене',
   'swap.input': 'Отдаете',

--- a/src/renderer/i18n/types.ts
+++ b/src/renderer/i18n/types.ts
@@ -839,6 +839,7 @@ type SwapMessageKey =
   | 'swap.streaming.quantity.info'
   | 'swap.state.sending'
   | 'swap.state.pending'
+  | 'swap.state.openingChannel'
   | 'swap.state.success'
   | 'swap.state.error'
   | 'swap.info.max.balance'


### PR DESCRIPTION
## Summary

- After password/Ledger confirm on a Chainflip swap, Asgardex awaited `requestChainflipDepositAddress` **before** showing `SwapTxModal`, which felt like a hang (blank gap after confirm).
- Confirm modals now close immediately on success.
- `submitCFSwap` publishes `swapTx: pending` first so the transaction modal covers the channel-open wait, then opens the channel and broadcasts.
- While pending with no live channel id yet, the modal title is **Opening Chainflip channel** (`swap.state.openingChannel`, all 7 locales).

## Test plan

- [x] Unit suite green (`yarn test`)
- [ ] Manual: keystore SOL→ETH Chainflip swap — after password confirm, SwapTxModal should appear immediately with “Opening Chainflip channel”, then move to sending/swapping (no blank hang)
- [ ] Manual: same path on Ledger confirm
- [ ] Manual: channel-open failure still surfaces error in SwapTxModal