### PR TITLE
fix(ui): rank native ETH.ETH first in asset search

### DIFF
--- a/src/renderer/components/uielements/assets/assetMenu/AssetMenu.helper.test.ts
+++ b/src/renderer/components/uielements/assets/assetMenu/AssetMenu.helper.test.ts
@@ -1,0 +1,66 @@
+import { AssetARB, AssetAETH } from '@xchainjs/xchain-arbitrum'
+import { AssetAVAX } from '@xchainjs/xchain-avax'
+import { AssetBETH } from '@xchainjs/xchain-base'
+import { AssetBTC } from '@xchainjs/xchain-bitcoin'
+import { AssetBSC } from '@xchainjs/xchain-bsc'
+import { AssetETH } from '@xchainjs/xchain-ethereum'
+import { assetFromStringEx, AssetType } from '@xchainjs/xchain-util'
+import { describe, expect, it } from 'vitest'
+
+import {
+  assetMatchesSearch,
+  ExtendedAssetType,
+  filterAndSortAssetsForMenu,
+  getAssetSearchRank
+} from './AssetMenu.helper'
+
+const assetUSDT = assetFromStringEx('ETH.USDT-0xdAC17F958D2ee523a2206206994597C13D831ec7')
+const assetUSDC = assetFromStringEx('ETH.USDC-0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')
+const assetAvaxEth = { ...AssetETH, chain: AssetAVAX.chain, type: AssetType.TOKEN }
+const assetBscEth = { ...AssetETH, chain: AssetBSC.chain, type: AssetType.TOKEN }
+
+describe('AssetMenu.helper', () => {
+  describe('getAssetSearchRank', () => {
+    it('ranks native ETH.ETH first when searching eth', () => {
+      expect(getAssetSearchRank(AssetETH, 'eth')).toBeLessThan(getAssetSearchRank(AssetBETH, 'eth'))
+      expect(getAssetSearchRank(AssetETH, 'eth')).toBeLessThan(getAssetSearchRank(AssetAETH, 'eth'))
+      expect(getAssetSearchRank(AssetETH, 'eth')).toBeLessThan(getAssetSearchRank(assetUSDT, 'eth'))
+      expect(getAssetSearchRank(AssetETH, 'eth')).toBeLessThan(getAssetSearchRank(assetAvaxEth, 'eth'))
+    })
+
+    it('ranks L2 native ETH ahead of ERC-20s on ETH when searching eth', () => {
+      expect(getAssetSearchRank(AssetBETH, 'eth')).toBeLessThan(getAssetSearchRank(assetUSDT, 'eth'))
+      expect(getAssetSearchRank(AssetAETH, 'eth')).toBeLessThan(getAssetSearchRank(assetUSDC, 'eth'))
+    })
+
+    it('ranks native BTC.BTC first when searching btc', () => {
+      expect(getAssetSearchRank(AssetBTC, 'btc')).toBe(0)
+    })
+  })
+
+  describe('filterAndSortAssetsForMenu', () => {
+    const poolOrder = [assetUSDT, assetUSDC, assetAvaxEth, AssetBETH, assetBscEth, AssetARB, AssetAETH, AssetETH]
+
+    it('puts ETH.ETH first when typing eth (All filter)', () => {
+      const sorted = filterAndSortAssetsForMenu(poolOrder, 'eth', ExtendedAssetType.All)
+      expect(sorted[0]).toEqual(AssetETH)
+    })
+
+    it('puts ETH.ETH first when typing eth with Native filter', () => {
+      const sorted = filterAndSortAssetsForMenu(poolOrder, 'eth', ExtendedAssetType.Native)
+      expect(sorted[0]).toEqual(AssetETH)
+      expect(sorted.every((a) => a.type === AssetType.NATIVE)).toBe(true)
+      expect(sorted).not.toContainEqual(assetUSDT)
+      expect(sorted).not.toContainEqual(assetUSDC)
+    })
+
+    it('keeps original order when search is empty', () => {
+      expect(filterAndSortAssetsForMenu(poolOrder, '', ExtendedAssetType.All)).toEqual(poolOrder)
+    })
+
+    it('matches via assetMatchesSearch substring', () => {
+      expect(assetMatchesSearch(assetUSDT, 'usdt')).toBe(true)
+      expect(assetMatchesSearch(AssetETH, 'usdt')).toBe(false)
+    })
+  })
+})

