### PR TITLE
fix(swap): stop lastblock polls from re-firing quotes every 60s

### DIFF
--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -94,6 +94,7 @@ import {
   isVultisigMode,
   isVultisigVaultPasswordRequired
 } from '../../services/wallet/types'
+import { useAggregator } from '../../store/aggregator/hooks'
 import { useCoingecko } from '../../store/gecko/hooks'
 import { AssetWithAmount } from '../../types/asgardex'
 import { GECKO_MAP } from '../../types/generated/geckoMap'
@@ -1345,20 +1346,50 @@ export const Swap = ({
   const isSwapTxInFlight = !RD.isInitial(swapState.swapTx)
   const pauseQuoteRefresh = isConfirmModalOpen || isSwapTxInFlight
 
+  // Keep latest fetchSwap without putting its identity in effect deps — halt/lastblock
+  // polls used to recreate the callback every ~60s and re-fire every provider quote.
+  const fetchSwapRef = useRef(fetchSwap)
+  fetchSwapRef.current = fetchSwap
+  const { protocols, isBoostEnabled } = useAggregator()
+  // Primitive so price-driven Option recreation does not re-fire quotes.
+  const applyBpsValue = FP.pipe(
+    oApplyBps,
+    O.fold(
+      () => 'none' as const,
+      (apply) => (apply ? 'true' : 'false')
+    )
+  )
+
   // Fetch / refresh quotes when inputs change — skipped during confirm / in-flight swap.
   useEffect(() => {
     if (pauseQuoteRefresh) return
-    if (amountToSwap.gt(baseAmount(0, amountToSwap.decimal)) && O.isSome(oApplyBps)) {
-      fetchSwap(amountToSwap)
+    if (amountToSwap.gt(baseAmount(0, amountToSwap.decimal)) && applyBpsValue !== 'none') {
+      void fetchSwapRef.current(amountToSwap)
     }
-  }, [sourceAsset, targetAsset, fetchSwap, amountToSwap, oApplyBps, pauseQuoteRefresh])
+  }, [
+    sourceAsset,
+    targetAsset,
+    amountToSwap,
+    applyBpsValue,
+    pauseQuoteRefresh,
+    // Include quote-relevant settings so changing them still refreshes without
+    // depending on fetchSwap identity.
+    streamingInterval,
+    streamingQuantity,
+    slipTolerance,
+    quoteOnly,
+    sourceWalletAddress,
+    effectiveRecipientAddressString,
+    protocols,
+    isBoostEnabled
+  ])
 
   const onInputBlurHandler = useCallback(() => {
     if (pauseQuoteRefresh) return
     if (amountToSwap.gt(baseAmount(0, amountToSwap.decimal))) {
-      fetchSwap(amountToSwap)
+      void fetchSwapRef.current(amountToSwap)
     }
-  }, [amountToSwap, fetchSwap, pauseQuoteRefresh])
+  }, [amountToSwap, pauseQuoteRefresh])
 
   const setAmountToSwapFromPercentValue = useCallback(
     (percents: number) => {

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -94,7 +94,6 @@ import {
   isVultisigMode,
   isVultisigVaultPasswordRequired
 } from '../../services/wallet/types'
-import { useAggregator } from '../../store/aggregator/hooks'
 import { useCoingecko } from '../../store/gecko/hooks'
 import { AssetWithAmount } from '../../types/asgardex'
 import { GECKO_MAP } from '../../types/generated/geckoMap'
@@ -476,6 +475,7 @@ export const Swap = ({
     fetchQuote: fetchSwap,
     selectQuote: handleSelectQuote,
     resetQuote,
+    quoteRefreshKey,
     canSwap,
     slippage: swapSlippage,
     expiry: swapExpiry,
@@ -1346,11 +1346,11 @@ export const Swap = ({
   const isSwapTxInFlight = !RD.isInitial(swapState.swapTx)
   const pauseQuoteRefresh = isConfirmModalOpen || isSwapTxInFlight
 
-  // Keep latest fetchSwap without putting its identity in effect deps — halt/lastblock
-  // polls used to recreate the callback every ~60s and re-fire every provider quote.
+  // Latest fetchSwap via ref + value-key deps (not fetchSwap identity).
   const fetchSwapRef = useRef(fetchSwap)
-  fetchSwapRef.current = fetchSwap
-  const { protocols, isBoostEnabled } = useAggregator()
+  useEffect(() => {
+    fetchSwapRef.current = fetchSwap
+  }, [fetchSwap])
   // Primitive so price-driven Option recreation does not re-fire quotes.
   const applyBpsValue = FP.pipe(
     oApplyBps,
@@ -1372,16 +1372,13 @@ export const Swap = ({
     amountToSwap,
     applyBpsValue,
     pauseQuoteRefresh,
-    // Include quote-relevant settings so changing them still refreshes without
-    // depending on fetchSwap identity.
     streamingInterval,
     streamingQuantity,
     slipTolerance,
     quoteOnly,
     sourceWalletAddress,
     effectiveRecipientAddressString,
-    protocols,
-    isBoostEnabled
+    quoteRefreshKey
   ])
 
   const onInputBlurHandler = useCallback(() => {

--- a/src/renderer/hooks/useMimirHalt.ts
+++ b/src/renderer/hooks/useMimirHalt.ts
@@ -91,7 +91,7 @@ export const useThorchainMimirHalt = (): { mimirHaltRD: MimirHaltRD; mimirHalt: 
         ),
         // lastblock ticks every 60s for scheduled-halt height checks; only emit when
         // halt flags actually change so quote/fetch callbacks do not churn identity.
-        RxOp.distinctUntilChanged((prev, curr) => isEqual(prev, curr)),
+        RxOp.distinctUntilChanged(isEqual),
         RxOp.shareReplay(1)
       ),
     RD.initial

--- a/src/renderer/hooks/useMimirHalt.ts
+++ b/src/renderer/hooks/useMimirHalt.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { array as A, function as FP, option as O } from 'fp-ts'
+import { isEqual } from 'lodash'
 import { useObservableState } from 'observable-hooks'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
@@ -88,6 +89,9 @@ export const useThorchainMimirHalt = (): { mimirHaltRD: MimirHaltRD; mimirHalt: 
             })
           )
         ),
+        // lastblock ticks every 60s for scheduled-halt height checks; only emit when
+        // halt flags actually change so quote/fetch callbacks do not churn identity.
+        RxOp.distinctUntilChanged((prev, curr) => isEqual(prev, curr)),
         RxOp.shareReplay(1)
       ),
     RD.initial

--- a/src/renderer/hooks/useMimirHaltMaya.ts
+++ b/src/renderer/hooks/useMimirHaltMaya.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 
 import * as RD from '@devexperts/remote-data-ts'
 import { array as A, function as FP, option as O } from 'fp-ts'
+import { isEqual } from 'lodash'
 import { useObservableState } from 'observable-hooks'
 import * as Rx from 'rxjs'
 import * as RxOp from 'rxjs/operators'
@@ -76,6 +77,9 @@ export const useMayachainMimirHalt = (): { mimirHaltRD: MimirHaltRD; mimirHalt: 
             })
           )
         ),
+        // lastblock ticks every 60s for scheduled-halt height checks; only emit when
+        // halt flags actually change so quote/fetch callbacks do not churn identity.
+        RxOp.distinctUntilChanged((prev, curr) => isEqual(prev, curr)),
         RxOp.shareReplay(1)
       ),
     RD.initial

