### PR TITLE
chore: release v1.45.3 — aggregator 3.0.2, OneClick fees, swap details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@
   in-repo human changelog — keep it updated when cutting releases.
 -->
 
+# 1.45.3 (2026-08-27)
+
+PRs merged to `develop` since tag `v1.45.2` / release branch for 1.45.2.
+
+## Update/Fixes
+
+- fix(swap): show OneClick affiliate from aggregator echoed `appFees` (no more false `free`); protocol-tuned swap details for Chainflip/OneClick (hide THOR streaming + slip controls); outbound fee uses quote destination asset + USD (not stale sats); don’t freeze all swap routes when THOR Midgard is down (affiliate USD gate + empty-pool pair fallback) [#1191](https://github.com/asgardex/asgardex-desktop/pull/1191)
+- fix(swap): stop lastblock polls from re-firing quotes every 60s [#1190](https://github.com/asgardex/asgardex-desktop/pull/1190)
+- fix: Chainflip submit UX (channel-open in tx modal), aggregator 3.0.1 broker expiry, asset search ranks native ETH first, smarter halt banners, sticky protocol + pause requotes on confirm [#1188](https://github.com/asgardex/asgardex-desktop/pull/1188)
+- fix(thor/maya): never auto-retry keystore `MsgDeposit` broadcasts [#1182](https://github.com/asgardex/asgardex-desktop/pull/1182)
+- fix(swap): restore ERC20 Approve CTA when quote is approval-blocked [#1178](https://github.com/asgardex/asgardex-desktop/pull/1178)
+- fix(evm): EIP-1559 tip+baseFee headroom for THOR/MAYA pool deposit txs [#1179](https://github.com/asgardex/asgardex-desktop/pull/1179)
+- fix(swap): skip quote requests for trading-halted THOR/MAYA routes [#1177](https://github.com/asgardex/asgardex-desktop/pull/1177)
+
+## Chores
+
+- chore(deps): bump `@xchainjs/xchain-aggregator` to 3.0.2 (OneClick affiliateFee from echoed appFees) [#1191](https://github.com/asgardex/asgardex-desktop/pull/1191)
+- chore(deps): bump `@xchainjs/*` + Chainflip deposit-channel for aggregator 3.0 [#1181](https://github.com/asgardex/asgardex-desktop/pull/1181)
+- chore(deps): bump axios to 1.18.1 to match xchainjs [#1173](https://github.com/asgardex/asgardex-desktop/pull/1173)
+- chore(deps): bump `@reduxjs/toolkit` from 2.3.0 to 2.12.0 [#1160](https://github.com/asgardex/asgardex-desktop/pull/1160)
+
 # 1.45.2 (2026-08-13)
 
 PRs merged to `develop` since tag `v1.45.1` / release branch for 1.45.1.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "asgardex",
   "productName": "ASGARDEX",
   "desktopName": "com.asgardex.Asgardex.desktop",
-  "version": "1.45.2",
+  "version": "1.45.3",
   "description": "WALLET AND EXCHANGE CLIENT FOR THORCHAIN, MAYACHAIN, CHAINFLIP",
   "main": "build/main/electron.js",
   "scripts": {
@@ -80,7 +80,7 @@
     "@reduxjs/toolkit": "^2.12.0",
     "@tanstack/react-table": "^8.21.3",
     "@vultisig/sdk": "2.19.19",
-    "@xchainjs/xchain-aggregator": "3.0.1",
+    "@xchainjs/xchain-aggregator": "3.0.2",
     "@xchainjs/xchain-arbitrum": "2.1.8",
     "@xchainjs/xchain-avax": "2.0.22",
     "@xchainjs/xchain-base": "1.0.22",

--- a/resources/linux/com.asgardex.Asgardex.metainfo.xml
+++ b/resources/linux/com.asgardex.Asgardex.metainfo.xml
@@ -57,6 +57,7 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="1.45.3" date="2026-08-27" />
     <release version="1.45.2" date="2026-08-13" />
     <release version="1.45.1" date="2026-08-07" />
   </releases>

--- a/src/renderer/components/swap/Swap.tsx
+++ b/src/renderer/components/swap/Swap.tsx
@@ -515,13 +515,14 @@ export const Swap = ({
     )
   }, [oQuoteProtocol, swapFees.outFee.amount, swapFees.outFee.asset])
 
-  const [outFeePriceValue, setOutFeePriceValue] = useState<CryptoAmount>(
-    new CryptoAmount(swapFees.outFee.amount, targetAsset)
-  )
+  const [outFeePriceValue, setOutFeePriceValue] = useState<CryptoAmount>(oSwapOutFee)
 
   useEffect(() => {
-    if (O.isNone(oQuoteProtocol)) return
-    const calculateSwapOutFeePrice = () => {
+    if (O.isNone(oQuoteProtocol)) {
+      setOutFeePriceValue(oSwapOutFee)
+      return
+    }
+    const calculateSwapOutFeePrice = (): O.Option<BaseAmount> => {
       if (isUSDAsset(oSwapOutFee.asset)) {
         return O.some(oSwapOutFee.baseAmount)
       }
@@ -538,49 +539,35 @@ export const Swap = ({
           })
     }
     const swapOutFeePrice = calculateSwapOutFeePrice()
-    if (O.isSome(swapOutFeePrice)) {
-      const newOutFeePriceValue = new CryptoAmount(swapOutFeePrice.value, pricePoolThor.asset)
-      setOutFeePriceValue((prevValue) =>
-        prevValue?.baseAmount.eq(newOutFeePriceValue.baseAmount) ? prevValue : newOutFeePriceValue
-      )
-    }
-  }, [
-    pricePoolThor,
-    pricePoolMaya,
-    oQuoteProtocol,
-    oSwapOutFee.asset,
-    oSwapOutFee.baseAmount,
-    poolDetailsThor,
-    poolDetailsMaya
-  ])
+    // Always refresh: USD when pools can price the quote outbound asset, otherwise the
+    // destination-asset fee itself — never keep a stale prior-swap price (e.g. BTC sats).
+    setOutFeePriceValue(
+      O.isSome(swapOutFeePrice) ? new CryptoAmount(swapOutFeePrice.value, pricePoolThor.asset) : oSwapOutFee
+    )
+  }, [pricePoolThor, pricePoolMaya, oQuoteProtocol, oSwapOutFee, poolDetailsThor, poolDetailsMaya])
 
+  // Quote outbound fee asset (destination / egress), not swapFees.outFee.asset from the
+  // chain fee estimator — mixing those produced "546 sats" on USDC→SOL etc.
   const priceSwapOutFeeLabel = useMemo(() => {
-    if (!swapFees) return ''
-    const {
-      outFee: { asset: feeAsset }
-    } = swapFees
+    const feeAsset = oSwapOutFee.asset
     const fee = formatAssetAmountCurrency({
       amount: baseToAsset(oSwapOutFee.baseAmount),
       asset: feeAsset,
       decimal: isUSDAsset(feeAsset) ? 2 : 6,
       trimZeros: !isUSDAsset(feeAsset)
     })
-    const price = FP.pipe(
-      O.some(outFeePriceValue),
-      O.map((cryptoAmount: CryptoAmount) =>
-        eqAsset.equals(feeAsset, cryptoAmount.asset)
-          ? ''
-          : formatAssetAmountCurrency({
-              amount: cryptoAmount.assetAmount,
-              asset: cryptoAmount.asset,
-              decimal: isUSDAsset(cryptoAmount.asset) ? 2 : 6,
-              trimZeros: !isUSDAsset(cryptoAmount.asset)
-            })
-      ),
-      O.getOrElse(() => '')
-    )
-    return price ? `${price} (${fee})` : fee
-  }, [swapFees, oSwapOutFee, outFeePriceValue])
+    if (!isUSDAsset(outFeePriceValue.asset) || eqAsset.equals(feeAsset, outFeePriceValue.asset)) {
+      return fee
+    }
+    const isVerySmallUSDAmount = outFeePriceValue.assetAmount.amount().lt(0.01)
+    const price = formatAssetAmountCurrency({
+      amount: outFeePriceValue.assetAmount,
+      asset: outFeePriceValue.asset,
+      decimal: isVerySmallUSDAmount ? 6 : 2,
+      trimZeros: isVerySmallUSDAmount
+    })
+    return `${price} (${fee})`
+  }, [oSwapOutFee, outFeePriceValue])
 
   // Affiliate fee from quote
   const affiliateFee: CryptoAmount = useMemo(() => {
@@ -639,14 +626,53 @@ export const Swap = ({
       ),
       O.getOrElse(() => '')
     )
-    const bps = getAsgardexAffiliateFee(network)
+    const configuredBps = getAsgardexAffiliateFee(network)
     const applyBps = FP.pipe(
       oApplyBps,
       O.getOrElse(() => false)
     )
-    const displayBps = applyBps && bps !== undefined ? `${bps / 100}%` : '0%'
-    return !applyBps ? `free` : price ? `${price} (${fee}) ${displayBps}` : fee
-  }, [swapFees, affiliateFee.assetAmount, affiliateFee.asset, affiliatePriceValue, oApplyBps, network, sourceAsset])
+    const protocol = FP.pipe(
+      oQuoteProtocol,
+      O.map((q) => q.protocol),
+      O.toUndefined
+    )
+    // OneClick (aggregator ≥3.0.2): fees.affiliateFee is amountIn * echoed partner bps
+    // after 1Click's 50/50 split — prefer that effective rate over the requested 30 bps.
+    let displayBps = '0%'
+    if (applyBps && configuredBps !== undefined) {
+      if (
+        protocol === 'OneClick' &&
+        amountToSwap.amount().gt(0) &&
+        affiliateFee.baseAmount.amount().gt(0) &&
+        eqAsset.equals(affiliateFee.asset, sourceAsset)
+      ) {
+        const effectiveBps = affiliateFee.baseAmount
+          .amount()
+          .multipliedBy(10000)
+          .dividedToIntegerBy(amountToSwap.amount())
+          .toNumber()
+        displayBps = `${effectiveBps / 100}%`
+      } else {
+        displayBps = `${configuredBps / 100}%`
+      }
+    }
+    // OneClick can still return a non-zero affiliateFee while applyBps is true; never show
+    // "free" when the quote itself reports an affiliate amount.
+    if (!applyBps && affiliateFee.baseAmount.amount().isZero()) return `free`
+    if (!applyBps) return price ? `${price} (${fee})` : fee
+    return price ? `${price} (${fee}) ${displayBps}` : `${fee} ${displayBps}`
+  }, [
+    swapFees,
+    affiliateFee.assetAmount,
+    affiliateFee.asset,
+    affiliateFee.baseAmount,
+    affiliatePriceValue,
+    oApplyBps,
+    oQuoteProtocol,
+    network,
+    sourceAsset,
+    amountToSwap
+  ])
 
   // ─── Hook 4: Swap execution ────────────────────────────────────────────────
   const {

--- a/src/renderer/components/swap/components/SwapDetailsPanel.tsx
+++ b/src/renderer/components/swap/components/SwapDetailsPanel.tsx
@@ -22,6 +22,7 @@ import * as O from 'fp-ts/Option'
 import { useIntl } from 'react-intl'
 
 import { isUSDAsset } from '../../../helpers/assetHelper'
+import { isDexStreamingProtocol } from '../../../helpers/protocolHelper'
 import { ChangeSlipToleranceHandler } from '../../../services/app/types'
 import { SwapFeesRD, SwapTxParams } from '../../../services/chain/types'
 import { SlipTolerance } from '../../../types/asgardex'
@@ -112,6 +113,11 @@ export const SwapDetailsPanel = ({
 }: Props) => {
   const intl = useIntl()
 
+  const protocol = O.toNullable(O.map((quote: ExtendedQuoteSwap) => quote.protocol)(oQuoteProtocol))
+  // Chainflip / OneClick: no streaming params and no slip-tolerance / min-result controls.
+  // Keep THOR/MAYA (and no-quote fallback) on the existing DEX details layout.
+  const showDexSlipAndStreaming = isDexStreamingProtocol(protocol) || protocol === null
+
   const slippageValue = useMemo(
     () =>
       formatAssetAmountCurrency({
@@ -185,7 +191,8 @@ export const SwapDetailsPanel = ({
           trimZeros: true
         })
 
-  const memoSection = showDetails && (
+  // Chainflip / OneClick quotes have an empty memo — hide the empty section.
+  const memoSection = showDetails && showDexSlipAndStreaming && (
     <>
       <div className="ml-[-2px] flex w-full items-start pt-10px font-main-bold text-[14px] text-text2 dark:text-text2d">
         {memoTitle}
@@ -237,66 +244,70 @@ export const SwapDetailsPanel = ({
     </>
   )
 
-  const renderSlippageSection = () => (
-    <>
-      <div
-        className={clsx(
-          'flex w-full justify-between font-main-bold text-[14px]',
-          { 'pt-10px': showDetails },
-          { 'text-error0 dark:text-error0d': isCausedSlippage }
-        )}>
-        <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'swap.slip.title' })}</div>
-        <div className="text-text2 dark:text-text2d">{slippageValue}</div>
-      </div>
+  const renderSlippageSection = () => {
+    if (!showDexSlipAndStreaming) return null
 
-      {showDetails && (
-        <>
-          <div className="flex w-full justify-between pl-10px text-[12px]">
-            <div className="flex items-center">
-              {intl.formatMessage({ id: 'swap.slip.tolerance' })}
-              <InfoIcon
-                className="ml-[3px] h-[15px] w-[15px] text-inherit"
-                tooltip={intl.formatMessage({ id: 'swap.slip.tolerance.info' })}
-              />
+    return (
+      <>
+        <div
+          className={clsx(
+            'flex w-full justify-between font-main-bold text-[14px]',
+            { 'pt-10px': showDetails },
+            { 'text-error0 dark:text-error0d': isCausedSlippage }
+          )}>
+          <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'swap.slip.title' })}</div>
+          <div className="text-text2 dark:text-text2d">{slippageValue}</div>
+        </div>
+
+        {showDetails && (
+          <>
+            <div className="flex w-full justify-between pl-10px text-[12px]">
+              <div className="flex items-center">
+                {intl.formatMessage({ id: 'swap.slip.tolerance' })}
+                <InfoIcon
+                  className="ml-[3px] h-[15px] w-[15px] text-inherit"
+                  tooltip={intl.formatMessage({ id: 'swap.slip.tolerance.info' })}
+                />
+              </div>
+              <div>
+                <SelectableSlipTolerance value={slipTolerance} onChange={changeSlipTolerance} />
+              </div>
             </div>
-            <div>
-              <SelectableSlipTolerance value={slipTolerance} onChange={changeSlipTolerance} />
+            <div className="flex w-full justify-between pl-10px text-[12px]">
+              <div className="flex items-center">
+                {intl.formatMessage({ id: 'swap.min.result.protected' })}
+                <InfoIcon
+                  className="ml-[3px] h-[15px] w-[15px] text-inherit"
+                  tooltip={intl.formatMessage({ id: 'swap.min.result.info' }, { tolerance: slipTolerance })}
+                />
+              </div>
+              <div>{swapMinResultLabel}</div>
             </div>
-          </div>
-          <div className="flex w-full justify-between pl-10px text-[12px]">
-            <div className="flex items-center">
-              {intl.formatMessage({ id: 'swap.min.result.protected' })}
-              <InfoIcon
-                className="ml-[3px] h-[15px] w-[15px] text-inherit"
-                tooltip={intl.formatMessage({ id: 'swap.min.result.info' }, { tolerance: slipTolerance })}
-              />
+            <div className="flex w-full justify-between pl-10px text-[12px]">
+              <div className="flex items-center text-text2 dark:text-text2d">
+                {intl.formatMessage({ id: 'swap.streaming.interval' })}
+                <InfoIcon
+                  className="ml-[3px] h-[15px] w-[15px] text-inherit"
+                  tooltip={intl.formatMessage({ id: 'swap.streaming.interval.info' })}
+                />
+              </div>
+              <div className="text-text2 dark:text-text2d">{streamingInterval}</div>
             </div>
-            <div>{swapMinResultLabel}</div>
-          </div>
-          <div className="flex w-full justify-between pl-10px text-[12px]">
-            <div className="flex items-center text-text2 dark:text-text2d">
-              {intl.formatMessage({ id: 'swap.streaming.interval' })}
-              <InfoIcon
-                className="ml-[3px] h-[15px] w-[15px] text-inherit"
-                tooltip={intl.formatMessage({ id: 'swap.streaming.interval.info' })}
-              />
+            <div className="flex w-full justify-between pl-10px text-[12px]">
+              <div className="flex items-center text-text2 dark:text-text2d">
+                {intl.formatMessage({ id: 'swap.streaming.quantity' })}
+                <InfoIcon
+                  className="ml-[3px] h-[15px] w-[15px] text-inherit"
+                  tooltip={intl.formatMessage({ id: 'swap.streaming.quantity.info' })}
+                />
+              </div>
+              <div className="text-text2 dark:text-text2d">{streamingQuantity}</div>
             </div>
-            <div className="text-text2 dark:text-text2d">{streamingInterval}</div>
-          </div>
-          <div className="flex w-full justify-between pl-10px text-[12px]">
-            <div className="flex items-center text-text2 dark:text-text2d">
-              {intl.formatMessage({ id: 'swap.streaming.quantity' })}
-              <InfoIcon
-                className="ml-[3px] h-[15px] w-[15px] text-inherit"
-                tooltip={intl.formatMessage({ id: 'swap.streaming.quantity.info' })}
-              />
-            </div>
-            <div className="text-text2 dark:text-text2d">{streamingQuantity}</div>
-          </div>
-        </>
-      )}
-    </>
-  )
+          </>
+        )}
+      </>
+    )
+  }
 
   const rateSection = (
     <div className="flex w-full justify-between font-main-bold text-[14px]">
@@ -381,10 +392,12 @@ export const SwapDetailsPanel = ({
           <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'common.fee.inbound' })}</div>
           <div className="text-text2 dark:text-text2d">{priceSwapInFeeLabel}</div>
         </div>
-        <div className="flex w-full justify-between pl-10px text-[12px]">
-          <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'swap.slip.title' })}</div>
-          <div className="text-text2 dark:text-text2d">{slippageValue}</div>
-        </div>
+        {showDexSlipAndStreaming && (
+          <div className="flex w-full justify-between pl-10px text-[12px]">
+            <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'swap.slip.title' })}</div>
+            <div className="text-text2 dark:text-text2d">{slippageValue}</div>
+          </div>
+        )}
         <div className="flex w-full justify-between pl-10px text-[12px]">
           <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'common.fee.outbound' })}</div>
           <div className="text-text2 dark:text-text2d">{priceSwapOutFeeLabel}</div>