--- a/src/renderer/components/uielements/assets/assetMenu/AssetMenu.helper.ts
+++ b/src/renderer/components/uielements/assets/assetMenu/AssetMenu.helper.ts
@@ -1,0 +1,90 @@
+import { AnyAsset, assetToString, AssetType } from '@xchainjs/xchain-util'
+
+export enum ExtendedAssetType {
+  All = 'all',
+  Favorite = 'favorite',
+  Native = AssetType.NATIVE,
+  Secured = AssetType.SECURED
+}
+
+export const filterButtons = [
+  {
+    text: 'All',
+    type: ExtendedAssetType.All
+  },
+  {
+    text: 'Native',
+    type: ExtendedAssetType.Native
+  },
+  {
+    text: 'Secured',
+    type: ExtendedAssetType.Secured
+  }
+]
+
+/**
+ * Lower rank = better match (earlier in the asset picker list).
+ * Typing "eth" should put native ETH.ETH ahead of ETH.USDT / BASE.ETH / etc.
+ */
+export const getAssetSearchRank = (asset: AnyAsset, search: string): number => {
+  const q = search.trim().toLowerCase()
+  if (!q) return 0
+
+  const ticker = asset.ticker.toLowerCase()
+  const chain = asset.chain.toLowerCase()
+  const symbol = asset.symbol.toLowerCase()
+  const full = assetToString(asset).toLowerCase()
+  const isNative = asset.type === AssetType.NATIVE
+
+  // Native gas on the chain named like the query (ETH.ETH, BTC.BTC, …)
+  if (isNative && ticker === q && chain === q) return 0
+  // Other native gas with matching ticker (BASE.ETH, ARB.ETH, …)
+  if (isNative && ticker === q) return 1
+  // Exact ticker match (tokens)
+  if (ticker === q) return 2
+  if (ticker.startsWith(q) && isNative) return 3
+  if (ticker.startsWith(q)) return 4
+  // Symbol (e.g. USDT-0x… when searching "usdt")
+  if (symbol === q || symbol.startsWith(`${q}-`)) return 5
+  if (symbol.startsWith(q)) return 6
+  // Chain match — ETH.USDT when searching "eth" (after ticker hits)
+  if (chain === q && isNative) return 7
+  if (chain === q) return 8
+  if (full.includes(q)) return 9
+  return 100
+}
+
+export const assetMatchesSearch = (asset: AnyAsset, search: string): boolean => {
+  const q = search.trim().toLowerCase()
+  if (!q) return true
+  return assetToString(asset).toLowerCase().includes(q)
+}
+
+export const assetMatchesTypeFilter = (asset: AnyAsset, activeFilter: ExtendedAssetType): boolean => {
+  if (asset.type === AssetType.SYNTH) return false
+  if (activeFilter === ExtendedAssetType.Native && asset.type !== AssetType.NATIVE) return false
+  if (activeFilter === ExtendedAssetType.Secured && asset.type !== AssetType.SECURED) return false
+  return true
+}
+
+/**
+ * Filter by type + search, then rank so exact native ticker matches come first.
+ * Empty search keeps the incoming order.
+ */
+export const filterAndSortAssetsForMenu = (
+  assets: AnyAsset[],
+  search: string,
+  activeFilter: ExtendedAssetType
+): AnyAsset[] => {
+  const filtered = assets.filter(
+    (asset) => assetMatchesTypeFilter(asset, activeFilter) && assetMatchesSearch(asset, search)
+  )
+
+  const q = search.trim()
+  if (!q) return filtered
+
+  return filtered
+    .map((asset, index) => ({ asset, index, rank: getAssetSearchRank(asset, q) }))
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .map(({ asset }) => asset)
+}