--- a/src/renderer/hooks/useMimirHaltMaya.ts
+++ b/src/renderer/hooks/useMimirHaltMaya.ts
@@ -79,7 +79,7 @@ export const useMayachainMimirHalt = (): { mimirHaltRD: MimirHaltRD; mimirHalt: 
         ),
         // lastblock ticks every 60s for scheduled-halt height checks; only emit when
         // halt flags actually change so quote/fetch callbacks do not churn identity.
-        RxOp.distinctUntilChanged((prev, curr) => isEqual(prev, curr)),
+        RxOp.distinctUntilChanged(isEqual),
         RxOp.shareReplay(1)
       ),
     RD.initial

--- a/src/renderer/hooks/useSwapQuote.ts
+++ b/src/renderer/hooks/useSwapQuote.ts
@@ -4,7 +4,6 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Protocol } from '@xchainjs/xchain-aggregator/lib/types'
 import { AnyAsset, BaseAmount, baseAmount, Chain, CryptoAmount, isSecuredAsset } from '@xchainjs/xchain-util'
 import { function as FP, option as O } from 'fp-ts'
-import { isEqual } from 'lodash'
 import { useObservableState } from 'observable-hooks'
 import * as RxOp from 'rxjs/operators'
 
@@ -18,6 +17,7 @@ import { createProtocolErrorMessage, validateProtocolsForAssets } from '../helpe
 import { quoteNeedsRouterApproval } from '../helpers/evmApprovalHelper'
 import { logger } from '../helpers/logger'
 import { filterQuotableProtocols } from '../helpers/protocolTradingHalt'
