### PR TITLE
fix(midgard): Liquify authenticated THOR Midgard endpoint

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -62,6 +62,7 @@ jobs:
           VITE_ASGARDEX_THORNODE_RPC: ${{ secrets.VITE_ASGARDEX_THORNODE_RPC }}
           VITE_LIQUIFY_THORCHAIN_API_KEY: ${{ secrets.VITE_LIQUIFY_THORCHAIN_API_KEY }}
           VITE_LIQUIFY_THORCHAIN_RPC_KEY: ${{ secrets.VITE_LIQUIFY_THORCHAIN_RPC_KEY }}
+          VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY: ${{ secrets.VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -70,6 +70,7 @@ jobs:
           VITE_ASGARDEX_THORNODE_RPC: ${{ secrets.VITE_ASGARDEX_THORNODE_RPC }}
           VITE_LIQUIFY_THORCHAIN_API_KEY: ${{ secrets.VITE_LIQUIFY_THORCHAIN_API_KEY }}
           VITE_LIQUIFY_THORCHAIN_RPC_KEY: ${{ secrets.VITE_LIQUIFY_THORCHAIN_RPC_KEY }}
+          VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY: ${{ secrets.VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY }}
           OS_NAME: ${{ matrix.os-name }}
           OS_VERSION: ${{ matrix.os-version }}
           OS_VERSION_SUFFIX: '${{ matrix.os-version }}-${{ matrix.os-name }}'

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -56,6 +56,7 @@ jobs:
           VITE_ASGARDEX_THORNODE_RPC: ${{ secrets.VITE_ASGARDEX_THORNODE_RPC }}
           VITE_LIQUIFY_THORCHAIN_API_KEY: ${{ secrets.VITE_LIQUIFY_THORCHAIN_API_KEY }}
           VITE_LIQUIFY_THORCHAIN_RPC_KEY: ${{ secrets.VITE_LIQUIFY_THORCHAIN_RPC_KEY }}
+          VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY: ${{ secrets.VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY }}
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/src/renderer/helpers/liquifyEndpoints.ts
+++ b/src/renderer/helpers/liquifyEndpoints.ts
@@ -1,6 +1,11 @@
 import { Network } from '@xchainjs/xchain-client'
 
-import { THORNODE_API_BASE_URLS } from '../../shared/thorchain/const'
+import {
+  LIQUIFY_THORCHAIN_MIDGARD_KEY,
+  liquifyAuthenticatedUrl,
+  PUBLIC_LIQUIFY_THORCHAIN_MIDGARD,
+  THORNODE_API_BASE_URLS
+} from '../../shared/thorchain/const'
 
 // Prefer the Liquify gateway over the public THORChain / MAYAChain endpoints.
 //
@@ -15,8 +20,10 @@ import { THORNODE_API_BASE_URLS } from '../../shared/thorchain/const'
 // THORNode: Liquify → optional Asgardex-hosted node from VITE_ASGARDEX_THORNODE_API.
 export const LIQUIFY_THORNODE_URLS = THORNODE_API_BASE_URLS
 
+const authenticatedMidgard = liquifyAuthenticatedUrl(LIQUIFY_THORCHAIN_MIDGARD_KEY)
 const LIQUIFY_MIDGARD_URLS = [
-  'https://gateway.liquify.com/chain/thorchain_midgard',
+  ...(authenticatedMidgard ? [authenticatedMidgard] : []),
+  PUBLIC_LIQUIFY_THORCHAIN_MIDGARD,
   'https://midgard.thorchain.network'
 ]
 const LIQUIFY_MAYANODE_URLS = ['https://api-maya.liquify.com', 'https://mayanode.mayachain.info']

--- a/src/renderer/services/clients/transaction/midgardHistory.ts
+++ b/src/renderer/services/clients/transaction/midgardHistory.ts
@@ -9,6 +9,7 @@ import * as RxOp from 'rxjs/operators'
 
 import { DEFAULT_MIDGARD_MAYA_URLS } from '../../../../shared/mayaMidgard/const'
 import { DEFAULT_MIDGARD_URLS } from '../../../../shared/midgard/const'
+import { resolveMidgardUrl } from '../../../../shared/thorchain/const'
 import { logger } from '../../../helpers/logger'
 import { network$ } from '../../app/service'
 import { midgard$, midgardMaya$ } from '../../storage/common'
@@ -142,7 +143,8 @@ const midgardBaseUrl$ = (protocol: MidgardProtocol): Rx.Observable<string> =>
   Rx.combineLatest([protocol === 'thor' ? midgard$ : midgardMaya$, network$]).pipe(
     RxOp.map(([urls, network]) => {
       const defaults = protocol === 'thor' ? DEFAULT_MIDGARD_URLS : DEFAULT_MIDGARD_MAYA_URLS
-      return urls[network as Network] || defaults[network as Network] || defaults.mainnet
+      const configured = urls[network as Network] || defaults[network as Network] || defaults.mainnet
+      return protocol === 'thor' ? resolveMidgardUrl(configured, network as Network) : configured
     }),
     RxOp.distinctUntilChanged()
   )

--- a/src/renderer/services/midgard/thorMidgard/service.ts
+++ b/src/renderer/services/midgard/thorMidgard/service.ts
@@ -7,6 +7,7 @@ import * as RxOp from 'rxjs/operators'
 
 import { ApiUrls } from '../../../../shared/api/types'
 import { DEFAULT_MIDGARD_URLS, FALLBACK_MIDGARD_URLS } from '../../../../shared/midgard/const'
+import { maskMidgardUrl, resolveMidgardUrl } from '../../../../shared/thorchain/const'
 import { eqApiUrls } from '../../../helpers/fp/eq'
 import { liveData } from '../../../helpers/rx/liveData'
 import { triggerStream, TriggerStream$ } from '../../../helpers/stateHelper'
@@ -53,10 +54,11 @@ const getMidgardUrl = (): ApiUrls =>
   )
 
 /**
- * Updates Midgard url and stores it persistently
+ * Updates Midgard url and stores it persistently.
+ * Liquify `/api=<KEY>` URLs are masked before storage (same as THORNode API/RPC).
  */
 const setMidgardUrl = (url: string, network: Network) => {
-  const midgardUrls = { ...getMidgardUrl(), [network]: url }
+  const midgardUrls = { ...getMidgardUrl(), [network]: maskMidgardUrl(url) }
   modifyStorage(O.some({ midgard: midgardUrls }))
 }
 
@@ -99,7 +101,8 @@ const healthInterval$ = Rx.timer(0 /* no delay for first value */, 5 * 60 * 1000
  */
 const midgardUrl$: MidgardUrlLD = Rx.combineLatest([network$, getMidgardUrl$, healthInterval$]).pipe(
   RxOp.switchMap(([network, midgardUrl]) => {
-    const primary = midgardUrl[network]
+    // Inject Liquify authenticated Midgard when the portal key is set (mainnet only).
+    const primary = resolveMidgardUrl(midgardUrl[network], network)
     const fallback = fallbackUrlForNetwork(network)
     if (!fallback || fallback === primary) return Rx.of(RD.success(primary))
     return probeMidgardHealth$(primary).pipe(RxOp.map((ok) => RD.success(ok ? primary : fallback)))
@@ -238,7 +241,9 @@ export const service: MidgardService = {
   reloadChartDataUI$,
   setSelectedPoolAsset,
   selectedPoolAsset$,
-  apiEndpoint$: midgardUrl$,
+  // Expert Mode must never display Liquify `/api=<KEY>` URLs — mask for UI only.
+  // Request traffic still uses the resolved (authenticated) midgardUrl$ below.
+  apiEndpoint$: midgardUrl$.pipe(liveData.map(maskMidgardUrl)),
   reloadApiEndpoint: reloadMidgardUrl,
   setMidgardUrl,
   checkMidgardUrl$,

--- a/src/shared/midgard/const.ts
+++ b/src/shared/midgard/const.ts
@@ -1,13 +1,14 @@
 import { ApiUrls } from '../api/types'
+import { maskMidgardUrl, PUBLIC_LIQUIFY_THORCHAIN_MIDGARD } from '../thorchain/const'
 import { envOrDefault } from '../utils/env'
 
 const TESTNET_URL = envOrDefault(import.meta.env.VITE_MIDGARD_TESTNET_URL, 'https://testnet.midgard.thorchain.info')
 
 const STAGENET_URL = envOrDefault(import.meta.env.VITE_MIDGARD_STAGENET_URL, '')
 
-const MAINNET_URL = envOrDefault(
-  import.meta.env.VITE_MIDGARD_MAINNET_URL,
-  'https://gateway.liquify.com/chain/thorchain_midgard'
+// Defaults stay public; authenticated Liquify Midgard is applied via resolveMidgardUrl().
+const MAINNET_URL = maskMidgardUrl(
+  envOrDefault(import.meta.env.VITE_MIDGARD_MAINNET_URL, PUBLIC_LIQUIFY_THORCHAIN_MIDGARD)
 )
 
 export const DEFAULT_MIDGARD_URLS: ApiUrls = {

--- a/src/shared/thorchain/const.midgard.test.ts
+++ b/src/shared/thorchain/const.midgard.test.ts
@@ -1,0 +1,41 @@
+import { Network } from '@xchainjs/xchain-client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('shared/thorchain Midgard Liquify auth', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('resolveMidgardUrl injects authenticated gateway URL on mainnet when key is set', async () => {
+    vi.stubEnv('VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY', 'THORCHAIN_MIDGARDTESTKEY')
+    const { resolveMidgardUrl, PUBLIC_LIQUIFY_THORCHAIN_MIDGARD, liquifyAuthenticatedUrl } = await import('./const')
+
+    expect(resolveMidgardUrl(PUBLIC_LIQUIFY_THORCHAIN_MIDGARD, Network.Mainnet)).toBe(
+      liquifyAuthenticatedUrl('THORCHAIN_MIDGARDTESTKEY')
+    )
+    expect(resolveMidgardUrl('', Network.Mainnet)).toBe('https://gateway.liquify.com/api=THORCHAIN_MIDGARDTESTKEY')
+  })
+
+  it('resolveMidgardUrl leaves custom Expert URLs alone', async () => {
+    vi.stubEnv('VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY', 'THORCHAIN_MIDGARDTESTKEY')
+    const { resolveMidgardUrl } = await import('./const')
+
+    expect(resolveMidgardUrl('https://custom.midgard.example', Network.Mainnet)).toBe('https://custom.midgard.example')
+  })
+
+  it('resolveMidgardUrl does not inject on stagenet', async () => {
+    vi.stubEnv('VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY', 'THORCHAIN_MIDGARDTESTKEY')
+    const { resolveMidgardUrl, PUBLIC_LIQUIFY_THORCHAIN_MIDGARD } = await import('./const')
+
+    expect(resolveMidgardUrl(PUBLIC_LIQUIFY_THORCHAIN_MIDGARD, Network.Stagenet)).toBe(PUBLIC_LIQUIFY_THORCHAIN_MIDGARD)
+  })
+
+  it('maskMidgardUrl strips authenticated Liquify paths', async () => {
+    const { maskMidgardUrl, PUBLIC_LIQUIFY_THORCHAIN_MIDGARD } = await import('./const')
+
+    expect(maskMidgardUrl('https://gateway.liquify.com/api=THORCHAIN_MIDGARDTESTKEY')).toBe(
+      PUBLIC_LIQUIFY_THORCHAIN_MIDGARD
+    )
+  })
+})

--- a/src/shared/thorchain/const.ts
+++ b/src/shared/thorchain/const.ts
@@ -9,6 +9,9 @@ export const PUBLIC_LIQUIFY_THORNODE_RPC = 'https://gateway.liquify.com/chain/th
 /** Public Liquify THORNode REST / LCD base — no API key. */
 export const PUBLIC_LIQUIFY_THORNODE_API = 'https://gateway.liquify.com/chain/thorchain_api'
 
+/** Public Liquify THOR Midgard base — no API key. */
+export const PUBLIC_LIQUIFY_THORCHAIN_MIDGARD = 'https://gateway.liquify.com/chain/thorchain_midgard'
+
 /**
  * Optional private mainnet THORNode fallbacks (full base URLs from env / GH secrets).
  * Not Liquify; empty when unset.
@@ -18,12 +21,13 @@ export const ASGARDEX_THORNODE_RPC = envOrDefault(import.meta.env.VITE_ASGARDEX_
 
 /**
  * Liquify portal keys — Liquify gateway only (not private Asgardex fallbacks).
- * Same path form for both products; the key value selects API vs RPC:
+ * Same path form for API / RPC / Midgard; the key value selects the product:
  *   `https://gateway.liquify.com/api=<KEY>`
  * Never surface in Expert Mode / storage — only inject at request/client construction.
  */
 export const LIQUIFY_THORCHAIN_API_KEY = envOrDefault(import.meta.env.VITE_LIQUIFY_THORCHAIN_API_KEY, '')
 export const LIQUIFY_THORCHAIN_RPC_KEY = envOrDefault(import.meta.env.VITE_LIQUIFY_THORCHAIN_RPC_KEY, '')
+export const LIQUIFY_THORCHAIN_MIDGARD_KEY = envOrDefault(import.meta.env.VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY, '')
 
 /** Build authenticated Liquify gateway URL from a portal key, or empty if unset. */
 export const liquifyAuthenticatedUrl = (key: string): string => (key ? `https://gateway.liquify.com/api=${key}` : '')
@@ -47,6 +51,13 @@ export const maskThornodeRpcUrl = (url: string): string =>
  */
 export const maskThornodeApiUrl = (url: string): string =>
   isLiquifyAuthenticatedUrl(url) ? PUBLIC_LIQUIFY_THORNODE_API : url
+
+/**
+ * URL safe for Expert Mode UI and persistent storage (Midgard field).
+ * Strips Liquify `/api=<KEY>` endpoints back to the public Midgard path.
+ */
+export const maskMidgardUrl = (url: string): string =>
+  isLiquifyAuthenticatedUrl(url) ? PUBLIC_LIQUIFY_THORCHAIN_MIDGARD : url
 
 /**
  * Resolve the THORNode REST/LCD base used for queries (inbound_addresses, etc.).
@@ -83,6 +94,26 @@ export const resolveThornodeRpcUrl = (configured: string, network: Network = Net
 
   const normalized = maskThornodeRpcUrl(configured)
   if (!normalized || normalized === PUBLIC_LIQUIFY_THORNODE_RPC) {
+    return authenticated
+  }
+
+  return normalized
+}
+
+/**
+ * Resolve the THOR Midgard base URL.
+ * Liquify portal Midgard key injection is **mainnet only**.
+ * On mainnet, when the key is set and the configured URL is empty or the public Liquify
+ * Midgard, use the authenticated portal URL. Custom Expert URLs are left alone.
+ */
+export const resolveMidgardUrl = (configured: string, network: Network = Network.Mainnet): string => {
+  if (network !== Network.Mainnet) return configured
+
+  const authenticated = liquifyAuthenticatedUrl(LIQUIFY_THORCHAIN_MIDGARD_KEY)
+  if (!authenticated) return configured
+
+  const normalized = maskMidgardUrl(configured)
+  if (!normalized || normalized === PUBLIC_LIQUIFY_THORCHAIN_MIDGARD) {
     return authenticated
   }
 


### PR DESCRIPTION
## Summary

Public Liquify THOR Midgard (`gateway.liquify.com/chain/thorchain_midgard`) is down. This wires the authenticated Liquify portal Midgard product the same way we already do for THORNode API/RPC:

- Env / secret: \`VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY\`
- Resolved URL: \`https://gateway.liquify.com/api=<KEY>\`
- Mainnet only; custom Expert Mode URLs are left alone
- Expert Mode / storage never persist the \`/api=<KEY>\` form (masked back to public Midgard path)
- Aggregator Midgard bases prefer authenticated → public Liquify → \`midgard.thorchain.network\`
- CI: pass the secret through linux/mac/win package workflows

## Local / secret setup

Add to \`.env\` (dev) and GitHub Actions secrets (releases):

\`\`\`
VITE_LIQUIFY_THORCHAIN_MIDGARD_KEY=<your Liquify Midgard portal key>
\`\`\`

## Test plan

- [ ] With key set: Midgard health / pools load via \`gateway.liquify.com/api=...\`
- [ ] Expert Mode Midgard field shows public Liquify path (no key leaked)
- [ ] Without key: unchanged public Liquify + \`midgard.thorchain.network\` fallback
- [x] Unit tests for \`resolveMidgardUrl\` / \`maskMidgardUrl\`