--- a/src/renderer/components/swap/components/TransactionTime.tsx
+++ b/src/renderer/components/swap/components/TransactionTime.tsx
@@ -6,6 +6,7 @@ import { option as O } from 'fp-ts'
 import { IntlShape } from 'react-intl'
 
 import { DefaultChainAttributes } from '../../../../shared/utils/chain'
+import { isDexStreamingProtocol } from '../../../helpers/protocolHelper'
 import { formatSwapTime } from '../../../helpers/timeHelper'
 import { ExtendedQuoteSwap } from '../Swap.types'
 
@@ -18,6 +19,11 @@ type Props = {
 }
 
 export const TransactionTime = ({ intl, showDetails, sourceChain, targetAsset, oQuoteProtocol }: Props) => {
+  const protocol = O.toNullable(O.map((quote: ExtendedQuoteSwap) => quote.protocol)(oQuoteProtocol))
+  // Chainflip/OneClick quotes carry a single total estimate — THOR-style inbound/confirm
+  // breakdown from DefaultChainAttributes is misleading for those protocols.
+  const showDexTimeBreakdown = isDexStreamingProtocol(protocol) || protocol === null
+
   const transactionTime = O.isSome(oQuoteProtocol)
     ? (oQuoteProtocol.value.totalSwapSeconds ??
       DefaultChainAttributes[targetAsset.chain].avgBlockTimeInSecs +
@@ -38,7 +44,7 @@ export const TransactionTime = ({ intl, showDetails, sourceChain, targetAsset, o
         <div className="text-text2 dark:text-text2d">{intl.formatMessage({ id: 'common.time.title' })}</div>
         <div className="text-text2 dark:text-text2d">{formatSwapTime(transactionTime)}</div>
       </div>
-      {showDetails && (
+      {showDetails && showDexTimeBreakdown && (
         <>
           <div className="flex w-full justify-between pl-10px text-[12px]">
             <div className="flex items-center text-text2 dark:text-text2d">

--- a/src/renderer/helpers/protocolHelper.ts
+++ b/src/renderer/helpers/protocolHelper.ts
@@ -1,3 +1,4 @@
+import { Protocol } from '@xchainjs/xchain-aggregator/lib/types'
 import { MAYAChain } from '@xchainjs/xchain-mayachain'
 import { THORChain } from '@xchainjs/xchain-thorchain'
 
@@ -12,3 +13,7 @@ export const protocolMapping = {
   Chainflip: 'Chainflip',
   OneClick: 'NEAR Intents'
 }
+
+/** THOR/MAYA use streaming + slip-tolerance controls; Chainflip/OneClick do not. */
+export const isDexStreamingProtocol = (protocol: Protocol | null | undefined): boolean =>
+  protocol === 'Thorchain' || protocol === 'Mayachain'

--- a/src/renderer/hooks/useSwapFees.ts
+++ b/src/renderer/hooks/useSwapFees.ts
@@ -278,16 +278,14 @@ export const useSwapFees = ({
     }
 
     if (balanceUsdValue.amount().isZero()) {
-      // Pools couldn't price the source. Distinguish "pool data not loaded yet"
-      // (defer via O.none — fetchQuote waits) from "no THOR/MAYA pool will ever
-      // price this" (e.g. SUI — 1Click-only). Note isChainOfThor can't tell the
-      // difference: DEX_CHAINS buckets every enabled non-MAYA chain as a THOR
-      // chain, pools or not (the SOL special case above exists because of that).
-      const poolsLoaded = poolDetailsThor.length > 0 || poolDetailsMaya.length > 0
-      if (!poolsLoaded) return O.none
-      // Pools are loaded and still no price — fall back to 1Click's token list
-      // so the affiliate threshold still applies; if it has no price either,
-      // skip the fee rather than blocking the quote (no price, no fee).
+      // Midgard/Maya pool USD prices unavailable (down, empty, or asset not pooled).
+      // Fall back to 1Click token list prices when possible.
+      //
+      // IMPORTANT: never return O.none here. useSwapQuote.fetchQuote bails while
+      // affiliateBps is none — historically that froze *all* protocols (Chainflip,
+      // OneClick, MAYA) whenever THOR Midgard failed, even though aggregator quotes
+      // hit Thornode/Chainflip/1Click APIs and do not need Midgard.
+      // Missing USD price → skip affiliate rather than block the swap page.
       const oneClickUsdPrice = getOneClickUsdPrice(sourceAsset)
       if (oneClickUsdPrice === undefined) return O.some(false)
       balanceUsdValue = assetToBase(

--- a/src/renderer/views/swap/SwapView.tsx
+++ b/src/renderer/views/swap/SwapView.tsx
@@ -556,23 +556,32 @@ const SuccessRouteView = ({
   // Falls back to assets routable without THOR/MAYA pools (Chainflip + OneClick,
   // with zero RUNE-denominated price) so the swap UI loads when pool data is
   // unavailable or the pair only exists on a poolless protocol (e.g. SUI, ADA).
+  // When Midgard is down, poolAssetDetails is often only the RUNE/CACAO stub —
+  // still allow the selected pair through so aggregator quotes (Thornode /
+  // Chainflip / 1Click) can run; USD prices stay 0 until Midgard recovers.
   const validatePoolAssets = (
     poolAssetDetails: PoolAssetDetail[],
     sourceAsset: AssetWithDecimal,
     targetAsset: AssetWithDecimal,
     poollessAssets: ReadonlyArray<AnyAsset>
   ): Either<Error, { sourceAssetDetail: PoolAssetDetail; targetAssetDetail: PoolAssetDetail }> => {
-    const findPoollessFallback = (asset: AnyAsset): PoolAssetDetail | null => {
+    const isProtocolStub = (asset: AnyAsset) =>
+      (asset.chain === THORChain && asset.symbol === AssetRuneNative.symbol) ||
+      (asset.chain === MAYAChain && asset.symbol === AssetCacao.symbol)
+    const midgardPoolsUnavailable =
+      poolAssetDetails.length === 0 || poolAssetDetails.every(({ asset }) => isProtocolStub(asset))
+
+    const findFallback = (asset: AnyAsset): PoolAssetDetail | null => {
       const target = assetToString(asset)
       const match = poollessAssets.find((a) => assetToString(a) === target)
-      return match ? { asset: match, assetPrice: bn(0) } : null
+      if (match) return { asset: match, assetPrice: bn(0) }
+      if (midgardPoolsUnavailable) return { asset, assetPrice: bn(0) }
+      return null
     }
     const sourceAssetDetail =
-      FP.pipe(Utils.pickPoolAsset(poolAssetDetails, sourceAsset.asset), O.toNullable) ??
-      findPoollessFallback(sourceAsset.asset)
+      FP.pipe(Utils.pickPoolAsset(poolAssetDetails, sourceAsset.asset), O.toNullable) ?? findFallback(sourceAsset.asset)
     const targetAssetDetail =
-      FP.pipe(Utils.pickPoolAsset(poolAssetDetails, targetAsset.asset), O.toNullable) ??
-      findPoollessFallback(targetAsset.asset)
+      FP.pipe(Utils.pickPoolAsset(poolAssetDetails, targetAsset.asset), O.toNullable) ?? findFallback(targetAsset.asset)
 
     if (!sourceAssetDetail) {
       return left(new Error(`Missing pool for source asset ${assetToString(sourceAsset.asset)}`))

--- a/src/shared/const.ts
+++ b/src/shared/const.ts
@@ -26,6 +26,7 @@ import { envOrDefault } from './utils/env'
 
 export const ASGARDEX_ADDRESS = 'thor1rr6rahhd4sy76a7rdxkjaen2q4k4pw2g06w7qp'
 
+/** Requested affiliate fee in basis points (30 = 0.30%). */
 export const ASGARDEX_AFFILIATE_FEE = 30
 export const ASGARDEX_THORNAME = envOrDefault(import.meta.env.VITE_ASGARDEX_THORNAME, 'dx')
 
@@ -44,6 +45,10 @@ export const ASGARDEX_ONECLICK_API_KEY = envOrDefault(import.meta.env.VITE_ASGAR
 // a native address on that chain. Configure as a JSON map of chain → address, e.g.
 // VITE_ASGARDEX_ONECLICK_AFFILIATES='{"BTC":"bc1...","ETH":"0x..."}'
 // When the destination chain has no entry, no affiliate fee is applied to that quote.
+//
+// 1Click applies a 50/50 revenue share on appFees by default: requesting
+// ASGARDEX_AFFILIATE_FEE (30) yields ~15 bps to our recipient in quoteRequest.appFees
+// (aggregator ≥3.0.2 surfaces that as fees.affiliateFee).
 const parseOneClickAffiliates = (raw: string): Record<string, string> => {
   if (!raw) return {}
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6412,9 +6412,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xchainjs/xchain-aggregator@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@xchainjs/xchain-aggregator@npm:3.0.1"
+"@xchainjs/xchain-aggregator@npm:3.0.2":
+  version: 3.0.2
+  resolution: "@xchainjs/xchain-aggregator@npm:3.0.2"
   dependencies:
     "@chainflip/sdk": "npm:2.2.1"
     "@xchainjs/xchain-client": "npm:2.0.17"
@@ -6428,7 +6428,7 @@ __metadata:
     "@xchainjs/xchain-thorchain-query": "npm:3.1.3"
     "@xchainjs/xchain-util": "npm:2.0.7"
     "@xchainjs/xchain-wallet": "npm:2.0.34"
-  checksum: 10/8dc9658183991cfc44b8e2420effa88f928e5227bdb81095e6cd4969da3b342c4ea2210976b7ff52b94b6adbb43785a58d90a93b058d2517fa6ecaedc1882760
+  checksum: 10/36dc3db65cbfddbe56422a2fe48b37d664455c9926848678319dab50f7a30caa9359bfe8b67a95b66bdda5bcb5fcfdda30a2f541c332961995e4094564614e50
   languageName: node
   linkType: hard
 
@@ -7593,7 +7593,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.4.1"
     "@vitest/ui": "npm:^4.1.9"
     "@vultisig/sdk": "npm:2.19.19"
-    "@xchainjs/xchain-aggregator": "npm:3.0.1"
+    "@xchainjs/xchain-aggregator": "npm:3.0.2"
     "@xchainjs/xchain-arbitrum": "npm:2.1.8"
     "@xchainjs/xchain-avax": "npm:2.0.22"
     "@xchainjs/xchain-base": "npm:1.0.22"


### PR DESCRIPTION
## Summary

Release prep for **v1.45.3**, squashed onto the aggregator OneClick-fees branch.

- Bump `@xchainjs/xchain-aggregator` **3.0.1 → 3.0.2** so OneClick `fees.affiliateFee` is populated from echoed `quoteRequest.appFees` (partner share after 1Click’s 50/50 split) — closes the false **free** affiliate UI ([xchainjs#1763](https://github.com/xchainjs/xchainjs-lib/issues/1763)).
- Swap details: show **effective** OneClick affiliate bps from `affiliateFee / amountIn`.
- Protocol-tuned **Swap details** for Chainflip / OneClick (NEAR Intents): hide THOR streaming interval/quantity, slip tolerance + min protected result, empty memo; show total time only (no THOR inbound/confirm breakdown).
- Fix **outbound fee** label to use the quote’s outbound/destination asset + USD (stop showing stale **sats** on USDC→SOL etc.).
- **Midgard resilience:** when THOR Midgard is down, do not freeze the whole swap page / other protocols. `affiliateBps` no longer stays `none` waiting on Midgard USD (that gated `fetchQuote` for Chainflip/OneClick/MAYA too). Empty pool lists still allow the selected pair through so aggregator quotes via Thornode/Chainflip/1Click can run (USD prices may be 0 until Midgard recovers).
- `package.json` → **1.45.3**, `CHANGELOG.md`, AppStream metainfo release entry.

## Test plan

- [ ] `yarn install` resolves aggregator 3.0.2
- [ ] OneClick swap ≥ \$1001: affiliate shows ~0.15% (not `free`); Network tab still has `appFees`
- [ ] Chainflip / OneClick details: no streaming / slip controls; THOR/MAYA unchanged
- [ ] Outbound fee on non-BTC pair shows dest asset + `\$` (not sats)
- [ ] Simulate Midgard down / empty pools: Chainflip and OneClick quotes still fetch; THOR aggregator quote can still appear via Thornode
- [ ] THOR/MAYA affiliate still shows configured 0.30% when applyBps is on and Midgard is healthy
- [ ] Version / changelog / metainfo read 1.45.3

## After merge

Create and push `release/v1.45.3` from `develop` per RELEASE.md to trigger the draft GitHub release + binary builds.