+import { getCurrentNetworkState } from '../services/app/service'
 import { useAggregator } from '../store/aggregator/hooks'
 import { useThorchainMimirHalt } from './useMimirHalt'
 import { useMayachainMimirHalt } from './useMimirHaltMaya'
@@ -43,6 +43,11 @@ type UseSwapQuoteResult = {
   fetchQuote: (amount: BaseAmount) => Promise<void>
   selectQuote: (quote: ExtendedQuoteSwap) => void
   resetQuote: () => void
+  /**
+   * Content-stable signature of hook-owned quote inputs (halt-filtered protocols,
+   * boost, network). Use in refresh effects instead of `fetchQuote` identity.
+   */
+  quoteRefreshKey: string
   // Derived
   canSwap: boolean
   slippage: number
@@ -62,6 +67,7 @@ export const useSwapQuote = ({
   affiliateBps
 }: UseSwapQuoteParams): UseSwapQuoteResult => {
   const { estimateSwap, protocols, isBoostEnabled } = useAggregator()
+  const network = getCurrentNetworkState()
   const { isOneClickSupportedAsset } = useOneClickContext()
   const { isChainflipSupportedAssetSync } = useChainflipContext()
   const { mimirHalt: mimirHaltThor } = useThorchainMimirHalt()
@@ -94,19 +100,16 @@ export const useSwapQuote = ({
     [haltedChainsThor, mimirHaltThor, haltedChainsMaya, mimirHaltMaya]
   )
 
-  const quotableProtocolsRaw: Protocol[] = useMemo(
+  const quotableProtocols: Protocol[] = useMemo(
     () => filterQuotableProtocols(protocols, sourceAsset, targetAsset, haltState),
     [protocols, sourceAsset, targetAsset, haltState]
   )
-  // Keep a stable array identity when halt/pool polls rebuild equivalent protocol lists.
-  const quotableProtocolsRef = useRef(quotableProtocolsRaw)
-  const quotableProtocols = useMemo(() => {
-    if (isEqual(quotableProtocolsRef.current, quotableProtocolsRaw)) {
-      return quotableProtocolsRef.current
-    }
-    quotableProtocolsRef.current = quotableProtocolsRaw
-    return quotableProtocolsRaw
-  }, [quotableProtocolsRaw])
+
+  // Halt-filtered protocol set + boost/network — not fetchQuote identity.
+  const quoteRefreshKey = useMemo(
+    () => `${quotableProtocols.join(',')}|boost:${isBoostEnabled}|net:${network}`,
+    [quotableProtocols, isBoostEnabled, network]
+  )
 
   const requestIdRef = useRef(0)
   /** Sticky user/auto selection across background re-quotes (Chainflip stays Chainflip). */
@@ -357,6 +360,7 @@ export const useSwapQuote = ({
     fetchQuote,
     selectQuote,
     resetQuote,
+    quoteRefreshKey,
     canSwap,
     slippage,
     expiry,

--- a/src/renderer/hooks/useSwapQuote.ts
+++ b/src/renderer/hooks/useSwapQuote.ts
@@ -4,6 +4,7 @@ import * as RD from '@devexperts/remote-data-ts'
 import { Protocol } from '@xchainjs/xchain-aggregator/lib/types'
 import { AnyAsset, BaseAmount, baseAmount, Chain, CryptoAmount, isSecuredAsset } from '@xchainjs/xchain-util'
 import { function as FP, option as O } from 'fp-ts'
+import { isEqual } from 'lodash'
 import { useObservableState } from 'observable-hooks'
 import * as RxOp from 'rxjs/operators'
 
@@ -93,10 +94,19 @@ export const useSwapQuote = ({
     [haltedChainsThor, mimirHaltThor, haltedChainsMaya, mimirHaltMaya]
   )
 
-  const quotableProtocols: Protocol[] = useMemo(
+  const quotableProtocolsRaw: Protocol[] = useMemo(
     () => filterQuotableProtocols(protocols, sourceAsset, targetAsset, haltState),
     [protocols, sourceAsset, targetAsset, haltState]
   )
+  // Keep a stable array identity when halt/pool polls rebuild equivalent protocol lists.
+  const quotableProtocolsRef = useRef(quotableProtocolsRaw)
+  const quotableProtocols = useMemo(() => {
+    if (isEqual(quotableProtocolsRef.current, quotableProtocolsRaw)) {
+      return quotableProtocolsRef.current
+    }
+    quotableProtocolsRef.current = quotableProtocolsRaw
+    return quotableProtocolsRaw
+  }, [quotableProtocolsRaw])
 
   const requestIdRef = useRef(0)
   /** Sticky user/auto selection across background re-quotes (Chainflip stays Chainflip). */
@@ -105,6 +115,8 @@ export const useSwapQuote = ({
   const [selectedQuote, setSelectedQuote] = useState<O.Option<ExtendedQuoteSwap>>(O.none)
   const [quoteError, setQuoteError] = useState<O.Option<Error>>(O.none)
   const [isFetching, setIsFetching] = useState(false)
+  // Aggregator QuoteSwap has no expiry field — capture a 15m window when a fetch lands.
+  const [expiry, setExpiry] = useState<Date>(() => new Date())
 
   // Pair change invalidates any sticky protocol preference from the previous route.
   useEffect(() => {
@@ -117,6 +129,7 @@ export const useSwapQuote = ({
         preferredProtocolRef.current = null
         setSelectedQuote(O.none)
         setQuoteError(O.none)
+        setExpiry(new Date())
         return
       }
 
@@ -217,6 +230,9 @@ export const useSwapQuote = ({
         const nextSelected = pickSelectedQuote(sortedQuotes, sortedApprovalBlocked, preferredProtocolRef.current)
 
         setQuotes(O.some(allQuotes))
+        // Reset the UI expiry window only when a new quote response lands — not when the
+        // user merely switches the selected protocol in the existing result set.
+        setExpiry(new Date(Date.now() + 15 * 60 * 1000))
 
         if (nextSelected) {
           // Only clear a sticky preference when that protocol disappeared from the new set.
@@ -290,6 +306,7 @@ export const useSwapQuote = ({
     setQuotes(O.none)
     setSelectedQuote(O.none)
     setQuoteError(O.none)
+    setExpiry(new Date())
   }, [])
 
   // Derived values from selected quote
@@ -312,22 +329,6 @@ export const useSwapQuote = ({
         O.fold(
           () => 0,
           (txDetails) => txDetails.slipBasisPoints / 100
-        )
-      ),
-    [selectedQuote]
-  )
-
-  const expiry: Date = useMemo(
-    () =>
-      FP.pipe(
-        selectedQuote,
-        O.fold(
-          () => new Date(),
-          () => {
-            const now = new Date()
-            now.setMinutes(now.getMinutes() + 15)
-            return now
-          }
         )
       ),
     [selectedQuote]


### PR DESCRIPTION
## Summary
- THOR/MAYA lastblock polls every 60s (for scheduled-halt height checks) were rebuilding `mimirHalt` object identity even when halt **flags** were unchanged.
- That churned `quotableProtocols` → `fetchQuote` → Swap’s `useEffect` (which depended on `fetchSwap`), so every provider flipped back to “Loading quote…” about a minute after quoting.
- The expiry bar always stuck near ~14 minutes because expiry was recomputed as `now + 15m` on every `selectedQuote` change (including those spurious re-quotes). Aggregator `QuoteSwap` has no expiry field.

## Changes
- **`useMimirHalt` / `useMimirHaltMaya`**: `distinctUntilChanged` (deep equal) so lastblock ticks only emit when halt flags actually change.
- **`useSwapQuote`**: stabilize `quotableProtocols` by content; set expiry state when a quote response lands (not when switching selected protocol).
- **`Swap.tsx`**: refresh quotes from a `fetchSwapRef` keyed on real inputs (amount, assets, streaming/slip, boost, protocols, affiliate decision), not callback identity.

## Test plan
- [ ] Quote a swap and leave the screen idle for 2–3 minutes — providers should **not** all reload on the minute.
- [ ] Expiry progress should count down (`14 → 13 → …`) instead of resetting near 14.
- [ ] Changing amount / assets / streaming / slip / boost / enabled protocols still re-fetches quotes.
- [ ] Confirm/tx-in-flight still pauses quote refresh.
- [ ] Switching selected route in an existing result set does **not** reset the expiry timer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap quote refresh behavior when network conditions, protocol availability, or boost settings change.
  * Quote expiration now starts when a quote is received and resets correctly when quotes are cleared.
  * Reduced unnecessary halt-status updates caused by routine block-time changes.
  * Improved swap refresh reliability when the app loses and regains focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->