--- a/src/renderer/components/uielements/assets/assetMenu/AssetMenu.tsx
+++ b/src/renderer/components/uielements/assets/assetMenu/AssetMenu.tsx
@@ -5,7 +5,7 @@ import { ArchiveBoxXMarkIcon, CheckIcon, XMarkIcon, ExclamationTriangleIcon } fr
 import { Network } from '@xchainjs/xchain-client'
 import { AnyAsset, assetToString, AssetType, Chain } from '@xchainjs/xchain-util'
 import clsx from 'clsx'
-import { array as A, function as FP, nonEmptyArray as NEA, option as O } from 'fp-ts'
+import { function as FP, nonEmptyArray as NEA, option as O } from 'fp-ts'
 import { useIntl } from 'react-intl'
 
 import { getChainAsset } from '../../../../helpers/chainHelper'
@@ -15,6 +15,7 @@ import { BaseButton, FilterButton } from '../../button'
 import { InputSearch } from '../../input'
 import { AssetData } from '../assetData'
 import { AssetIcon } from '../assetIcon/AssetIcon'
+import { ExtendedAssetType, filterAndSortAssetsForMenu, filterButtons } from './AssetMenu.helper'
 
 export type Props = {
   asset: AnyAsset
@@ -28,27 +29,7 @@ export type Props = {
   synthDisabled?: boolean
 }
 
-export enum ExtendedAssetType {
-  All = 'all',
-  Favorite = 'favorite',
-  Native = AssetType.NATIVE,
-  Secured = AssetType.SECURED
-}
-
-export const filterButtons = [
-  {
-    text: 'All',
-    type: ExtendedAssetType.All
-  },
-  {
-    text: 'Native',
-    type: ExtendedAssetType.Native
-  },
-  {
-    text: 'Secured',
-    type: ExtendedAssetType.Secured
-  }
-]
+export { ExtendedAssetType, filterButtons } from './AssetMenu.helper'
 
 export const AssetMenu = (props: Props): JSX.Element => {
   const {
@@ -81,24 +62,7 @@ export const AssetMenu = (props: Props): JSX.Element => {
   )
 
   const filteredAssets = useMemo(
-    () =>
-      FP.pipe(
-        assets,
-        A.filter((asset) => {
-          // if synth asset is disabled for To Asset type
-          if (asset.type === AssetType.SYNTH) return false
-
-          if (activeFilter === ExtendedAssetType.Native && asset.type !== AssetType.NATIVE) return false
-          if (activeFilter === ExtendedAssetType.Secured && asset.type !== AssetType.SECURED) return false
-
-          if (searchValue) {
-            const lowerSearchValue = searchValue.toLowerCase()
-            return assetToString(asset).toLowerCase().includes(lowerSearchValue)
-          }
-          // If there's no search value, return all assets
-          return true
-        })
-      ),
+    () => filterAndSortAssetsForMenu(assets, searchValue, activeFilter),
     [activeFilter, assets, searchValue]
   )
 


### PR DESCRIPTION
## Summary

- Typing \`eth\` in the swap asset picker kept pool order, so \`ETH.USDT\` / \`ETH.USDC\` appeared before native \`ETH.ETH\`.
- Add search relevance ranking in \`AssetMenu\`:
  1. Native gas on the chain named like the query (\`ETH.ETH\`, \`BTC.BTC\`)
  2. Other native gas with matching ticker (\`BASE.ETH\`, \`ARB.ETH\`)
  3. Exact ticker / symbol matches
  4. Chain matches (e.g. \`ETH.USDT\` when searching \`eth\`)
- Native type filter unchanged; empty search keeps original order.

## Test plan

- [x] \`yarn vitest run src/renderer/components/uielements/assets/assetMenu/AssetMenu.helper.test.ts\`
- [ ] Manual: open swap asset picker, type \`eth\` — \`ETH.ETH\` should be first
- [ ] Manual: Native filter + \`eth\` — natives only, \`ETH.ETH\` first
- [ ] Manual: type \`usdt\` / \`btc\` still behave sensibly