### PR TITLE
fix(evm): EIP-1559 tip+baseFee headroom for plain transfers

### DIFF
--- a/src/main/api/ledger/evm/transaction.ts
+++ b/src/main/api/ledger/evm/transaction.ts
@@ -18,7 +18,7 @@ import { either as E } from 'fp-ts'
 import { isEVMTokenAsset } from '../../../../renderer/helpers/assetHelper'
 import { EVMZeroAddress } from '../../../../renderer/services/evm/const'
 import { GasMultiplier, LedgerError, LedgerErrorId } from '../../../../shared/api/types'
-import { applyGasMultiplier } from '../../../../shared/evm/gas'
+import { applyGasMultiplier, eip1559FeesFromGasPrices } from '../../../../shared/evm/gas'
 import { getBlocktime } from '../../../../shared/evm/provider'
 import { EvmHDMode } from '../../../../shared/evm/types'
 import { isError } from '../../../../shared/utils/guard'
@@ -74,6 +74,13 @@ export const evmSend = async ({
 
     const rawGasPrices = await ledgerClient.estimateGasPrices()
     const gasPrices = applyGasMultiplier(rawGasPrices, gasMultiplier)
+    // Prefer EIP-1559 tip + 2×baseFee headroom (same as keystore send / pool deposits).
+    // Passing gasPrice makes xchain set maxFee = tip with no baseFee buffer → stuck txs.
+    const latestBlock = await provider.getBlock('latest')
+    const transferFees =
+      latestBlock?.baseFeePerGas != null
+        ? eip1559FeesFromGasPrices(gasPrices, feeOption)
+        : { gasPrice: gasPrices[feeOption] }
 
     const txHash = await ledgerClient.transfer({
       walletIndex,
@@ -81,7 +88,7 @@ export const evmSend = async ({
       recipient,
       amount,
       memo,
-      gasPrice: gasPrices[feeOption]
+      ...transferFees
     })
 
     if (!txHash) {

--- a/src/renderer/services/evm/factory/transaction.ts
+++ b/src/renderer/services/evm/factory/transaction.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../../shared/api/io'
 import { ApiUrls, LedgerError } from '../../../../shared/api/types'
 import { DEFAULT_EVM_GAS_MULTIPLIER } from '../../../../shared/const'
-import { applyGasMultiplier, eip1559FeesFromGasPrices } from '../../../../shared/evm/gas'
+import { applyGasMultiplier, eip1559FeesFromGasPrices, eip1559MaxFeePerGas } from '../../../../shared/evm/gas'
 import { getBlocktime } from '../../../../shared/evm/provider'
 import { isError, isEvmHDMode, isLedgerWallet, isVultisigWallet } from '../../../../shared/utils/guard'
 import { getEVMAssetAddress, isChainAsset, isEVMTokenAsset } from '../../../helpers/assetHelper'
@@ -491,20 +491,23 @@ export const createEvmTransactionService = (
   }
 
   /**
-   * Keystore EVM send.
+   * Keystore EVM send (wallet Send, Chainflip, OneClick deposits).
    *
    * Max in the UI is `balance − feeQuote`, but fee quotes can be stale or estimated with
    * dummy amount/recipient (`SendView`). Send used to re-call `estimateGasPrices()` and
    * let xchain re-estimate gasLimit — so the fee attached to the tx could exceed what Max
    * reserved → node "insufficient funds for gas * price + value" by dust.
    *
+   * Also: passing `gasPrice` into xchain `transfer()` upgrades type-1 → type-2 with
+   * `maxFee = maxPriority = gasPrice` and **no 2×baseFee headroom**, so txs can stall when
+   * base fee ticks up (same bug #1179 fixed for pool deposits). Prefer tip-only EIP-1559.
+   *
    * Fix for native sends:
-   * 1. Fresh gasPrice (tier + multiplier)
+   * 1. Fresh fee tier + multiplier → `maxPriorityFeePerGas` (tip)
    * 2. Estimate gasLimit for the current amount
-   * 3. feeCap = gasPrice × gasLimit; reclamp amount to balance − feeCap
-   * 4. Re-estimate gasLimit for the **final** amount and reclamp again if feeCap grew
-   *    (amount can affect eth_estimateGas; one re-pass is enough for simple transfers)
-   * 5. Pass pinned gasPrice + gasLimit into transfer so xchain does not re-quote
+   * 3. feeCap = (2×baseFee + tip) × gasLimit when EIP-1559; else gasPrice × gasLimit
+   * 4. Reclamp amount to balance − feeCap; re-estimate gasLimit; repeat (max 3 passes)
+   * 5. Pass tip (or legacy gasPrice) + pinned gasLimit into transfer
    *
    * Token sends leave amount alone (gas paid in native separately).
    */
@@ -522,10 +525,17 @@ export const createEvmTransactionService = (
         (async (): Promise<TxHash> => {
           const rawGasPrices = await client.estimateGasPrices()
           const gasPrices = applyGasMultiplier(rawGasPrices, gasMultiplier)
-          const gasPrice = gasPrices[params.feeOption]
+          const { maxPriorityFeePerGas } = eip1559FeesFromGasPrices(gasPrices, params.feeOption)
+          const legacyGasPrice = gasPrices[params.feeOption]
           const assetInfo = client.getAssetInfo()
           const isNative = isChainAsset(params.asset)
           const fallbackGasLimit = isNative ? ETH_OUT_TX_GAS_LIMIT : ERC20_OUT_TX_GAS_LIMIT
+
+          // Prefer EIP-1559 tip + 2×baseFee (via xchain) when the chain exposes baseFee.
+          const latestBlock = await client.getProvider().getBlock('latest')
+          const baseFeePerGas = latestBlock?.baseFeePerGas ?? null
+          const useEip1559 = baseFeePerGas != null
+          const feeUnit = useEip1559 ? eip1559MaxFeePerGas(maxPriorityFeePerGas, baseFeePerGas) : legacyGasPrice
 
           let amount: BaseAmount = params.amount
 
@@ -542,6 +552,8 @@ export const createEvmTransactionService = (
               return fallbackGasLimit
             }
           }
+
+          const transferFees = useEip1559 ? { maxPriorityFeePerGas } : { gasPrice: legacyGasPrice }
 
           if (isNative) {
             const sender = await client.getAddressAsync(params.walletIndex)
@@ -561,7 +573,7 @@ export const createEvmTransactionService = (
             let gasLimit = await estimateGasLimitFor(amount, sender)
             for (let pass = 0; pass < 3; pass++) {
               const feeCap = getFee({
-                gasPrice,
+                gasPrice: feeUnit,
                 gasLimit,
                 decimals: assetInfo.decimal
               })
@@ -589,7 +601,7 @@ export const createEvmTransactionService = (
               amount,
               recipient: params.recipient,
               memo: params.memo,
-              gasPrice,
+              ...transferFees,
               gasLimit,
               walletIndex: params.walletIndex
             })
@@ -602,7 +614,7 @@ export const createEvmTransactionService = (
             amount,
             recipient: params.recipient,
             memo: params.memo,
-            gasPrice,
+            ...transferFees,
             gasLimit,
             walletIndex: params.walletIndex
           })

--- a/src/shared/evm/gas.test.ts
+++ b/src/shared/evm/gas.test.ts
@@ -2,7 +2,7 @@ import { FeeOption } from '@xchainjs/xchain-client'
 import { baseAmount } from '@xchainjs/xchain-util'
 import { describe, expect, it } from 'vitest'
 
-import { applyGasMultiplier, eip1559FeesFromGasPrices } from './gas'
+import { applyGasMultiplier, eip1559FeesFromGasPrices, eip1559MaxFeePerGas } from './gas'
 
 describe('shared/evm/gas', () => {
   const gasPrices = {
@@ -38,5 +38,14 @@ describe('shared/evm/gas', () => {
     expect(eip1559FeesFromGasPrices(gasPrices)).toEqual({
       maxPriorityFeePerGas: gasPrices.fast
     })
+  })
+
+  it('eip1559MaxFeePerGas is 2*baseFee + tip', () => {
+    const tip = baseAmount(1_500_000_000, 18)
+    const baseFee = BigInt(20_000_000_000)
+    const maxFee = eip1559MaxFeePerGas(tip, baseFee)
+    // 2 * 20 gwei + 1.5 gwei = 41.5 gwei
+    expect(maxFee.amount().toFixed(0)).toBe('41500000000')
+    expect(maxFee.decimal).toBe(18)
   })
 })

--- a/src/shared/evm/gas.ts
+++ b/src/shared/evm/gas.ts
@@ -45,3 +45,12 @@ export const eip1559FeesFromGasPrices = (
 ): Eip1559TransferFees => ({
   maxPriorityFeePerGas: gasPrices[feeOption]
 })
+
+/**
+ * EIP-1559 maxFeePerGas = 2 * baseFee + tip (ethers v5 / xchain-evm default).
+ * Use for Max-send feeCap reclamping so reserved gas matches what transfer() will attach.
+ */
+export const eip1559MaxFeePerGas = (tip: BaseAmount, baseFeePerGas: bigint): BaseAmount => {
+  const maxFee = baseFeePerGas * BigInt(2) + BigInt(tip.amount().toFixed(0))
+  return baseAmount(maxFee.toString(), tip.decimal)
+}


### PR DESCRIPTION
## Summary
- Plain EVM `sendTx$` (wallet Send, **Chainflip**, **OneClick**) still passed `gasPrice` into xchain `transfer()`, which upgrades to type-2 with `maxFee = tip` and **no 2×baseFee headroom** — same stall mode #1179 fixed for THOR/MAYA pool deposits.
- Keystore `runSendTx$` now prefers `maxPriorityFeePerGas` when the chain exposes `baseFeePerGas`, and Max reclamps against `(2×baseFee + tip) × gasLimit`.
- Ledger plain `evmSend` gets the same tip-only path; legacy `gasPrice` remains if there is no base fee.

## Test plan
- [ ] ETH (or other EIP-1559) keystore Send of native + ERC20
- [ ] Max native send still broadcasts (no insufficient-funds dust)
- [ ] Chainflip EVM deposit lands under mild fee movement
- [ ] OneClick EVM deposit lands
- [ ] Ledger EVM send (if available)
- [ ] `yarn test -- --run src/shared/evm/gas.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * EVM transactions now use EIP-1559 fee pricing when supported by the network.
  * Transactions automatically fall back to legacy gas pricing when EIP-1559 data is unavailable.
  * Native and token transfers now apply the appropriate network fee fields for more reliable fee estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->